### PR TITLE
[night-orch] #4 Planning issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A self-hosted Node.js/TypeScript CLI that autonomously processes GitHub/Forgejo 
 ## Features
 
 - **Configurable workflows** — YAML-defined pipelines (Plan→Code→Verify→Review or custom)
+- **Planning-only mode** — label an issue to produce a single PRD markdown artifact (no code changes)
 - **Multi-agent support** — Claude, Codex, Gemini, and 17+ agents via ACP protocol
 - **Issue decomposition** — automatically splits complex issues into parallel sub-tasks
 - **Merge queue** — Bors-style batch-and-bisect for automated PR merging
@@ -71,6 +72,8 @@ mise run labels-init
 5. Reviewer can bounce back to coder (up to configured max iterations)
 6. Push branch, create/update PR, label `orch:review-ready`
 7. Notify via console, webhook, GitHub comment, or email
+
+Special case: issues labeled `orch:planning` (configurable) run in planning-only mode and generate only one PRD markdown file in the configured PRD directory.
 
 The orchestrator's job ends when the PR is ready. A human merges.
 

--- a/config.yaml
+++ b/config.yaml
@@ -103,6 +103,9 @@ repos:
       reviewReady: orch:review-ready
       error: orch:error
       retry: orch:retry
+      planning: orch:planning
+    planning:
+      prdDirectory: docs/prd
     defaults:
       planner: claude
       coder: codex

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -282,6 +282,7 @@ Reference a workflow in `repos[].workflow` by name.
 | `labels` | object | no | object with defaults | Orchestration label names. |
 | `labelConfig` | record | no | `{}` | Label metadata overrides for `labels-init`. |
 | `defaults` | object | no | object with defaults | Default roles + mention settings. |
+| `planning` | object | no | object with defaults | Planning-only mode settings (PRD path). |
 | `environment` | object | no | none | Shared/dedicated env setup. |
 | `verify` | `CommandSpec[]` | no | `[]` | Verify commands run in worktree. |
 | `prompts` | object | no | none | Optional custom system prompt template paths. |
@@ -301,6 +302,7 @@ Reference a workflow in `repos[].workflow` by name.
 | `reviewReady` | string | `orch:review-ready` |  |
 | `error` | string | `orch:error` |  |
 | `retry` | string | `orch:retry` |  |
+| `planning` | string | `orch:planning` | When present on an issue, night-orch switches to planning-only mode and publishes only a PRD markdown file. |
 | `mergeQueued` | string | `orch:merge-queued` | Set when PR enters the merge queue. |
 | `merging` | string | `orch:merging` | Set while staging branch CI is running. |
 | `mergeFailed` | string | `orch:merge-failed` | Set when the merge queue identifies this PR as the culprit. |
@@ -334,6 +336,18 @@ Role labels can override these defaults per issue:
 - `plan:claude` / `plan:codex`
 - `code:claude` / `code:codex`
 - `review:claude` / `review:codex`
+
+Planning-only mode label:
+
+- `orch:planning` (or whatever `repos[].labels.planning` is set to)
+
+When this label is present, night-orch uses a planning-only workflow and must produce a PR containing exactly one PRD markdown file.
+
+### `repos[].planning`
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `prdDirectory` | string | `docs/prd` | Repository-relative directory where planning-mode PRD files are created. |
 
 ### `repos[].environment`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -99,6 +99,8 @@ Each repo can have its own worker profiles, verify commands, workflow, merge que
 5. **Publishing** — approved changes are committed, pushed, and a PR is created on the remote
 6. **Merge queue** (optional) — approved PRs are batched, tested, and merged automatically
 
+Planning-only override: if an issue also has the planning label (default `orch:planning`), night-orch runs a planning-only workflow and publishes exactly one PRD markdown file (no code/test/config changes).
+
 ### Label lifecycle
 
 ```

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -120,9 +120,12 @@ repos:
       reviewReady: orch:review-ready
       error: orch:error
       retry: orch:retry
+      planning: orch:planning
       # mergeQueued: orch:merge-queued
       # merging: orch:merging
       # mergeFailed: orch:merge-failed
+    planning:
+      prdDirectory: docs/prd
     # Optional per-label metadata overrides used by `night-orch labels-init`
     labelConfig:
       orch:ready:
@@ -131,6 +134,9 @@ repos:
       orch:running:
         color: FBCA04
         description: Currently being processed by night-orch
+      orch:planning:
+        color: C2E0C6
+        description: Planning-only mode (PRD markdown only)
     defaults:
       planner: claude
       coder: codex

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -109,6 +109,7 @@ const LabelsSchema = z.object({
   reviewReady: z.string().default('orch:review-ready'),
   error: z.string().default('orch:error'),
   retry: z.string().default('orch:retry'),
+  planning: z.string().default('orch:planning'),
   mergeQueued: z.string().default('orch:merge-queued'),
   merging: z.string().default('orch:merging'),
   mergeFailed: z.string().default('orch:merge-failed'),
@@ -139,6 +140,10 @@ const PromptsSchema = z.object({
   plannerSystem: z.string().optional(),
   coderSystem: z.string().optional(),
   reviewerSystem: z.string().optional(),
+})
+
+const PlanningConfigSchema = z.object({
+  prdDirectory: z.string().default('docs/prd'),
 })
 
 // --- Workflow schemas ---
@@ -201,6 +206,7 @@ const RepoConfigSchema = z.object({
   environment: EnvironmentConfigSchema.optional(),
   verify: z.array(CommandSpecSchema).default([]),
   prompts: PromptsSchema.optional(),
+  planning: PlanningConfigSchema.default({}),
   selectors: SelectorsSchema.default({}),
   agents: z.record(z.string()).default({}),
   workflow: z.string().optional(),

--- a/src/labels/bootstrap.ts
+++ b/src/labels/bootstrap.ts
@@ -6,7 +6,7 @@ export interface LabelBootstrapDefinition {
   description: string
 }
 
-type LabelRole = 'ready' | 'running' | 'blocked' | 'reviewReady' | 'error' | 'retry' | 'mergeQueued' | 'merging' | 'mergeFailed'
+type LabelRole = 'ready' | 'running' | 'blocked' | 'reviewReady' | 'error' | 'retry' | 'planning' | 'mergeQueued' | 'merging' | 'mergeFailed'
 
 const DEFAULT_LABEL_PRESENTATION: Record<LabelRole, { color: string; description: string }> = {
   ready: {
@@ -32,6 +32,10 @@ const DEFAULT_LABEL_PRESENTATION: Record<LabelRole, { color: string; description
   retry: {
     color: '5319E7',
     description: 'Queued for retry',
+  },
+  planning: {
+    color: 'C2E0C6',
+    description: 'Planning-only mode: produce a PRD markdown file (no code changes)',
   },
   mergeQueued: {
     color: '006B75',
@@ -77,6 +81,7 @@ export function buildLabelBootstrapDefinitions(
   add(repoConfig.labels.reviewReady, 'reviewReady')
   add(repoConfig.labels.error, 'error')
   add(repoConfig.labels.retry, 'retry')
+  add(repoConfig.labels.planning, 'planning')
   add(repoConfig.labels.mergeQueued, 'mergeQueued')
   add(repoConfig.labels.merging, 'merging')
   add(repoConfig.labels.mergeFailed, 'mergeFailed')

--- a/src/labels/config.ts
+++ b/src/labels/config.ts
@@ -10,6 +10,7 @@ export function buildLabelConfig(repoConfig: Pick<RepoConfig, 'labels'>): LabelC
     reviewReady: repoConfig.labels.reviewReady,
     error: repoConfig.labels.error,
     retry: repoConfig.labels.retry,
+    planning: repoConfig.labels.planning,
     mergeQueued: repoConfig.labels.mergeQueued,
     merging: repoConfig.labels.merging,
     mergeFailed: repoConfig.labels.mergeFailed,

--- a/src/labels/transitions.ts
+++ b/src/labels/transitions.ts
@@ -15,6 +15,7 @@ export interface LabelConfig {
   reviewReady: string
   error: string
   retry: string
+  planning: string
   mergeQueued: string
   merging: string
   mergeFailed: string

--- a/src/loop/commit.ts
+++ b/src/loop/commit.ts
@@ -2,6 +2,18 @@ import { execa } from 'execa'
 import { checkDiffSize } from './diff-guard.js'
 import type { Config } from '../config/schema.js'
 import { logger } from '../utils/logger.js'
+import { normalizeRepoRelativePath } from '../planning/mode.js'
+
+export interface CommitChangesOptions {
+  planningOnlyPrdPath?: string
+}
+
+export interface CommitChangesResult {
+  committed: boolean
+  reason: string | null
+  /** If true, caller should end the run as blocked instead of publishing. */
+  blockRun: boolean
+}
 
 /**
  * Stage all changes and commit with a standard message.
@@ -12,13 +24,25 @@ export async function commitChanges(
   issueNumber: number,
   issueTitle: string,
   securityConfig: Config['security'],
-): Promise<{ committed: boolean; reason: string | null }> {
+  opts: CommitChangesOptions = {},
+): Promise<CommitChangesResult> {
+  const expectedPlanningPath = opts.planningOnlyPrdPath
+    ? normalizeGitPath(opts.planningOnlyPrdPath)
+    : null
+
   // Check if there are any changes to commit
   const { stdout: statusOutput } = await execa('git', ['status', '--porcelain'], {
     cwd: worktreePath,
   })
   if (statusOutput.trim() === '') {
-    return { committed: false, reason: 'No changes to commit' }
+    if (expectedPlanningPath) {
+      return {
+        committed: false,
+        reason: `Planning-only guard: expected "${expectedPlanningPath}" but no changes were found`,
+        blockRun: true,
+      }
+    }
+    return { committed: false, reason: 'No changes to commit', blockRun: false }
   }
 
   // Stage before diff-size guard so new files are included in checks.
@@ -32,7 +56,22 @@ export async function commitChanges(
       { stats: diffCheck.stats, reason: diffCheck.reason },
       'Diff-size guard triggered — skipping commit',
     )
-    return { committed: false, reason: `Diff-size guard: ${diffCheck.reason}` }
+    return { committed: false, reason: `Diff-size guard: ${diffCheck.reason}`, blockRun: true }
+  }
+
+  if (expectedPlanningPath) {
+    const changedFiles = await getStagedChangedFiles(worktreePath)
+    const normalizedFiles = changedFiles.map(normalizeGitPath)
+    const isOnlyExpected = normalizedFiles.length === 1 && normalizedFiles[0] === expectedPlanningPath
+
+    if (!isOnlyExpected) {
+      await execa('git', ['reset', 'HEAD', '--', '.'], { cwd: worktreePath, reject: false })
+      return {
+        committed: false,
+        reason: `Planning-only guard: expected only "${expectedPlanningPath}" but found [${normalizedFiles.join(', ') || '(none)'}]`,
+        blockRun: true,
+      }
+    }
   }
 
   const message = `night-orch: implement #${issueNumber} ${sanitizeCommitTitle(issueTitle)}`
@@ -43,7 +82,7 @@ export async function commitChanges(
     'Changes committed',
   )
 
-  return { committed: true, reason: null }
+  return { committed: true, reason: null, blockRun: false }
 }
 
 function sanitizeCommitTitle(title: string): string {
@@ -52,4 +91,16 @@ function sanitizeCommitTitle(title: string): string {
     .replace(/[ \t]{2,}/g, ' ')
     .replace(/[^\w\s.,:;!?()[\]{}\-/#]/g, '')
     .trim()
+}
+
+function normalizeGitPath(path: string): string {
+  return normalizeRepoRelativePath(path).replace(/^\/+/, '')
+}
+
+async function getStagedChangedFiles(worktreePath: string): Promise<string[]> {
+  const { stdout } = await execa('git', ['diff', '--cached', '--name-only'], { cwd: worktreePath })
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
 }

--- a/src/loop/decision.ts
+++ b/src/loop/decision.ts
@@ -1,5 +1,6 @@
 import type { RunContext, LoopDecision } from './types.js'
 import type { Config } from '../config/schema.js'
+import { isPlanningIssue } from '../planning/mode.js'
 
 /**
  * Determine next action based on review verdict, verify results,
@@ -33,6 +34,15 @@ export function decide(
   // Rule 2: Max total passes
   if (ctx.totalAgentPasses >= maxTotalPasses) {
     return { action: 'block', reason: `Max total agent passes reached: ${ctx.totalAgentPasses}/${maxTotalPasses}`, blockReason: 'agent_pass_limit' }
+  }
+
+  // Planning-only mode bypasses verify/review gates. The commit guard enforces
+  // that only the configured PRD markdown file is committed.
+  if (isPlanningIssue(ctx.issue.labels, ctx.repoConfig)) {
+    if (!ctx.codeResult) {
+      return { action: 'block', reason: 'Planning-only mode requires a PRD output from the coder', blockReason: 'ambiguous_review' }
+    }
+    return { action: 'publish', reason: 'Planning-only mode: PRD ready for publishing' }
   }
 
   const review = ctx.reviewResult

--- a/src/loop/engine.ts
+++ b/src/loop/engine.ts
@@ -10,6 +10,7 @@ import { Checkpoint } from './checkpoint.js'
 import { CostTracker } from './cost.js'
 import { logger } from '../utils/logger.js'
 import type Database from 'better-sqlite3'
+import { buildPlanningPrdPath, isPlanningIssue } from '../planning/mode.js'
 
 export interface LoopDependencies {
   db: Database.Database
@@ -127,15 +128,21 @@ export async function executeLoop(
 
       switch (decision.action) {
         case 'publish': {
+          const planningOnly = isPlanningIssue(ctx.issue.labels, ctx.repoConfig)
+          const planningOnlyPrdPath = planningOnly
+            ? buildPlanningPrdPath(ctx.issueNumber, ctx.issue.title, ctx.repoConfig)
+            : undefined
+
           const commitResult = await commitChanges(
             ctx.worktreePath,
             ctx.issueNumber,
             ctx.issue.title,
             config.security,
+            { planningOnlyPrdPath },
           )
           if (!commitResult.committed) {
             logger.warn({ reason: commitResult.reason }, 'Commit skipped')
-            if (commitResult.reason?.startsWith('Diff-size guard')) {
+            if (commitResult.blockRun) {
               return recordPhase(
                 updateContext(ctx, { currentPhase: 'blocked', terminalStatus: 'blocked' }),
                 'publish',

--- a/src/loop/step-executor.ts
+++ b/src/loop/step-executor.ts
@@ -11,6 +11,7 @@ import { buildWorkerEnv, buildVerifierEnv } from '../workers/env.js'
 import { getDiffAgainstBranch, getChangedFilesAgainstBranch } from '../git/repo.js'
 import { superviseWorker } from './supervisor.js'
 import { logger } from '../utils/logger.js'
+import { buildPlanningPrdPath, isPlanningIssue } from '../planning/mode.js'
 
 export interface StepDependencies {
   adapters: Record<string, WorkerAdapter>
@@ -56,7 +57,11 @@ export async function executeWorkerStep(
   const adapter = resolveAdapter(step.role, ctx, deps)
   const profile = getWorkerProfile(ctx, step.role, deps)
   const promptCtx = buildPromptContext(ctx, step.role)
-  const template = step.prompt ?? getDefaultTemplate(step.role)
+  let template = step.prompt ?? getDefaultTemplate(step.role)
+  if (!step.prompt && step.role === 'coder' && isPlanningIssue(ctx.issue.labels, ctx.repoConfig)) {
+    const prdPath = buildPlanningPrdPath(ctx.issueNumber, ctx.issue.title, ctx.repoConfig)
+    template = buildPlanningOnlyCoderTemplate(prdPath)
+  }
   const { systemPrompt, userPrompt } = compilePrompt(
     null,
     template,
@@ -368,6 +373,34 @@ After making changes, output a summary as JSON:
   "blockers": null
 }
 \`\`\``
+
+function buildPlanningOnlyCoderTemplate(prdPath: string): string {
+  return `You are a software planning implementation assistant.
+
+Create exactly one PRD markdown file at:
+\`${prdPath}\`
+
+Constraints:
+- This is planning-only mode. Do NOT modify code, tests, configs, or any other file.
+- The PR must contain only this single markdown file.
+- If the directory does not exist, create it.
+- The PRD must include:
+  1. Problem statement and scope
+  2. Assumptions and open questions
+  3. Implementation phases
+  4. A checklist for each phase
+  5. Risks and validation strategy
+
+After making changes, output a summary as JSON:
+\`\`\`json
+{
+  "summary": "...",
+  "changedFiles": ["${prdPath}"],
+  "remainingUncertainty": null,
+  "blockers": null
+}
+\`\`\``
+}
 
 export const DEFAULT_REVIEWER_TEMPLATE = `You are a code reviewer. Perform a thorough, evidence-based review of the changes.
 

--- a/src/loop/workflow.ts
+++ b/src/loop/workflow.ts
@@ -1,5 +1,6 @@
 import type { Config, RepoConfig } from '../config/schema.js'
 import type { TriageLevel } from '../discovery/triage.js'
+import { isPlanningIssue } from '../planning/mode.js'
 
 export type WorkerStep = {
   type: 'worker'
@@ -38,6 +39,14 @@ export const DEFAULT_WORKFLOW: ResolvedWorkflow = {
   ],
 }
 
+export const PLANNING_ONLY_WORKFLOW: ResolvedWorkflow = {
+  steps: [
+    { type: 'worker', id: 'plan', role: 'planner' },
+    { type: 'worker', id: 'code', role: 'coder', continueFrom: 'plan' },
+    { type: 'decide', id: 'decide', onIterate: 'code' },
+  ],
+}
+
 /**
  * Resolve which workflow to use for a given repo and triage level.
  * Falls back to DEFAULT_WORKFLOW when no workflow is configured.
@@ -45,8 +54,11 @@ export const DEFAULT_WORKFLOW: ResolvedWorkflow = {
 export function resolveWorkflow(
   repoConfig: RepoConfig,
   config: Config,
+  issueLabels: string[],
   _triageLevel: TriageLevel,
 ): ResolvedWorkflow {
+  if (isPlanningIssue(issueLabels, repoConfig)) return PLANNING_ONLY_WORKFLOW
+
   const workflowName = repoConfig.workflow
   if (!workflowName) return DEFAULT_WORKFLOW
 

--- a/src/planning/mode.ts
+++ b/src/planning/mode.ts
@@ -1,0 +1,42 @@
+import type { RepoConfig } from '../config/schema.js'
+import { slugify } from '../utils/ids.js'
+
+/**
+ * Whether this issue should run in planning-only mode.
+ */
+export function isPlanningIssue(
+  issueLabels: string[],
+  repoConfig: Pick<RepoConfig, 'labels'>,
+): boolean {
+  const planningLabel = repoConfig.labels?.planning
+  if (!planningLabel) return false
+  return issueLabels.includes(planningLabel)
+}
+
+/**
+ * Deterministic PRD file path for planning-only mode.
+ */
+export function buildPlanningPrdPath(
+  issueNumber: number,
+  issueTitle: string,
+  repoConfig: Pick<RepoConfig, 'planning'>,
+): string {
+  const prdDirectory = repoConfig.planning?.prdDirectory ?? 'docs/prd'
+  const dir = normalizeRepoRelativePath(prdDirectory).replace(/\/+$/g, '')
+  const slug = slugify(issueTitle, 60) || `issue-${issueNumber}`
+  const filename = `${issueNumber}-${slug}.md`
+
+  if (!dir || dir === '.') return filename
+  return `${dir}/${filename}`
+}
+
+/**
+ * Normalize repository-relative paths to a canonical git-style form.
+ */
+export function normalizeRepoRelativePath(path: string): string {
+  return path
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/{2,}/g, '/')
+}

--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -38,6 +38,7 @@ import { processMergeQueue } from '../merge-queue/runner.js'
 import { decomposeIssue, shouldAttemptDecompose } from '../discovery/decomposer.js'
 import { executeParallelSubtasks } from '../loop/parallel.js'
 import { buildWorkerEnv } from '../workers/env.js'
+import { isPlanningIssue } from '../planning/mode.js'
 
 const STATUS_MARKER = markerTag('status')
 
@@ -204,7 +205,8 @@ export async function pollOnce(
         await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
 
         // Check if prior run left tainted work that should be discarded
-        const resetToBase = shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)
+        const planningMode = isPlanningIssue(discoveredIssue.issue.labels, repoConfig)
+        const resetToBase = planningMode || shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)
 
         // Create worktree
         await worktreeManager.ensure({
@@ -275,6 +277,7 @@ export async function pollOnce(
         // Check if decomposition is enabled and appropriate
         const shouldDecompose = config.loop.decompose
           && discoveredIssue.triage.level === 'standard'
+          && !planningMode
           && shouldAttemptDecompose(discoveredIssue.issue)
 
         if (shouldDecompose) {
@@ -301,7 +304,7 @@ export async function pollOnce(
                 coder: createWorkerAdapter(coderProfile),
                 reviewer: createWorkerAdapter(reviewerProfile),
               },
-              workflow: resolveWorkflow(repoConfig, config, discoveredIssue.triage.level),
+              workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
               envOverrides: envSetup?.envOverrides ?? {},
               metrics,
             }
@@ -347,7 +350,7 @@ export async function pollOnce(
             coder: createWorkerAdapter(coderProfile),
             reviewer: createWorkerAdapter(reviewerProfile),
           },
-          workflow: resolveWorkflow(repoConfig, config, discoveredIssue.triage.level),
+          workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
           envOverrides: envSetup?.envOverrides ?? {},
           metrics,
           onPlanReady: async (ctx) => {

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -111,6 +111,17 @@ describe('ConfigSchema', () => {
     }
   })
 
+  it('applies planning defaults for labels and PRD directory', () => {
+    const minimal = {
+      version: 1,
+      github: { tokenEnv: 'GITHUB_TOKEN' },
+      repos: [{ repo: 'org/repo', localPath: '/tmp/repo' }],
+    }
+    const result = ConfigSchema.parse(minimal)
+    expect(result.repos[0]!.labels.planning).toBe('orch:planning')
+    expect(result.repos[0]!.planning.prdDirectory).toBe('docs/prd')
+  })
+
   it('validates worker profile schema', () => {
     const raw = loadExampleConfig()
     raw.workerProfiles['claude-default'].workerTimeoutSeconds = -1

--- a/test/labels/bootstrap.test.ts
+++ b/test/labels/bootstrap.test.ts
@@ -11,6 +11,7 @@ describe('buildLabelBootstrapDefinitions', () => {
         reviewReady: 'orch:review-ready',
         error: 'orch:error',
         retry: 'orch:retry',
+        planning: 'orch:planning',
       },
       labelConfig: {},
     })
@@ -23,6 +24,7 @@ describe('buildLabelBootstrapDefinitions', () => {
       'orch:review-ready',
       'orch:error',
       'orch:retry',
+      'orch:planning',
     ])
     expect(result.find((l) => l.name === 'orch:ready')).toEqual({
       name: 'orch:ready',
@@ -40,6 +42,7 @@ describe('buildLabelBootstrapDefinitions', () => {
         reviewReady: 'team:review',
         error: 'team:error',
         retry: 'team:retry',
+        planning: 'team:planning',
       },
       labelConfig: {
         'team:triage': { color: 'abcdef', description: 'Ready in team workflow' },
@@ -68,6 +71,7 @@ describe('buildLabelBootstrapDefinitions', () => {
         reviewReady: 'orch:shared',
         error: 'orch:shared',
         retry: 'orch:shared',
+        planning: 'orch:shared',
       },
       labelConfig: {},
     })

--- a/test/labels/manager.test.ts
+++ b/test/labels/manager.test.ts
@@ -20,6 +20,10 @@ const labelConfig: LabelConfig = {
   reviewReady: 'orch:review-ready',
   error: 'orch:error',
   retry: 'orch:retry',
+  planning: 'orch:planning',
+  mergeQueued: 'orch:merge-queued',
+  merging: 'orch:merging',
+  mergeFailed: 'orch:merge-failed',
 }
 
 function makeMockForge(): ForgeAdapter {

--- a/test/labels/transitions.test.ts
+++ b/test/labels/transitions.test.ts
@@ -9,6 +9,10 @@ const config: LabelConfig = {
   reviewReady: 'orch:review-ready',
   error: 'orch:error',
   retry: 'orch:retry',
+  planning: 'orch:planning',
+  mergeQueued: 'orch:merge-queued',
+  merging: 'orch:merging',
+  mergeFailed: 'orch:merge-failed',
 }
 
 describe('isHumanRequired', () => {

--- a/test/loop/commit.test.ts
+++ b/test/loop/commit.test.ts
@@ -39,7 +39,7 @@ describe('commitChanges', () => {
 
     const result = await commitChanges('/tmp/wt', 1, 'No-op', limits)
 
-    expect(result).toEqual({ committed: false, reason: 'No changes to commit' })
+    expect(result).toEqual({ committed: false, reason: 'No changes to commit', blockRun: false })
     expect(mockCheckDiffSize).not.toHaveBeenCalled()
   })
 
@@ -56,7 +56,7 @@ describe('commitChanges', () => {
 
     const result = await commitChanges('/tmp/wt', 42, 'Fix title', limits)
 
-    expect(result.committed).toBe(true)
+    expect(result).toEqual({ committed: true, reason: null, blockRun: false })
     expect(mockCheckDiffSize).toHaveBeenCalledWith('/tmp/wt', limits, { staged: true })
     expect(mockExeca).toHaveBeenCalledWith('git', ['add', '-A'], { cwd: '/tmp/wt' })
     expect(mockExeca).toHaveBeenCalledWith(
@@ -100,11 +100,53 @@ describe('commitChanges', () => {
     const result = await commitChanges('/tmp/wt', 1, 'Big diff', limits)
 
     expect(result.committed).toBe(false)
+    expect(result.blockRun).toBe(true)
     expect(result.reason).toContain('Diff-size guard')
     expect(mockExeca).toHaveBeenCalledWith(
       'git',
       ['reset', 'HEAD', '--', '.'],
       { cwd: '/tmp/wt', reject: false },
     )
+  })
+
+  it('blocks planning-only commit when staged files are not exactly the expected PRD file', async () => {
+    mockExeca
+      .mockResolvedValueOnce({ stdout: ' M src/a.ts\n?? docs/prd/1-test.md\n' } as never) // git status
+      .mockResolvedValueOnce({} as never) // git add -A
+      .mockResolvedValueOnce({ stdout: 'docs/prd/1-test.md\nsrc/a.ts\n' } as never) // git diff --cached --name-only
+      .mockResolvedValueOnce({} as never) // git reset
+    mockCheckDiffSize.mockResolvedValue({
+      ok: true,
+      stats: { changedFiles: 2, insertions: 10, deletions: 1, totalChangedLines: 11 },
+      reason: null,
+    })
+
+    const result = await commitChanges('/tmp/wt', 1, 'Planning', limits, {
+      planningOnlyPrdPath: 'docs/prd/1-test.md',
+    })
+
+    expect(result.committed).toBe(false)
+    expect(result.blockRun).toBe(true)
+    expect(result.reason).toContain('Planning-only guard')
+    expect(mockExeca).toHaveBeenCalledWith('git', ['diff', '--cached', '--name-only'], { cwd: '/tmp/wt' })
+  })
+
+  it('allows planning-only commit when only the expected PRD file is staged', async () => {
+    mockExeca
+      .mockResolvedValueOnce({ stdout: '?? docs/prd/1-test.md\n' } as never) // git status
+      .mockResolvedValueOnce({} as never) // git add -A
+      .mockResolvedValueOnce({ stdout: 'docs/prd/1-test.md\n' } as never) // git diff --cached --name-only
+      .mockResolvedValueOnce({} as never) // git commit
+    mockCheckDiffSize.mockResolvedValue({
+      ok: true,
+      stats: { changedFiles: 1, insertions: 50, deletions: 0, totalChangedLines: 50 },
+      reason: null,
+    })
+
+    const result = await commitChanges('/tmp/wt', 1, 'Planning', limits, {
+      planningOnlyPrdPath: 'docs/prd/1-test.md',
+    })
+
+    expect(result).toEqual({ committed: true, reason: null, blockRun: false })
   })
 })

--- a/test/loop/decision.test.ts
+++ b/test/loop/decision.test.ts
@@ -26,7 +26,11 @@ function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
     repo: 'org/repo',
     issueNumber: 1,
     issue: { number: 1, nodeId: '', title: '', body: '', labels: [], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
-    repoConfig: { verify: ['pnpm test'] } as RunContext['repoConfig'],
+    repoConfig: {
+      verify: ['pnpm test'],
+      labels: { planning: 'orch:planning' },
+      planning: { prdDirectory: 'docs/prd' },
+    } as RunContext['repoConfig'],
     roles: { planner: 'claude', coder: 'claude', reviewer: 'claude' },
     triageResult: { level: 'standard', reason: '' },
     adjustedLimits: { maxReviewIterations: 4, maxTotalAgentPasses: 10, workerTimeoutSeconds: 1800 },
@@ -67,6 +71,33 @@ describe('decide', () => {
     })
     const d = decide(ctx, loopConfig, securityConfig)
     expect(d.action).toBe('publish')
+  })
+
+  it('planning label + coder output present → publish without review/verify', () => {
+    const ctx = makeCtx({
+      issue: { ...makeCtx().issue, labels: ['orch:planning'] },
+      codeResult: {
+        summary: 'Wrote PRD',
+        changedFiles: ['docs/prd/1-test.md'],
+        remainingUncertainty: null,
+        blockers: null,
+      },
+      reviewResult: null,
+      verifyResults: [],
+    })
+    const d = decide(ctx, loopConfig, securityConfig)
+    expect(d.action).toBe('publish')
+  })
+
+  it('planning label + missing coder output → block', () => {
+    const ctx = makeCtx({
+      issue: { ...makeCtx().issue, labels: ['orch:planning'] },
+      codeResult: null,
+      reviewResult: null,
+      verifyResults: [],
+    })
+    const d = decide(ctx, loopConfig, securityConfig)
+    expect(d.action).toBe('block')
   })
 
   it('APPROVED + verify fail → iterate', () => {
@@ -189,7 +220,7 @@ describe('decide', () => {
 
   it('APPROVED with no verify commands + requireVerificationPass=false → publish', () => {
     const ctx = makeCtx({
-      repoConfig: { verify: [] } as RunContext['repoConfig'],
+      repoConfig: { ...makeCtx().repoConfig, verify: [] },
       verifyResults: [],
       reviewResult: {
         verdict: 'APPROVED',

--- a/test/loop/workflow.test.ts
+++ b/test/loop/workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveWorkflow, DEFAULT_WORKFLOW } from '../../src/loop/workflow.js'
+import { resolveWorkflow, DEFAULT_WORKFLOW, PLANNING_ONLY_WORKFLOW } from '../../src/loop/workflow.js'
 import type { Config, RepoConfig } from '../../src/config/schema.js'
 
 function makeRepoConfig(overrides: Partial<RepoConfig> = {}): RepoConfig {
@@ -9,8 +9,9 @@ function makeRepoConfig(overrides: Partial<RepoConfig> = {}): RepoConfig {
     localPath: '/tmp/repo',
     baseBranch: 'main',
     branchPrefix: 'orch',
-    labels: { ready: ['orch:ready'], running: 'orch:running', blocked: 'orch:blocked', needsHuman: 'orch:needs-human', reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry' },
+    labels: { ready: ['orch:ready'], running: 'orch:running', blocked: 'orch:blocked', needsHuman: 'orch:needs-human', reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry', planning: 'orch:planning' },
     defaults: { planner: 'claude', coder: 'claude', reviewer: 'claude', doneMode: 'pr-ready', notifyPriority: 'normal', prMentions: [] },
+    planning: { prdDirectory: 'docs/prd' },
     verify: [],
     selectors: { includeLabelsAny: [], excludeLabelsAny: [] },
     agents: {},
@@ -37,7 +38,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 
 describe('resolveWorkflow', () => {
   it('returns DEFAULT_WORKFLOW when no workflow configured', () => {
-    const result = resolveWorkflow(makeRepoConfig(), makeConfig(), 'standard')
+    const result = resolveWorkflow(makeRepoConfig(), makeConfig(), [], 'standard')
     expect(result).toBe(DEFAULT_WORKFLOW)
   })
 
@@ -45,6 +46,7 @@ describe('resolveWorkflow', () => {
     const result = resolveWorkflow(
       makeRepoConfig({ workflow: 'nonexistent' }),
       makeConfig(),
+      [],
       'standard',
     )
     expect(result).toBe(DEFAULT_WORKFLOW)
@@ -61,10 +63,21 @@ describe('resolveWorkflow', () => {
     const result = resolveWorkflow(
       makeRepoConfig({ workflow: 'minimal' }),
       makeConfig({ workflows: { minimal: customWorkflow } }),
+      [],
       'standard',
     )
     expect(result.steps).toHaveLength(3)
     expect(result.steps[0]!.id).toBe('code')
+  })
+
+  it('returns PLANNING_ONLY_WORKFLOW when planning label is present', () => {
+    const result = resolveWorkflow(
+      makeRepoConfig({ workflow: 'minimal' }),
+      makeConfig(),
+      ['orch:planning'],
+      'standard',
+    )
+    expect(result).toBe(PLANNING_ONLY_WORKFLOW)
   })
 })
 

--- a/test/planning/mode.test.ts
+++ b/test/planning/mode.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { buildPlanningPrdPath, isPlanningIssue, normalizeRepoRelativePath } from '../../src/planning/mode.js'
+
+describe('isPlanningIssue', () => {
+  it('returns true when planning label is present', () => {
+    expect(isPlanningIssue(['bug', 'orch:planning'], { labels: { planning: 'orch:planning' } } as never)).toBe(true)
+  })
+
+  it('returns false when planning label is absent', () => {
+    expect(isPlanningIssue(['bug'], { labels: { planning: 'orch:planning' } } as never)).toBe(false)
+  })
+})
+
+describe('buildPlanningPrdPath', () => {
+  it('builds deterministic path from issue number and title', () => {
+    const path = buildPlanningPrdPath(42, 'Add SSO + SCIM Support', {
+      planning: { prdDirectory: 'docs/prd' },
+    } as never)
+    expect(path).toBe('docs/prd/42-add-sso-scim-support.md')
+  })
+
+  it('normalizes odd directory formatting', () => {
+    const path = buildPlanningPrdPath(7, 'Test', {
+      planning: { prdDirectory: './docs//prd/' },
+    } as never)
+    expect(path).toBe('docs/prd/7-test.md')
+  })
+})
+
+describe('normalizeRepoRelativePath', () => {
+  it('normalizes slashes and leading ./', () => {
+    expect(normalizeRepoRelativePath('./docs\\prd//x')).toBe('docs/prd/x')
+  })
+})

--- a/test/poller/poller.test.ts
+++ b/test/poller/poller.test.ts
@@ -100,8 +100,9 @@ function makeConfig(dbPath: string): Config {
     metrics: { enabled: false, port: 9090, host: '127.0.0.1' },
     repos: [{
       repo: 'org/repo', forge: 'github', localPath: '/tmp/repo', baseBranch: 'main',
-      branchPrefix: 'orch', labels: { ready: ['orch:ready'], running: 'orch:running', blocked: ['orch:blocked'], reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry' },
+      branchPrefix: 'orch', labels: { ready: ['orch:ready'], running: 'orch:running', blocked: ['orch:blocked'], reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry', planning: 'orch:planning' },
       defaults: { planner: 'claude', coder: 'claude', reviewer: 'claude', doneMode: 'pr-ready', notifyPriority: 'normal', prMentions: [] },
+      planning: { prdDirectory: 'docs/prd' },
       verify: ['pnpm test'], selectors: { includeLabelsAny: [], excludeLabelsAny: [] }, agents: { claude: 'claude' },
     }],
     mcp: { enabled: false, transport: 'stdio', authTokenEnv: null },

--- a/test/publishing/full-publish.test.ts
+++ b/test/publishing/full-publish.test.ts
@@ -30,6 +30,10 @@ const labelConfig: LabelConfig = {
   reviewReady: 'orch:review-ready',
   error: 'orch:error',
   retry: 'orch:retry',
+  planning: 'orch:planning',
+  mergeQueued: 'orch:merge-queued',
+  merging: 'orch:merging',
+  mergeFailed: 'orch:merge-failed',
 }
 
 function makePR(num: number): ForgePR {
@@ -71,7 +75,8 @@ function makeCtx(): RunContext {
       localPath: '/tmp/repo',
       baseBranch: 'main',
       branchPrefix: 'orch',
-      labels: { ready: ['orch:ready'], running: 'orch:running', blocked: ['orch:blocked'], reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry' },
+      labels: { ready: ['orch:ready'], running: 'orch:running', blocked: ['orch:blocked'], reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry', planning: 'orch:planning' },
+      planning: { prdDirectory: 'docs/prd' },
       defaults: { planner: 'claude', coder: 'claude', reviewer: 'claude', doneMode: 'pr-ready', notifyPriority: 'normal', prMentions: [] },
       verify: [],
       selectors: { includeLabelsAny: [], excludeLabelsAny: [] },


### PR DESCRIPTION
Closes #4

## Plan
**Objective:** Add a planning-only label mode that makes the agent produce a PRD markdown file instead of code, with the PR containing only that PRD

1. Add `planning` label to LabelsSchema with default `orch:planning`, add to LabelConfig interface in transitions.ts, add to bootstrap.ts DEFAULT_LABEL_PRESENTATION, and include in buildLabelBootstrapDefinitions(). This is a mode label, not a state label — it stays on the issue permanently.
2. Add `prdPath` to RepoConfigSchema (string, default `docs/prds`) — the directory within the repo where PRD files are written. Add to RepoConfig type.
3. Add planning-only detection: create a helper `isPlanningOnly(issue: ForgeIssue, labelConfig: LabelConfig): boolean` that checks if the issue has the planning label. This goes in discovery or a shared util. Also export a `IssueMode` type: `'standard' | 'planning'`.
4. Define a PLANNING_WORKFLOW in workflow.ts — a single planner worker step (no skipWhen) with a PRD-specific prompt template, no coder/verify/review/decide. Add `resolveWorkflow` logic: if issue mode is planning, return PLANNING_WORKFLOW regardless of configured workflow. This requires passing issue mode into resolveWorkflow.
5. Add DEFAULT_PRD_PLANNER_TEMPLATE in step-executor.ts — instructs the planner to produce a complete PRD markdown document (not JSON) with sections: Overview, Problem Statement, Goals/Non-Goals, User Stories, Implementation Phases with checklists, Acceptance Criteria, Risks, Open Questions. The template should tell the agent to explore the codebase first, then produce the PRD.
6. Modify engine.ts executeLoop: after the loop completes all steps (falls through without a decide step), if no decide step was present in the workflow, auto-publish. Specifically: when the while loop ends without a terminal status, check if the workflow had no decide step — if so, treat as implicit publish. This handles the planning workflow cleanly since it has no decide step.
7. Add PRD file writing logic: after the planner step in a planning-only run, write the PRD content to `{prdPath}/{issueNumber}-{slug}.md` in the worktree. This happens in the poller's onPlanReady callback or as a new post-planner hook in the engine. The cleanest approach: add a new field `issueMode` to RunContext, and in engine.ts after the planner step completes in planning mode, write the PRD file to disk.
8. Update commit.ts: planning-only commits should use a different message template like `night-orch: PRD for #N <title>` instead of `night-orch: implement #N <title>`. Pass issue mode or a flag.
9. Update pr-body.ts: add a planning-only PR body variant. The PR body should say this is a PRD-only PR, include the PRD objective, and not include implementation/verification/review sections. Add `issueMode` to PRBodyContext.
10. Update poller.ts: detect planning-only mode from issue labels, pass it through to RunContext construction, use PLANNING_WORKFLOW, and handle the finalization appropriately. Planning runs don't need coder/reviewer profiles — skip the profile resolution for those roles or provide stub values.
11. Update docs/CONFIGURATION.md with the new `planning` label, `prdPath` config field, and planning-only workflow behavior. Update examples/config.example.yaml.
12. Add/update tests: label bootstrap includes planning label, planning-only workflow resolution, engine handles no-decide workflow, PR body planning variant, commit message for planning runs.

## Implementation
Implemented planning-only issue mode driven by a new configurable planning label (`repos[].labels.planning`, default `orch:planning`). Added per-repo PRD directory config (`repos[].planning.prdDirectory`, default `docs/prd`), planning-mode detection/path helpers, and a planning-only workflow override (`plan -> code -> decide`) that bypasses review/verify gating and publishes when PRD output is produced. Added a planning-specific coder prompt that instructs creation of exactly one PRD markdown file with implementation phases/checklists. Enforced a hard planning-only commit guard so runs are blocked unless staged changes contain only the expected PRD file, and forced planning-mode runs to reset branch state to base to prevent prior code commits leaking into PRs. Updated label bootstrap/init behavior, docs/examples, and tests. Validation: `pnpm test`, `pnpm typecheck`, and `pnpm lint` all pass.

**Changed files:**
- `README.md`
- `config.yaml`
- `docs/CONFIGURATION.md`
- `docs/USAGE.md`
- `examples/config.example.yaml`
- `src/config/schema.ts`
- `src/labels/bootstrap.ts`
- `src/labels/config.ts`
- `src/labels/transitions.ts`
- `src/loop/commit.ts`
- `src/loop/decision.ts`
- `src/loop/engine.ts`
- `src/loop/step-executor.ts`
- `src/loop/workflow.ts`
- `src/planning/mode.ts`
- `src/runner/poller.ts`
- `test/config/schema.test.ts`
- `test/labels/bootstrap.test.ts`
- `test/labels/manager.test.ts`
- `test/labels/transitions.test.ts`
- `test/loop/commit.test.ts`
- `test/loop/decision.test.ts`
- `test/loop/workflow.test.ts`
- `test/planning/mode.test.ts`
- `test/poller/poller.test.ts`
- `test/publishing/full-publish.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Clean, well-scoped implementation of planning-only mode. New src/planning/mode.ts module provides pure helper functions. The feature correctly threads through all layers: config schema, label bootstrap, workflow resolution, step executor prompt override, decision bypass of review/verify, commit guard enforcement, and poller integration. Tests cover the key paths. The blockRun refactor in commit.ts is a nice improvement over the string-matching approach.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude