### PR TITLE
[night-orch] #9 Continuous running

### DIFF
--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -95,206 +95,215 @@ export async function pollOnce(
       continue
     }
 
-    // Process first eligible (serial)
-    const first = discovered[0]!
-
-    if (first.triage.level === 'architectural') {
-      await forge.addLabels(repoConfig.repo, first.issue.number, ['orch:needs-human'])
-      await forge.commentOnIssue(
-        repoConfig.repo,
-        first.issue.number,
-        '🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.',
-      )
-      continue
-    }
-
-    if (!leaseManager.acquire(repoConfig.repo, first.issue.number, 'poller', 7200)) {
-      continue
-    }
-
-    let runId: string | null = null
-    let envSetup: EnvSetupResult | null = null
-    let activeWorktreePath: string | null = null
     const labelConfig = buildLabelConfig(repoConfig)
 
-    try {
-      const resolvedRoles = resolveRoles(first.issue.labels, repoConfig.defaults)
-      const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, first.issue.number)
-      const roles = queuedRun
-        ? {
-            planner: coerceAgentName(queuedRun.planner, resolvedRoles.planner),
-            coder: coerceAgentName(queuedRun.coder, resolvedRoles.coder),
-            reviewer: coerceAgentName(queuedRun.reviewer, resolvedRoles.reviewer),
-          }
-        : resolvedRoles
-      const slug = getOrPinSlug(db, repoConfig.repo, first.issue.number, first.issue.title)
-      const branch = branchName(repoConfig.branchPrefix, first.issue.number, slug)
-      const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, first.issue.number)
-      activeWorktreePath = worktreePath
+    // Process all currently eligible issues serially for this repo.
+    for (const discoveredIssue of discovered) {
+      if (discoveredIssue.triage.level === 'architectural') {
+        await forge.addLabels(repoConfig.repo, discoveredIssue.issue.number, ['orch:needs-human'])
+        await forge.commentOnIssue(
+          repoConfig.repo,
+          discoveredIssue.issue.number,
+          '🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.',
+        )
+        continue
+      }
 
-      const run = queuedRun ?? runManager.create({
-        repo: repoConfig.repo,
-        issueNumber: first.issue.number,
-        issueNodeId: first.issue.nodeId,
-        planner: roles.planner,
-        coder: roles.coder,
-        reviewer: roles.reviewer,
-      })
-      runId = run.id
-      runManager.update(run.id, {
-        status: 'running',
-        branchName: branch,
-        branchSlug: slug,
-        worktreePath,
-        endedAt: null,
-        lastError: null,
-      })
+      if (!leaseManager.acquire(repoConfig.repo, discoveredIssue.issue.number, 'poller', 7200)) {
+        continue
+      }
 
-      // Label transition
-      await transitionLabels(forge, repoConfig.repo, first.issue.number, first.issue.labels, 'queued', 'running', labelConfig)
+      let runId: string | null = null
+      let envSetup: EnvSetupResult | null = null
+      let activeWorktreePath: string | null = null
 
-      // Notify
-      await notifier.dispatch(makePayload('run_started', repoConfig.repo, first.issue))
+      try {
+        const resolvedRoles = resolveRoles(discoveredIssue.issue.labels, repoConfig.defaults)
+        const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, discoveredIssue.issue.number)
+        const roles = queuedRun
+          ? {
+              planner: coerceAgentName(queuedRun.planner, resolvedRoles.planner),
+              coder: coerceAgentName(queuedRun.coder, resolvedRoles.coder),
+              reviewer: coerceAgentName(queuedRun.reviewer, resolvedRoles.reviewer),
+            }
+          : resolvedRoles
+        const slug = getOrPinSlug(db, repoConfig.repo, discoveredIssue.issue.number, discoveredIssue.issue.title)
+        const branch = branchName(repoConfig.branchPrefix, discoveredIssue.issue.number, slug)
+        const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, discoveredIssue.issue.number)
+        activeWorktreePath = worktreePath
 
-      // Create worktree
-      await worktreeManager.ensure({
-        repoLocalPath: repoConfig.localPath,
-        baseBranch: repoConfig.baseBranch,
-        branchName: branch,
-        worktreePath,
-      })
-
-      if (repoConfig.environment) {
-        const mode = resolveEnvironmentMode(first.issue.labels, repoConfig)
-        envSetup = await setupEnvironment({
+        const run = queuedRun ?? runManager.create({
+          repo: repoConfig.repo,
+          issueNumber: discoveredIssue.issue.number,
+          issueNodeId: discoveredIssue.issue.nodeId,
+          planner: roles.planner,
+          coder: roles.coder,
+          reviewer: roles.reviewer,
+        })
+        runId = run.id
+        runManager.update(run.id, {
+          status: 'running',
+          branchName: branch,
+          branchSlug: slug,
           worktreePath,
-          issueNumber: first.issue.number,
-          repoConfig,
-          mode,
-          usedPorts: usedPortsInPass,
+          endedAt: null,
+          lastError: null,
         })
-      }
 
-      // Get worker adapters
-      const adjustedLimits = adjustLimitsForTriage(
-        config.loop,
-        config.workerProfiles[repoConfig.agents[roles.planner] ?? '']?.workerTimeoutSeconds ?? 1800,
-        first.triage,
-      )
+        // Label transition
+        await transitionLabels(
+          forge,
+          repoConfig.repo,
+          discoveredIssue.issue.number,
+          discoveredIssue.issue.labels,
+          'queued',
+          'running',
+          labelConfig,
+        )
 
-      const plannerProfile = config.workerProfiles[repoConfig.agents[roles.planner] ?? '']
-      const coderProfile = config.workerProfiles[repoConfig.agents[roles.coder] ?? '']
-      const reviewerProfile = config.workerProfiles[repoConfig.agents[roles.reviewer] ?? '']
+        // Notify
+        await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
 
-      if (!plannerProfile || !coderProfile || !reviewerProfile) {
-        throw new Error('Missing worker profiles for resolved roles')
-      }
-
-      const initialCtx: RunContext = {
-        runId: run.id,
-        repo: repoConfig.repo,
-        issueNumber: first.issue.number,
-        issue: first.issue,
-        repoConfig,
-        roles,
-        triageResult: first.triage,
-        adjustedLimits,
-        branchName: branch,
-        worktreePath,
-        plan: null,
-        codeResult: null,
-        diff: null,
-        verifyResults: [],
-        reviewResult: null,
-        reviewFindings: [],
-        iteration: 1,
-        totalAgentPasses: 0,
-        estimatedCostUsd: 0,
-        currentPhase: 'plan',
-        terminalStatus: 'running',
-        phaseHistory: [],
-        dryRun: false,
-      }
-
-      // Execute loop
-      const loopStart = Date.now()
-      const finalCtx = await executeLoop(initialCtx, {
-        db,
-        config,
-        plannerAdapter: createWorkerAdapter(plannerProfile),
-        coderAdapter: createWorkerAdapter(coderProfile),
-        reviewerAdapter: createWorkerAdapter(reviewerProfile),
-        envOverrides: envSetup?.envOverrides ?? {},
-        metrics,
-        onPlanReady: async (ctx) => {
-          await postPlanSummaryComment(forge, ctx.repo, ctx.issueNumber, ctx.plan)
-        },
-      })
-
-      const runDurationSec = (Date.now() - loopStart) / 1000
-      const outcome = await finalizeRunOutcome({
-        finalCtx,
-        runId: run.id,
-        issue: first.issue,
-        runDurationSec,
-        repo: repoConfig.repo,
-        issueNumber: first.issue.number,
-        labelConfig,
-        db,
-        forge,
-        runManager,
-        notifier,
-        metrics,
-      })
-
-      if (outcome === 'processed') processed++
-      else errors++
-    } catch (err) {
-      logger.error({ repo: repoConfig.repo, issue: first.issue.number, err }, 'Failed to process issue')
-      if (runId) {
-        runManager.update(runId, {
-          status: 'error',
-          lastError: String(err),
-          endedAt: new Date().toISOString(),
+        // Create worktree
+        await worktreeManager.ensure({
+          repoLocalPath: repoConfig.localPath,
+          baseBranch: repoConfig.baseBranch,
+          branchName: branch,
+          worktreePath,
         })
-        try {
-          const latestIssue = await forge.getIssue(repoConfig.repo, first.issue.number)
-          await transitionLabels(
-            forge,
-            repoConfig.repo,
-            first.issue.number,
-            latestIssue.labels,
-            'running',
-            'error',
-            labelConfig,
-          )
-        } catch (labelErr) {
-          logger.warn({ repo: repoConfig.repo, issue: first.issue.number, err: labelErr }, 'Failed to transition labels after poller error')
-        }
-        try {
-          await notifier.dispatch(makePayload('error', repoConfig.repo, first.issue, {
-            summary: `Failed to process issue: ${(err as Error).message}`,
-          }))
-        } catch (notifyErr) {
-          logger.warn({ repo: repoConfig.repo, issue: first.issue.number, err: notifyErr }, 'Failed to send error notification after poller error')
-        }
-      }
-      errors++
-    } finally {
-      if (envSetup && activeWorktreePath) {
-        try {
-          await teardownEnvironment({
-            worktreePath: activeWorktreePath,
-            issueNumber: first.issue.number,
+
+        if (repoConfig.environment) {
+          const mode = resolveEnvironmentMode(discoveredIssue.issue.labels, repoConfig)
+          envSetup = await setupEnvironment({
+            worktreePath,
+            issueNumber: discoveredIssue.issue.number,
             repoConfig,
-            mode: envSetup.mode,
-            composeProjectName: envSetup.composeProjectName,
+            mode,
+            usedPorts: usedPortsInPass,
           })
-        } catch (envErr) {
-          logger.warn({ repo: repoConfig.repo, issue: first.issue.number, err: envErr }, 'Failed to tear down environment')
         }
+
+        // Get worker adapters
+        const adjustedLimits = adjustLimitsForTriage(
+          config.loop,
+          config.workerProfiles[repoConfig.agents[roles.planner] ?? '']?.workerTimeoutSeconds ?? 1800,
+          discoveredIssue.triage,
+        )
+
+        const plannerProfile = config.workerProfiles[repoConfig.agents[roles.planner] ?? '']
+        const coderProfile = config.workerProfiles[repoConfig.agents[roles.coder] ?? '']
+        const reviewerProfile = config.workerProfiles[repoConfig.agents[roles.reviewer] ?? '']
+
+        if (!plannerProfile || !coderProfile || !reviewerProfile) {
+          throw new Error('Missing worker profiles for resolved roles')
+        }
+
+        const initialCtx: RunContext = {
+          runId: run.id,
+          repo: repoConfig.repo,
+          issueNumber: discoveredIssue.issue.number,
+          issue: discoveredIssue.issue,
+          repoConfig,
+          roles,
+          triageResult: discoveredIssue.triage,
+          adjustedLimits,
+          branchName: branch,
+          worktreePath,
+          plan: null,
+          codeResult: null,
+          diff: null,
+          verifyResults: [],
+          reviewResult: null,
+          reviewFindings: [],
+          iteration: 1,
+          totalAgentPasses: 0,
+          estimatedCostUsd: 0,
+          currentPhase: 'plan',
+          terminalStatus: 'running',
+          phaseHistory: [],
+          dryRun: false,
+        }
+
+        // Execute loop
+        const loopStart = Date.now()
+        const finalCtx = await executeLoop(initialCtx, {
+          db,
+          config,
+          plannerAdapter: createWorkerAdapter(plannerProfile),
+          coderAdapter: createWorkerAdapter(coderProfile),
+          reviewerAdapter: createWorkerAdapter(reviewerProfile),
+          envOverrides: envSetup?.envOverrides ?? {},
+          metrics,
+          onPlanReady: async (ctx) => {
+            await postPlanSummaryComment(forge, ctx.repo, ctx.issueNumber, ctx.plan)
+          },
+        })
+
+        const runDurationSec = (Date.now() - loopStart) / 1000
+        const outcome = await finalizeRunOutcome({
+          finalCtx,
+          runId: run.id,
+          issue: discoveredIssue.issue,
+          runDurationSec,
+          repo: repoConfig.repo,
+          issueNumber: discoveredIssue.issue.number,
+          labelConfig,
+          db,
+          forge,
+          runManager,
+          notifier,
+          metrics,
+        })
+
+        if (outcome === 'processed') processed++
+        else errors++
+      } catch (err) {
+        logger.error({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err }, 'Failed to process issue')
+        if (runId) {
+          runManager.update(runId, {
+            status: 'error',
+            lastError: String(err),
+            endedAt: new Date().toISOString(),
+          })
+          try {
+            const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+            await transitionLabels(
+              forge,
+              repoConfig.repo,
+              discoveredIssue.issue.number,
+              latestIssue.labels,
+              'running',
+              'error',
+              labelConfig,
+            )
+          } catch (labelErr) {
+            logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels after poller error')
+          }
+          try {
+            await notifier.dispatch(makePayload('error', repoConfig.repo, discoveredIssue.issue, {
+              summary: `Failed to process issue: ${(err as Error).message}`,
+            }))
+          } catch (notifyErr) {
+            logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: notifyErr }, 'Failed to send error notification after poller error')
+          }
+        }
+        errors++
+      } finally {
+        if (envSetup && activeWorktreePath) {
+          try {
+            await teardownEnvironment({
+              worktreePath: activeWorktreePath,
+              issueNumber: discoveredIssue.issue.number,
+              repoConfig,
+              mode: envSetup.mode,
+              composeProjectName: envSetup.composeProjectName,
+            })
+          } catch (envErr) {
+            logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: envErr }, 'Failed to tear down environment')
+          }
+        }
+        leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
       }
-      leaseManager.release(repoConfig.repo, first.issue.number)
     }
   }
 

--- a/test/poller/poller.test.ts
+++ b/test/poller/poller.test.ts
@@ -285,6 +285,43 @@ describe('pollOnce', () => {
     expect(callOrder).toEqual(['executeLoop', 'comment', 'afterOnPlanReady'])
   })
 
+  it('processes the next eligible issue in the same poll cycle', async () => {
+    mockDiscoverEligibleIssues.mockResolvedValue([
+      {
+        issue: { number: 1, nodeId: '', title: 'First', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      },
+      {
+        issue: { number: 2, nodeId: '', title: 'Second', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      },
+    ])
+    mockExecuteLoop.mockResolvedValue({
+      currentPhase: 'publish',
+      terminalStatus: 'blocked',
+    })
+
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    const result = await pollOnce(config, db, false)
+
+    expect(result.processed).toBe(2)
+    expect(result.errors).toBe(0)
+    expect(mockExecuteLoop).toHaveBeenCalledTimes(2)
+
+    const firstCallCtx = mockExecuteLoop.mock.calls[0]?.[0] as { issueNumber: number }
+    const secondCallCtx = mockExecuteLoop.mock.calls[1]?.[0] as { issueNumber: number }
+    expect(firstCallCtx.issueNumber).toBe(1)
+    expect(secondCallCtx.issueNumber).toBe(2)
+
+    const runs = db
+      .prepare('SELECT issue_number, status FROM runs ORDER BY created_at')
+      .all() as Array<{ issue_number: number; status: string }>
+    expect(runs).toEqual([
+      { issue_number: 1, status: 'blocked' },
+      { issue_number: 2, status: 'blocked' },
+    ])
+  })
+
   it('processes only the targeted issue when targetIssue is provided', async () => {
     mockDiscoverEligibleIssues.mockResolvedValue([
       {


### PR DESCRIPTION
Closes #9

## Plan
**Objective:** After an agent completes work on an issue (transitions to blocked/pr/done), immediately start the next open issue for that repo instead of waiting for the next poll cycle

1. In the runner's per-repo processing function, wrap the single-issue run in a loop: after a run completes with a terminal status (blocked, pr_created, done, error), immediately call discovery again for that same repo to find the next open issue. Continue the loop as long as there are eligible issues. Break when no more issues are found or a budget/concurrency limit is reached.
2. Ensure the loop engine's run result clearly communicates terminal statuses that should trigger continuation (e.g., 'completed', 'blocked', 'pr_created') vs statuses that should NOT continue (e.g., 'budget_exhausted', 'shutdown_requested'). Add a helper or flag like `shouldContinueToNextIssue(result)` if not already distinguishable.
3. Add a safety mechanism: respect graceful shutdown signals within the continuation loop so that SIGINT/SIGTERM breaks out of the inner loop cleanly, not just the outer poll loop. Check the poller's shutdown flag before starting the next issue.
4. Add logging at info level when continuing to next issue within the same poll cycle: log the completed issue number, the transition status, and the next issue being picked up. Log at info level when no more issues are found for a repo.
5. Ensure lease for the completed issue is fully released before attempting to acquire a lease on the next issue, to avoid any lease conflicts within the same repo.

## Implementation
Coder output could not be parsed. Changed files detected via git diff.

**Changed files:**
- `src/runner/poller.ts`
- `test/poller/poller.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Clean mechanical change: wraps the existing single-issue processing in a `for...of` loop over all discovered issues. Logic is preserved identically, just re-indented. Test covers the new multi-issue-per-cycle behavior. Typecheck, lint, and tests pass.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude