### PR TITLE
[CHORE] Enable issues in projects (night-orch / #13)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -284,6 +284,7 @@ Reference a workflow in `repos[].workflow` by name.
 | --- | --- | --- | --- | --- |
 | `repo` | `owner/name` string | yes | none | Repository slug. |
 | `forge` | `github` or `forgejo` | no | `github` | Forge implementation selector. |
+| `linkedProjects` | `owner/name` string[] | no | `[]` | Additional issue-source repos to discover from using this repo's selectors/flow. |
 | `apiBaseUrl` | URL string | no | none | Required for `forgejo`; optional override for `github`. |
 | `tokenEnv` | string | no | none | Token env override per repo. |
 | `maxConcurrentRuns` | int 1-20 | no | `1` | Max issues processed concurrently for this repo per poll cycle. |
@@ -291,6 +292,7 @@ Reference a workflow in `repos[].workflow` by name.
 | `baseBranch` | string | no | `main` | PR target branch. |
 | `branchPrefix` | string | no | `orch` | Work branch prefix. |
 | `labels` | object | no | object with defaults | Orchestration label names. |
+| `kanban` | object | no | none | Optional alternate state-label flow activated by a trigger label. |
 | `labelConfig` | record | no | `{}` | Label metadata overrides for `labels-init`. |
 | `defaults` | object | no | object with defaults | Default roles + mention settings. |
 | `planning` | object | no | object with defaults | Planning-only mode settings (PRD path). |
@@ -321,6 +323,45 @@ Poll execution model:
 | `mergeQueued` | string | `orch:merge-queued` | Set when PR enters the merge queue. |
 | `merging` | string | `orch:merging` | Set while staging branch CI is running. |
 | `mergeFailed` | string | `orch:merge-failed` | Set when the merge queue identifies this PR as the culprit. |
+
+### `repos[].linkedProjects`
+
+List of additional repositories to use as issue sources for the repo.
+
+Example:
+
+```yaml
+repos:
+  - repo: myorg/app
+    linkedProjects:
+      - myorg/tracker
+      - myorg/platform-triage
+```
+
+Each entry must use `owner/name` format.
+
+### `repos[].kanban`
+
+Optional alternate state flow. When `triggerLabel` is present on an issue, night-orch uses `kanban.labels` for status transitions (queued/running/blocked/review/error/retry) instead of `repos[].labels`.
+
+```yaml
+repos:
+  - repo: myorg/myrepo
+    kanban:
+      triggerLabel: flow:kanban
+      labels:
+        ready: [kanban:todo]
+        running: kanban:doing
+        blocked: kanban:blocked
+        needsHuman: kanban:needs-human
+        reviewReady: kanban:review
+        error: kanban:error
+        retry: kanban:retry
+        planning: kanban:planning
+        mergeQueued: kanban:merge-queued
+        merging: kanban:merging
+        mergeFailed: kanban:merge-failed
+```
 
 ### `repos[].labelConfig`
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -113,6 +113,8 @@ commentCommands:
 repos:
   - repo: myorg/myrepo
     forge: github
+    # linkedProjects:
+    #   - myorg/tracker
     localPath: ~/code/myrepo
     maxConcurrentRuns: 1
     baseBranch: main
@@ -131,6 +133,22 @@ repos:
       # mergeQueued: orch:merge-queued
       # merging: orch:merging
       # mergeFailed: orch:merge-failed
+    # Optional kanban-state flow. If triggerLabel is present on an issue,
+    # these labels are used for state transitions instead of labels above.
+    # kanban:
+    #   triggerLabel: flow:kanban
+    #   labels:
+    #     ready: [kanban:todo]
+    #     running: kanban:doing
+    #     blocked: kanban:blocked
+    #     needsHuman: kanban:needs-human
+    #     reviewReady: kanban:review
+    #     error: kanban:error
+    #     retry: kanban:retry
+    #     planning: kanban:planning
+    #     mergeQueued: kanban:merge-queued
+    #     merging: kanban:merging
+    #     mergeFailed: kanban:merge-failed
     planning:
       prdDirectory: docs/prd
     # Optional per-label metadata overrides used by `night-orch labels-init`

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -115,6 +115,15 @@ const LabelsSchema = z.object({
   mergeFailed: z.string().default('orch:merge-failed'),
 })
 
+const LinkedProjectSchema = z
+  .string()
+  .regex(/^[^/]+\/[^/]+$/, 'Must be in format owner/name')
+
+const KanbanSchema = z.object({
+  triggerLabel: z.string().min(1, 'triggerLabel must not be empty'),
+  labels: LabelsSchema,
+})
+
 const LabelPresentationSchema = z.object({
   color: z.string().regex(/^[0-9A-Fa-f]{6}$/, 'Color must be a 6-character hex value').optional(),
   description: z.string().max(100, 'Description must be 100 characters or fewer').optional(),
@@ -195,6 +204,7 @@ const MergeQueueSchema = z.object({
 const RepoConfigSchema = z.object({
   repo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be in format owner/name'),
   forge: z.enum(['github', 'forgejo']).default('github'),
+  linkedProjects: z.array(LinkedProjectSchema).default([]),
   apiBaseUrl: z.string().url().optional(),
   tokenEnv: z.string().optional(),
   maxConcurrentRuns: z.number().int().min(1).max(20).default(1),
@@ -202,6 +212,7 @@ const RepoConfigSchema = z.object({
   baseBranch: z.string().default('main'),
   branchPrefix: z.string().default('orch'),
   labels: LabelsSchema.default({ ready: ['orch:ready'] }),
+  kanban: KanbanSchema.optional(),
   labelConfig: z.record(LabelPresentationSchema).default({}),
   defaults: DefaultsSchema.default({}),
   environment: EnvironmentConfigSchema.optional(),

--- a/src/discovery/discover.ts
+++ b/src/discovery/discover.ts
@@ -1,12 +1,14 @@
 import type { RepoConfig } from '../config/schema.js'
 import type { ForgeAdapter, ForgeIssue } from '../forge/types.js'
 import type { LeaseManager } from '../state/leases.js'
-import { filterEligible } from './selector.js'
+import { isEligible, type IssueSelector } from './selector.js'
 import { triageIssue, type TriageResult } from './triage.js'
 import { logger } from '../utils/logger.js'
+import { isKanbanIssue } from '../labels/config.js'
 
 export interface DiscoveredIssue {
   issue: ForgeIssue
+  issueRepo: string
   triage: TriageResult
   repoConfig: RepoConfig
 }
@@ -31,13 +33,14 @@ export async function discoverEligibleIssues(
   logger.debug({ repo: repoConfig.repo, count: rawIssues.length }, 'Fetched issues from forge')
 
   // 2. Local filter
-  const eligible = filterEligible(rawIssues, repoConfig.selectors)
+  const eligible = rawIssues.filter((issue) => isIssueEligibleForRepo(issue, repoConfig))
   logger.debug({ repo: repoConfig.repo, count: eligible.length }, 'Issues after selector filter')
 
   // 3. Exclude leased
   const unleased = eligible.filter((issue) => {
-    if (leaseManager.isLeased(repoConfig.repo, issue.number)) {
-      logger.debug({ repo: repoConfig.repo, issue: issue.number }, 'Skipping leased issue')
+    const issueRepo = resolveIssueRepo(issue, repoConfig.repo)
+    if (leaseManager.isLeased(issueRepo, issue.number)) {
+      logger.debug({ repo: issueRepo, issue: issue.number }, 'Skipping leased issue')
       return false
     }
     return true
@@ -46,6 +49,7 @@ export async function discoverEligibleIssues(
   // 4. Triage
   const discovered: DiscoveredIssue[] = unleased.map((issue) => ({
     issue,
+    issueRepo: resolveIssueRepo(issue, repoConfig.repo),
     triage: triageIssue(issue),
     repoConfig,
   }))
@@ -70,4 +74,58 @@ export async function discoverEligibleIssues(
   )
 
   return discovered
+}
+
+export function isIssueEligibleForRepo(issue: ForgeIssue, repoConfig: RepoConfig): boolean {
+  return isEligible(issue, buildSelectorForIssue(repoConfig, issue))
+}
+
+function buildSelectorForIssue(repoConfig: RepoConfig, issue: ForgeIssue): IssueSelector {
+  if (!repoConfig.kanban || !isKanbanIssue(issue.labels, repoConfig)) {
+    return repoConfig.selectors
+  }
+
+  const kanbanReady = Array.isArray(repoConfig.kanban.labels.ready)
+    ? [...repoConfig.kanban.labels.ready]
+    : [repoConfig.kanban.labels.ready]
+
+  return {
+    includeLabelsAny: kanbanReady,
+    excludeLabelsAny: [
+      repoConfig.kanban.labels.running,
+      repoConfig.kanban.labels.blocked,
+      repoConfig.kanban.labels.needsHuman,
+      repoConfig.kanban.labels.reviewReady,
+      repoConfig.kanban.labels.error,
+      repoConfig.kanban.labels.retry,
+    ],
+  }
+}
+
+function resolveIssueRepo(
+  issue: Pick<ForgeIssue, 'repo' | 'url'>,
+  fallbackRepo: string,
+): string {
+  if (typeof issue.repo === 'string' && issue.repo.length > 0) {
+    return issue.repo
+  }
+
+  try {
+    const pathSegments = new URL(issue.url).pathname.split('/').filter(Boolean)
+    const issuesIndex = pathSegments.lastIndexOf('issues')
+
+    if (issuesIndex >= 2) {
+      const owner = pathSegments[issuesIndex - 2]
+      const repo = pathSegments[issuesIndex - 1]
+      if (owner && repo) return `${owner}/${repo}`
+    }
+
+    const owner = pathSegments[0]
+    const repo = pathSegments[1]
+    if (owner && repo) return `${owner}/${repo}`
+  } catch {
+    // Ignore parse errors and use fallback.
+  }
+
+  return fallbackRepo
 }

--- a/src/forge/forgejo.ts
+++ b/src/forge/forgejo.ts
@@ -3,6 +3,7 @@ import type {
   ForgeAdapter, ForgeIssue, ForgePR, PRParams, ForgeAuthInfo,
   ForgeComment, ForgePRReview, ForgePRReviewComment, PRReviewState, MergeMethod,
 } from './types.js'
+import { getDiscoveryIncludeLabels } from '../labels/config.js'
 import { ForgejoClient, ForgejoApiError } from './forgejo-client.js'
 import { LabelCache } from './forgejo-labels.js'
 
@@ -79,37 +80,43 @@ export class ForgejoForgeAdapter implements ForgeAdapter {
   }
 
   async listEligibleIssues(repoConfig: RepoConfig): Promise<ForgeIssue[]> {
-    const { owner, repo } = splitRepo(repoConfig.repo)
-    const includeLabels = repoConfig.selectors.includeLabelsAny
+    const includeLabels = getDiscoveryIncludeLabels(repoConfig)
+    const discoveryRepos = [...new Set([repoConfig.repo, ...(repoConfig.linkedProjects ?? [])])]
 
-    const seenNumbers = new Set<number>()
+    const seenKeys = new Set<string>()
     const allIssues: ForgeIssue[] = []
 
-    if (includeLabels.length === 0) {
-      const issues = await this.client.getPaginated<ForgejoIssueData>(
-        `/repos/${owner}/${repo}/issues`,
-        { state: 'open', type: 'issues' },
-      )
-      for (const issue of issues) {
-        if (issue.pull_request) continue
-        if (seenNumbers.has(issue.number)) continue
-        seenNumbers.add(issue.number)
-        allIssues.push(this.mapIssue(issue, repoConfig.repo))
+    for (const targetRepo of discoveryRepos) {
+      const { owner, repo } = splitRepo(targetRepo)
+
+      if (includeLabels.length === 0) {
+        const issues = await this.client.getPaginated<ForgejoIssueData>(
+          `/repos/${owner}/${repo}/issues`,
+          { state: 'open', type: 'issues' },
+        )
+        for (const issue of issues) {
+          if (issue.pull_request) continue
+          const key = `${targetRepo}#${issue.number}`
+          if (seenKeys.has(key)) continue
+          seenKeys.add(key)
+          allIssues.push(this.mapIssue(issue, targetRepo))
+        }
+        continue
       }
-      return allIssues
-    }
 
-    for (const label of includeLabels) {
-      const issues = await this.client.getPaginated<ForgejoIssueData>(
-        `/repos/${owner}/${repo}/issues`,
-        { state: 'open', labels: label, type: 'issues' },
-      )
+      for (const label of includeLabels) {
+        const issues = await this.client.getPaginated<ForgejoIssueData>(
+          `/repos/${owner}/${repo}/issues`,
+          { state: 'open', labels: label, type: 'issues' },
+        )
 
-      for (const issue of issues) {
-        if (issue.pull_request) continue
-        if (seenNumbers.has(issue.number)) continue
-        seenNumbers.add(issue.number)
-        allIssues.push(this.mapIssue(issue, repoConfig.repo))
+        for (const issue of issues) {
+          if (issue.pull_request) continue
+          const key = `${targetRepo}#${issue.number}`
+          if (seenKeys.has(key)) continue
+          seenKeys.add(key)
+          allIssues.push(this.mapIssue(issue, targetRepo))
+        }
       }
     }
 
@@ -324,10 +331,11 @@ export class ForgejoForgeAdapter implements ForgeAdapter {
 
   // --- Internal mapping ---
 
-  private mapIssue(data: ForgejoIssueData, _repoSlug: string): ForgeIssue {
+  private mapIssue(data: ForgejoIssueData, repoSlug: string): ForgeIssue {
     return {
       number: data.number,
       nodeId: null,
+      repo: repoSlug,
       title: data.title,
       body: data.body ?? '',
       labels: data.labels.map((l) => l.name).filter(Boolean),

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -5,6 +5,7 @@ import type {
   ForgeComment, ForgePRReview, ForgePRReviewComment, PRReviewState, MergeMethod,
   PRCheckStatus, PRCheckRun, CheckConclusion,
 } from './types.js'
+import { getDiscoveryIncludeLabels } from '../labels/config.js'
 import { logger } from '../utils/logger.js'
 
 function splitRepo(repo: string): { owner: string; repo: string } {
@@ -24,57 +25,63 @@ export class GitHubForgeAdapter implements ForgeAdapter {
   }
 
   async listEligibleIssues(repoConfig: RepoConfig): Promise<ForgeIssue[]> {
-    const { owner, repo } = splitRepo(repoConfig.repo)
-    const includeLabels = repoConfig.selectors.includeLabelsAny
+    const includeLabels = getDiscoveryIncludeLabels(repoConfig)
+    const discoveryRepos = [...new Set([repoConfig.repo, ...(repoConfig.linkedProjects ?? [])])]
 
     // GitHub API filters by labels (AND), so we fetch with each include label
     // and deduplicate. For OR semantics with few labels, this is efficient enough.
-    const seenNumbers = new Set<number>()
+    const seenKeys = new Set<string>()
     const allIssues: ForgeIssue[] = []
 
-    if (includeLabels.length === 0) {
-      const issues = await this.octokit.paginate(
-        this.octokit.rest.issues.listForRepo,
-        {
-          owner,
-          repo,
-          state: 'open',
-          per_page: 100,
-        },
-      )
-      for (const issue of issues) {
-        if (issue.pull_request) continue
-        if (seenNumbers.has(issue.number)) continue
-        seenNumbers.add(issue.number)
-        allIssues.push(this.mapIssue(issue, repoConfig.repo))
-      }
-      await this.checkRateLimit()
-      return allIssues
-    }
+    for (const targetRepo of discoveryRepos) {
+      const { owner, repo } = splitRepo(targetRepo)
 
-    for (const label of includeLabels) {
-      const issues = await this.octokit.paginate(
-        this.octokit.rest.issues.listForRepo,
-        {
-          owner,
-          repo,
-          state: 'open',
-          labels: label,
-          per_page: 100,
-        },
-      )
-
-      for (const issue of issues) {
-        // Skip pull requests (GitHub API includes them in issues)
-        if (issue.pull_request) continue
-        if (seenNumbers.has(issue.number)) continue
-        seenNumbers.add(issue.number)
-
-        allIssues.push(this.mapIssue(issue, repoConfig.repo))
+      if (includeLabels.length === 0) {
+        const issues = await this.octokit.paginate(
+          this.octokit.rest.issues.listForRepo,
+          {
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100,
+          },
+        )
+        for (const issue of issues) {
+          if (issue.pull_request) continue
+          const key = `${targetRepo}#${issue.number}`
+          if (seenKeys.has(key)) continue
+          seenKeys.add(key)
+          allIssues.push(this.mapIssue(issue, targetRepo))
+        }
+        await this.checkRateLimit()
+        continue
       }
 
-      // Check rate limit
-      await this.checkRateLimit()
+      for (const label of includeLabels) {
+        const issues = await this.octokit.paginate(
+          this.octokit.rest.issues.listForRepo,
+          {
+            owner,
+            repo,
+            state: 'open',
+            labels: label,
+            per_page: 100,
+          },
+        )
+
+        for (const issue of issues) {
+          // Skip pull requests (GitHub API includes them in issues)
+          if (issue.pull_request) continue
+          const key = `${targetRepo}#${issue.number}`
+          if (seenKeys.has(key)) continue
+          seenKeys.add(key)
+
+          allIssues.push(this.mapIssue(issue, targetRepo))
+        }
+
+        // Check rate limit
+        await this.checkRateLimit()
+      }
     }
 
     return allIssues
@@ -423,7 +430,7 @@ export class GitHubForgeAdapter implements ForgeAdapter {
 
   // --- Internals ---
 
-  private mapIssue(data: Record<string, unknown>, _repoSlug: string): ForgeIssue {
+  private mapIssue(data: Record<string, unknown>, repoSlug: string): ForgeIssue {
     const d = data as {
       number: number
       node_id: string
@@ -439,6 +446,7 @@ export class GitHubForgeAdapter implements ForgeAdapter {
     return {
       number: d.number,
       nodeId: d.node_id,
+      repo: repoSlug,
       title: d.title,
       body: d.body ?? '',
       labels: d.labels.map((l) => (typeof l === 'string' ? l : l.name ?? '')).filter(Boolean),

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -32,6 +32,8 @@ export type MergeMethod = 'merge' | 'squash' | 'rebase'
 export interface ForgeIssue {
   number: number
   nodeId: string | null
+  /** Canonical owner/name source repo for this issue (can differ from run repo). */
+  repo?: string
   title: string
   body: string
   labels: string[]

--- a/src/labels/bootstrap.ts
+++ b/src/labels/bootstrap.ts
@@ -7,6 +7,7 @@ export interface LabelBootstrapDefinition {
 }
 
 type LabelRole = 'ready' | 'running' | 'blocked' | 'reviewReady' | 'error' | 'retry' | 'planning' | 'mergeQueued' | 'merging' | 'mergeFailed'
+  | 'kanbanTrigger'
 
 const DEFAULT_LABEL_PRESENTATION: Record<LabelRole, { color: string; description: string }> = {
   ready: {
@@ -49,6 +50,10 @@ const DEFAULT_LABEL_PRESENTATION: Record<LabelRole, { color: string; description
     color: 'E4E669',
     description: 'Merge attempt failed; manual action required',
   },
+  kanbanTrigger: {
+    color: '5319E7',
+    description: 'Use kanban state flow instead of default orchestration labels',
+  },
 }
 
 /**
@@ -56,7 +61,7 @@ const DEFAULT_LABEL_PRESENTATION: Record<LabelRole, { color: string; description
  * optional per-label overrides from repo.labelConfig.
  */
 export function buildLabelBootstrapDefinitions(
-  repoConfig: Pick<RepoConfig, 'labels' | 'labelConfig'>,
+  repoConfig: Pick<RepoConfig, 'labels' | 'labelConfig' | 'kanban'>,
 ): LabelBootstrapDefinition[] {
   const definitions: LabelBootstrapDefinition[] = []
   const seen = new Set<string>()
@@ -75,9 +80,9 @@ export function buildLabelBootstrapDefinitions(
     })
   }
 
-  for (const label of repoConfig.labels.ready) add(label, 'ready')
+  for (const label of asLabelArray(repoConfig.labels.ready)) add(label, 'ready')
   add(repoConfig.labels.running, 'running')
-  for (const label of repoConfig.labels.blocked) add(label, 'blocked')
+  for (const label of asLabelArray(repoConfig.labels.blocked)) add(label, 'blocked')
   add(repoConfig.labels.reviewReady, 'reviewReady')
   add(repoConfig.labels.error, 'error')
   add(repoConfig.labels.retry, 'retry')
@@ -86,5 +91,27 @@ export function buildLabelBootstrapDefinitions(
   add(repoConfig.labels.merging, 'merging')
   add(repoConfig.labels.mergeFailed, 'mergeFailed')
 
+  if (repoConfig.kanban) {
+    add(repoConfig.kanban.triggerLabel, 'kanbanTrigger')
+    for (const label of asLabelArray(repoConfig.kanban.labels.ready)) add(label, 'ready')
+    add(repoConfig.kanban.labels.running, 'running')
+    add(repoConfig.kanban.labels.blocked, 'blocked')
+    add(repoConfig.kanban.labels.needsHuman, 'blocked')
+    add(repoConfig.kanban.labels.reviewReady, 'reviewReady')
+    add(repoConfig.kanban.labels.error, 'error')
+    add(repoConfig.kanban.labels.retry, 'retry')
+    add(repoConfig.kanban.labels.planning, 'planning')
+    add(repoConfig.kanban.labels.mergeQueued, 'mergeQueued')
+    add(repoConfig.kanban.labels.merging, 'merging')
+    add(repoConfig.kanban.labels.mergeFailed, 'mergeFailed')
+  }
+
   return definitions
+}
+
+function asLabelArray(value: string | readonly string[]): string[] {
+  if (typeof value === 'string') {
+    return [value]
+  }
+  return [...value]
 }

--- a/src/labels/config.ts
+++ b/src/labels/config.ts
@@ -1,18 +1,71 @@
 import type { RepoConfig } from '../config/schema.js'
 import type { LabelConfig } from './transitions.js'
 
-export function buildLabelConfig(repoConfig: Pick<RepoConfig, 'labels'>): LabelConfig {
-  return {
-    ready: repoConfig.labels.ready,
-    running: repoConfig.labels.running,
-    blocked: repoConfig.labels.blocked,
-    needsHuman: repoConfig.labels.needsHuman,
-    reviewReady: repoConfig.labels.reviewReady,
-    error: repoConfig.labels.error,
-    retry: repoConfig.labels.retry,
-    planning: repoConfig.labels.planning,
-    mergeQueued: repoConfig.labels.mergeQueued,
-    merging: repoConfig.labels.merging,
-    mergeFailed: repoConfig.labels.mergeFailed,
+type LabelsSource = RepoConfig['labels']
+
+export function isKanbanIssue(
+  issueLabels: readonly string[] | undefined,
+  repoConfig: Pick<RepoConfig, 'kanban'>,
+): boolean {
+  const trigger = repoConfig.kanban?.triggerLabel
+  if (typeof trigger !== 'string' || trigger.length === 0) return false
+  if (!issueLabels) return false
+  return issueLabels.includes(trigger)
+}
+
+export function getDiscoveryIncludeLabels(
+  repoConfig: Pick<RepoConfig, 'selectors' | 'kanban'>,
+): string[] {
+  const include = new Set<string>(repoConfig.selectors?.includeLabelsAny ?? [])
+  if (repoConfig.kanban) {
+    for (const label of asLabelArray(repoConfig.kanban.labels.ready, [])) {
+      include.add(label)
+    }
   }
+  return [...include]
+}
+
+export function buildLabelConfig(
+  repoConfig: Pick<RepoConfig, 'labels' | 'kanban'>,
+  issueLabels?: readonly string[],
+): LabelConfig {
+  const source: LabelsSource = isKanbanIssue(issueLabels, repoConfig) && repoConfig.kanban
+    ? repoConfig.kanban.labels
+    : repoConfig.labels
+
+  return {
+    ready: asLabelArray(source.ready, ['orch:ready']),
+    running: asSingleLabel(source.running, 'orch:running'),
+    blocked: asSingleLabel(source.blocked, 'orch:blocked'),
+    needsHuman: asSingleLabel(source.needsHuman, 'orch:needs-human'),
+    reviewReady: asSingleLabel(source.reviewReady, 'orch:review-ready'),
+    error: asSingleLabel(source.error, 'orch:error'),
+    retry: asSingleLabel(source.retry, 'orch:retry'),
+    planning: asSingleLabel(source.planning, 'orch:planning'),
+    mergeQueued: asSingleLabel(source.mergeQueued, 'orch:merge-queued'),
+    merging: asSingleLabel(source.merging, 'orch:merging'),
+    mergeFailed: asSingleLabel(source.mergeFailed, 'orch:merge-failed'),
+  }
+}
+
+function asSingleLabel(value: string | readonly string[] | undefined, fallback: string): string {
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : fallback
+  }
+  if (Array.isArray(value)) {
+    const first = value.find((label): label is string => typeof label === 'string' && label.length > 0)
+    return first ?? fallback
+  }
+  return fallback
+}
+
+function asLabelArray(value: string | readonly string[] | undefined, fallback: string[]): string[] {
+  if (Array.isArray(value)) {
+    const labels = value.filter((label): label is string => typeof label === 'string' && label.length > 0)
+    return labels.length > 0 ? labels : fallback
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return [value]
+  }
+  return [...fallback]
 }

--- a/src/loop/types.ts
+++ b/src/loop/types.ts
@@ -28,6 +28,7 @@ export interface PhaseRecord {
 export interface RunContext {
   readonly runId: string
   readonly repo: string
+  readonly issueRepo?: string
   readonly issueNumber: number
   readonly issue: ForgeIssue
   readonly repoConfig: RepoConfig

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -6,7 +6,7 @@ import { CostTracker } from '../../loop/cost.js'
 import { SyncEngine } from '../../ops/sync.js'
 import { CleanupEngine } from '../../ops/cleanup.js'
 import { RetryEngine } from '../../ops/retry.js'
-import { filterEligible } from '../../discovery/selector.js'
+import { isIssueEligibleForRepo } from '../../discovery/discover.js'
 import { pollOnce } from '../../runner/poller.js'
 import { flushActiveAgentObservability } from '../../events/observability.js'
 import { createForgeAdapter } from '../../forge/factory.js'
@@ -386,10 +386,8 @@ async function handleListIssues(
     throw new Error(`Repo not found in config: ${args.repo}`)
   }
 
-  const issues: ForgeIssue[] = filterEligible(
-    await adapter.listEligibleIssues(repoConfig),
-    repoConfig.selectors,
-  )
+  const issues: ForgeIssue[] = (await adapter.listEligibleIssues(repoConfig))
+    .filter((issue) => isIssueEligibleForRepo(issue, repoConfig))
   const runManager = new RunManager(deps.db)
   const filter = args.filter ?? 'all'
 

--- a/src/ops/rebase-and-check.ts
+++ b/src/ops/rebase-and-check.ts
@@ -8,6 +8,7 @@ import { RunManager } from '../state/runs.js'
 import { transitionLabels } from '../labels/manager.js'
 import { buildLabelConfig } from '../labels/config.js'
 import { upsertBotComment, markerTag } from '../forge/bot-comment.js'
+import { resolveIssueRepo } from '../utils/issue-repo.js'
 import { logger } from '../utils/logger.js'
 
 const STATUS_MARKER = markerTag('status')
@@ -33,7 +34,6 @@ export async function queueRebase(
   botUser: string,
 ): Promise<{ queued: boolean; reason: string }> {
   const runManager = new RunManager(db)
-  const labelConfig = buildLabelConfig(repoConfig)
 
   // Find the latest run with a branch for this issue
   const run = runManager.getByRepoAndIssue(repoConfig.repo, issueNumber)
@@ -45,6 +45,8 @@ export async function queueRebase(
     return { queued: false, reason: `Run is already ${run.status}` }
   }
 
+  const issueRepo = resolveIssueRepo(run.phaseData, repoConfig.repo)
+
   // Store rebase context and transition to queued
   const existingPhaseData = run.phaseData ?? {}
   runManager.update(run.id, {
@@ -53,6 +55,7 @@ export async function queueRebase(
     endedAt: null,
     phaseData: {
       ...existingPhaseData,
+      issueRepo,
       reactionContext: 'Rebase requested. Rebase onto latest base branch, run verify, and fix any issues introduced by upstream changes.',
       reactionType: 'rebase',
       reactionSummary: 'Rebase and re-evaluate',
@@ -61,21 +64,21 @@ export async function queueRebase(
 
   // Transition labels
   try {
-    const issue = await forge.getIssue(repoConfig.repo, issueNumber)
+    const issue = await forge.getIssue(issueRepo, issueNumber)
     const fromState = run.status === 'review_ready' ? 'review_ready' : run.status === 'blocked' ? 'blocked' : 'error'
     await transitionLabels(
-      forge, repoConfig.repo, issueNumber, issue.labels,
-      fromState, 'queued', labelConfig,
+      forge, issueRepo, issueNumber, issue.labels,
+      fromState, 'queued', buildLabelConfig(repoConfig, issue.labels),
     )
   } catch (err) {
-    logger.warn({ repo: repoConfig.repo, issueNumber, err }, 'Failed to transition labels for rebase queue')
+    logger.warn({ repo: issueRepo, issueNumber, err }, 'Failed to transition labels for rebase queue')
   }
 
   // Post status comment
-  await commentStatus(forge, repoConfig.repo, issueNumber, botUser,
+  await commentStatus(forge, issueRepo, issueNumber, botUser,
     'Queued for rebase and re-evaluation. The branch will be rebased onto the latest base, verified, and if anything breaks the coder will fix it.')
 
-  logger.info({ repo: repoConfig.repo, issueNumber, runId: run.id }, 'Queued issue for rebase-and-re-evaluate')
+  logger.info({ repo: issueRepo, issueNumber, runId: run.id }, 'Queued issue for rebase-and-re-evaluate')
   return { queued: true, reason: 'Queued for rebase and re-evaluation on next poll cycle' }
 }
 

--- a/src/ops/retry.ts
+++ b/src/ops/retry.ts
@@ -7,6 +7,7 @@ import { transitionLabels } from '../labels/manager.js'
 import { LeaseManager } from '../state/leases.js'
 import { RunManager, type RunStatus } from '../state/runs.js'
 import { pollOnce } from '../runner/poller.js'
+import { resolveIssueRepo } from '../utils/issue-repo.js'
 import { logger } from '../utils/logger.js'
 
 export interface RetryOptions {
@@ -57,6 +58,7 @@ export class RetryEngine {
     }
 
     logger.info({ runId: run.id, repo, issue: issueNumber, status: run.status, opts }, 'Retrying run')
+    const issueRepo = resolveIssueRepo(run.phaseData, repo)
 
     if (opts.dryRun) {
       logger.info({ runId: run.id }, '[dry-run] Would reset run to queued')
@@ -84,20 +86,23 @@ export class RetryEngine {
 
     // Release any lease
     this.leaseManager.release(repo, issueNumber)
+    if (issueRepo !== repo) {
+      this.leaseManager.release(issueRepo, issueNumber)
+    }
 
     // Apply label mutations
-    await this.updateLabels(repo, issueNumber, run.status)
+    await this.updateLabels(repo, issueRepo, issueNumber, run.status)
 
     logger.info({ runId: run.id, repo, issue: issueNumber }, 'Run reset to queued for retry')
 
       // If --immediate, start processing right away
     if (opts.immediate) {
       logger.info({ runId: run.id }, 'Starting immediate retry')
-      await pollOnce(this.config, this.db, false, undefined, { repo, issueNumber })
+      await pollOnce(this.config, this.db, false, undefined, { repo: issueRepo, issueNumber })
     }
   }
 
-  private async updateLabels(repo: string, issueNumber: number, fromStatus: RunStatus): Promise<void> {
+  private async updateLabels(repo: string, issueRepo: string, issueNumber: number, fromStatus: RunStatus): Promise<void> {
     const repoConfig = this.config.repos.find((r) => r.repo === repo)
     if (!repoConfig) return
 
@@ -110,11 +115,11 @@ export class RetryEngine {
     }
 
     try {
-      const issue = await forge.getIssue(repo, issueNumber)
-      const labelConfig = buildLabelConfig(repoConfig)
-      await transitionLabels(forge, repo, issueNumber, issue.labels, fromStatus, 'queued', labelConfig)
+      const issue = await forge.getIssue(issueRepo, issueNumber)
+      const labelConfig = buildLabelConfig(repoConfig, issue.labels)
+      await transitionLabels(forge, issueRepo, issueNumber, issue.labels, fromStatus, 'queued', labelConfig)
     } catch (err) {
-      logger.warn({ repo, issue: issueNumber, err }, 'Failed to update labels during retry')
+      logger.warn({ repo: issueRepo, issue: issueNumber, err }, 'Failed to update labels during retry')
     }
   }
 }

--- a/src/ops/sync.ts
+++ b/src/ops/sync.ts
@@ -8,6 +8,7 @@ import { transitionLabels } from '../labels/manager.js'
 import { buildLabelConfig } from '../labels/config.js'
 import { computeLabelMutation } from '../labels/transitions.js'
 import { createWorktreeManager } from '../git/worktree.js'
+import { resolveIssueRepo } from '../utils/issue-repo.js'
 import { logger } from '../utils/logger.js'
 
 export interface SyncAction {
@@ -41,6 +42,7 @@ interface ActiveRunRow {
   pr_number: number | null
   branch_name: string | null
   worktree_path: string | null
+  phase_data: string | null
 }
 
 export class SyncEngine {
@@ -75,7 +77,9 @@ export class SyncEngine {
     for (const run of activeRuns) {
       if (run.status === 'running') {
         // Running runs require an active lease; if lease expired, reconcile.
-        const leased = this.leaseManager.isLeased(run.repo, run.issue_number)
+        const issueRepo = resolveIssueRepoFromRun(run)
+        const leased = this.leaseManager.isLeased(issueRepo, run.issue_number)
+          || (issueRepo !== run.repo && this.leaseManager.isLeased(run.repo, run.issue_number))
         if (!leased) {
           const action = await this.reconcileStaleRun(run, dryRun)
           if (action) {
@@ -195,16 +199,17 @@ export class SyncEngine {
 
   private async resolveIssueState(
     forge: ForgeAdapter,
-    run: Pick<ActiveRunRow, 'repo' | 'issue_number'>,
+    run: Pick<ActiveRunRow, 'repo' | 'issue_number' | 'phase_data'>,
   ): Promise<'open' | 'closed' | 'missing' | 'unknown'> {
+    const issueRepo = resolveIssueRepoFromRun(run)
     try {
-      const issue = await forge.getIssue(run.repo, run.issue_number)
+      const issue = await forge.getIssue(issueRepo, run.issue_number)
       return issue.state === 'closed' ? 'closed' : 'open'
     } catch (err) {
       if (isNotFoundError(err)) {
         return 'missing'
       }
-      logger.warn({ repo: run.repo, issue: run.issue_number, err }, 'Failed to check issue state')
+      logger.warn({ repo: issueRepo, issue: run.issue_number, err }, 'Failed to check issue state')
       return 'unknown'
     }
   }
@@ -261,7 +266,11 @@ export class SyncEngine {
         status: 'completed',
         endedAt: new Date().toISOString(),
       })
-      this.leaseManager.release(run.repo, run.issue_number)
+      const issueRepo = resolveIssueRepoFromRun(run)
+      this.leaseManager.release(issueRepo, run.issue_number)
+      if (issueRepo !== run.repo) {
+        this.leaseManager.release(run.repo, run.issue_number)
+      }
       this.updateLabels(forge, run, 'completed').catch((err) => {
         logger.debug({ repo: run.repo, issue: run.issue_number, err }, 'Label update failed while marking run completed')
       })
@@ -276,7 +285,11 @@ export class SyncEngine {
         status: 'completed',
         endedAt: new Date().toISOString(),
       })
-      this.leaseManager.release(run.repo, run.issue_number)
+      const issueRepo = resolveIssueRepoFromRun(run)
+      this.leaseManager.release(issueRepo, run.issue_number)
+      if (issueRepo !== run.repo) {
+        this.leaseManager.release(run.repo, run.issue_number)
+      }
       this.updateLabels(forge, run, 'completed').catch((err) => {
         logger.debug({ repo: run.repo, issue: run.issue_number, err }, 'Label update failed while marking run closed')
       })
@@ -290,7 +303,11 @@ export class SyncEngine {
       this.runManager.update(run.id, {
         status: 'review_ready',
       })
-      this.leaseManager.release(run.repo, run.issue_number)
+      const issueRepo = resolveIssueRepoFromRun(run)
+      this.leaseManager.release(issueRepo, run.issue_number)
+      if (issueRepo !== run.repo) {
+        this.leaseManager.release(run.repo, run.issue_number)
+      }
       this.updateLabels(forge, run, 'review_ready').catch((err) => {
         logger.debug({ repo: run.repo, issue: run.issue_number, err }, 'Label update failed while marking run review_ready')
       })
@@ -306,16 +323,20 @@ export class SyncEngine {
         currentPhase: null,
         lastError: reason,
       })
-      this.leaseManager.release(run.repo, run.issue_number)
+      const issueRepo = resolveIssueRepoFromRun(run)
+      this.leaseManager.release(issueRepo, run.issue_number)
+      if (issueRepo !== run.repo) {
+        this.leaseManager.release(run.repo, run.issue_number)
+      }
 
       // Transition labels back to queued (ready) so the poller picks it up
       const repoConfig = this.config.repos.find((r) => r.repo === run.repo)
       if (repoConfig) {
         try {
           const forge = this.forgeFactory(run.repo)
-          const issue = await forge.getIssue(run.repo, run.issue_number)
-          const labelConfig = buildLabelConfig(repoConfig)
-          await transitionLabels(forge, run.repo, run.issue_number, issue.labels, 'running', 'queued', labelConfig)
+          const issue = await forge.getIssue(issueRepo, run.issue_number)
+          const labelConfig = buildLabelConfig(repoConfig, issue.labels)
+          await transitionLabels(forge, issueRepo, run.issue_number, issue.labels, 'running', 'queued', labelConfig)
         } catch (err) {
           logger.warn({ repo: run.repo, issue: run.issue_number, err }, 'Failed to transition labels during stale run recovery')
         }
@@ -330,10 +351,11 @@ export class SyncEngine {
     if (!repoConfig) return
 
     try {
-      const issue = await forge.getIssue(run.repo, run.issue_number)
-      const labelConfig = buildLabelConfig(repoConfig)
+      const issueRepo = resolveIssueRepoFromRun(run)
+      const issue = await forge.getIssue(issueRepo, run.issue_number)
+      const labelConfig = buildLabelConfig(repoConfig, issue.labels)
       const fromStatus = this.toRunStatus(run.status) ?? 'running'
-      await transitionLabels(forge, run.repo, run.issue_number, issue.labels, fromStatus, targetStatus, labelConfig)
+      await transitionLabels(forge, issueRepo, run.issue_number, issue.labels, fromStatus, targetStatus, labelConfig)
     } catch (err) {
       logger.warn({ repo: run.repo, issue: run.issue_number, err }, 'Failed to update labels during sync')
     }
@@ -354,8 +376,9 @@ export class SyncEngine {
       }
 
       try {
-        const issue = await forge.getIssue(run.repo, run.issue_number)
-        const labelConfig = buildLabelConfig(repoConfig)
+        const issueRepo = resolveIssueRepoFromRun(run)
+        const issue = await forge.getIssue(issueRepo, run.issue_number)
+        const labelConfig = buildLabelConfig(repoConfig, issue.labels)
 
         const targetStatus = this.toRunStatus(run.status)
         if (!targetStatus) continue
@@ -370,10 +393,10 @@ export class SyncEngine {
           }
           if (!dryRun) {
             if (mutation.remove.length > 0) {
-              await forge.removeLabels(run.repo, run.issue_number, mutation.remove)
+              await forge.removeLabels(issueRepo, run.issue_number, mutation.remove)
             }
             if (mutation.add.length > 0) {
-              await forge.addLabels(run.repo, run.issue_number, mutation.add)
+              await forge.addLabels(issueRepo, run.issue_number, mutation.add)
             }
           }
           corrections.push(correction)
@@ -396,7 +419,7 @@ export class SyncEngine {
   private loadActiveRuns(): ActiveRunRow[] {
     return this.db
       .prepare(
-        `WITH canonical_active AS (
+         `WITH canonical_active AS (
            SELECT
              i.current_run_id AS id,
              i.repo,
@@ -404,8 +427,10 @@ export class SyncEngine {
              i.status,
              i.pr_number,
              i.branch_name,
-             i.worktree_path
+             i.worktree_path,
+             r.phase_data
            FROM issues i
+           LEFT JOIN runs r ON r.id = i.current_run_id
            WHERE i.status IN ('running', 'queued', 'blocked', 'review_ready', 'error')
              AND i.current_run_id IS NOT NULL
          ),
@@ -417,7 +442,8 @@ export class SyncEngine {
              r.status,
              r.pr_number,
              r.branch_name,
-             r.worktree_path
+             r.worktree_path,
+             r.phase_data
            FROM runs r
            WHERE r.status IN ('running', 'queued', 'blocked', 'review_ready', 'error')
              AND NOT EXISTS (
@@ -429,10 +455,10 @@ export class SyncEngine {
                  AND i.status = r.status
              )
          )
-         SELECT id, repo, issue_number, status, pr_number, branch_name, worktree_path
+         SELECT id, repo, issue_number, status, pr_number, branch_name, worktree_path, phase_data
          FROM canonical_active
          UNION ALL
-         SELECT id, repo, issue_number, status, pr_number, branch_name, worktree_path
+         SELECT id, repo, issue_number, status, pr_number, branch_name, worktree_path, phase_data
          FROM fallback_active`,
       )
       .all() as ActiveRunRow[]
@@ -472,4 +498,15 @@ function getHttpStatus(err: unknown): number | null {
 
 function isNotFoundError(err: unknown): boolean {
   return getHttpStatus(err) === 404
+}
+
+function resolveIssueRepoFromRun(run: Pick<ActiveRunRow, 'repo' | 'phase_data'>): string {
+  if (!run.phase_data) return run.repo
+  try {
+    const phaseData = JSON.parse(run.phase_data) as Record<string, unknown>
+    return resolveIssueRepo(phaseData, run.repo)
+  } catch {
+    // Ignore malformed phase data and fall back to run repo.
+  }
+  return run.repo
 }

--- a/src/publishing/publisher.ts
+++ b/src/publishing/publisher.ts
@@ -24,25 +24,27 @@ async function transitionToError(
   ctx: RunContext,
   errorMessage: string,
 ): Promise<void> {
+  const issueRepo = ctx.issueRepo ?? ctx.repo
+
   try {
-    const issue = await forge.getIssue(ctx.repo, ctx.issueNumber)
+    const issue = await forge.getIssue(issueRepo, ctx.issueNumber)
     await transitionLabels(
       forge,
-      ctx.repo,
+      issueRepo,
       ctx.issueNumber,
       issue.labels,
       'running',
       'error',
-      buildLabelConfig(ctx.repoConfig),
+      buildLabelConfig(ctx.repoConfig, issue.labels),
     )
   } catch (labelErr) {
-    logger.warn({ repo: ctx.repo, issue: ctx.issueNumber, err: labelErr }, 'Failed to transition labels to error during publish failure')
+    logger.warn({ repo: issueRepo, issue: ctx.issueNumber, err: labelErr }, 'Failed to transition labels to error during publish failure')
   }
 
   try {
-    await forge.commentOnIssue(ctx.repo, ctx.issueNumber, `Publishing failed: ${errorMessage}`)
+    await forge.commentOnIssue(issueRepo, ctx.issueNumber, `Publishing failed: ${errorMessage}`)
   } catch (commentErr) {
-    logger.warn({ repo: ctx.repo, issue: ctx.issueNumber, err: commentErr }, 'Failed to comment on issue during publish failure')
+    logger.warn({ repo: issueRepo, issue: ctx.issueNumber, err: commentErr }, 'Failed to comment on issue during publish failure')
   }
 }
 

--- a/src/reactions/handler.ts
+++ b/src/reactions/handler.ts
@@ -3,14 +3,16 @@ import type { ForgeAdapter } from '../forge/types.js'
 import type { RunManager } from '../state/runs.js'
 import type Database from 'better-sqlite3'
 import { transitionLabels } from '../labels/manager.js'
-import type { buildLabelConfig } from '../labels/config.js'
+import { buildLabelConfig } from '../labels/config.js'
+import type { RepoConfig } from '../config/schema.js'
+import { resolveIssueRepo } from '../utils/issue-repo.js'
 import { logger } from '../utils/logger.js'
 
 export interface ReactionHandlerDeps {
   db: Database.Database
   forge: ForgeAdapter
   runManager: RunManager
-  labelConfig: ReturnType<typeof buildLabelConfig>
+  repoConfig: Pick<RepoConfig, 'labels' | 'kanban'>
 }
 
 /**
@@ -24,7 +26,7 @@ export async function handleReaction(
   reaction: Reaction,
   deps: ReactionHandlerDeps,
 ): Promise<void> {
-  const { forge, runManager, labelConfig } = deps
+  const { forge, runManager, repoConfig } = deps
 
   logger.info(
     { repo: reaction.repo, prNumber: reaction.prNumber, issueNumber: reaction.issueNumber, type: reaction.type },
@@ -63,15 +65,16 @@ export async function handleReaction(
 
   // Transition labels back to ready so the poller picks it up
   try {
-    const issue = await forge.getIssue(reaction.repo, reaction.issueNumber)
+    const issueRepo = resolveIssueRepo(run.phaseData, reaction.repo)
+    const issue = await forge.getIssue(issueRepo, reaction.issueNumber)
     await transitionLabels(
       forge,
-      reaction.repo,
+      issueRepo,
       reaction.issueNumber,
       issue.labels,
       'review_ready',
       'queued',
-      labelConfig,
+      buildLabelConfig(repoConfig, issue.labels),
     )
   } catch (err) {
     logger.warn(

--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -41,6 +41,7 @@ import { decomposeIssue, shouldAttemptDecompose } from '../discovery/decomposer.
 import { executeParallelSubtasks } from '../loop/parallel.js'
 import { buildWorkerEnv } from '../workers/env.js'
 import { isPlanningIssue } from '../planning/mode.js'
+import { resolveIssueRepo } from '../utils/issue-repo.js'
 import {
   isCommandProcessed,
   markCommandProcessed,
@@ -100,7 +101,10 @@ export async function pollOnce(
     leaseManager.cleanExpired()
 
     const reposToProcess = targetIssue
-      ? config.repos.filter((repoConfig) => repoConfig.repo === targetIssue.repo)
+      ? config.repos.filter((repoConfig) => {
+          const issueRepos = new Set([repoConfig.repo, ...(repoConfig.linkedProjects ?? [])])
+          return issueRepos.has(targetIssue.repo)
+        })
       : config.repos
     const usedPortsInPass: number[] = []
 
@@ -122,12 +126,10 @@ export async function pollOnce(
             logger.debug({ repo: repoConfig.repo }, 'Could not resolve bot user for comment upserts')
           }
 
-          const labelConfig = buildLabelConfig(repoConfig)
-
           // --- Reaction scan: check review_ready PRs for CI failures or human reviews ---
           try {
             await scanAndHandleReactions({
-              db, forge, runManager, repoConfig, labelConfig, botUser,
+              db, forge, runManager, repoConfig, botUser,
             })
           } catch (err) {
             logger.warn({ repo: repoConfig.repo, err }, 'Reaction scan failed — continuing with issue discovery')
@@ -149,7 +151,6 @@ export async function pollOnce(
               runManager,
               leaseManager,
               repoConfig,
-              labelConfig,
               botUser,
             })
           } catch (err) {
@@ -158,7 +159,10 @@ export async function pollOnce(
 
           const discoveredAll = await discoverEligibleIssues(repoConfig, forge, leaseManager)
           const discovered = targetIssue
-            ? discoveredAll.filter((d) => d.issue.number === targetIssue.issueNumber)
+            ? discoveredAll.filter((d) => {
+                const issueRepo = d.issueRepo || d.issue.repo || repoConfig.repo
+                return d.issue.number === targetIssue.issueNumber && issueRepo === targetIssue.repo
+              })
             : prioritizeDiscoveredIssues(runManager, repoConfig.repo, discoveredAll)
           try { metrics?.setEligibleIssues(repoConfig.repo, discovered.length) } catch { /* best-effort */ }
 
@@ -185,19 +189,21 @@ export async function pollOnce(
                 if (!discoveredIssue) {
                   break
                 }
+                const issueRepo = discoveredIssue.issueRepo || discoveredIssue.issue.repo || repoConfig.repo
 
                 if (discoveredIssue.triage.level === 'architectural') {
-                  await forge.addLabels(repoConfig.repo, discoveredIssue.issue.number, ['orch:needs-human'])
+                  const labelConfig = buildLabelConfig(repoConfig, discoveredIssue.issue.labels)
+                  await forge.addLabels(issueRepo, discoveredIssue.issue.number, [labelConfig.needsHuman])
                   const archBody = formatStatusComment({ blockReason: 'This issue is classified as architectural and requires human guidance.' })
                   if (botUser) {
-                    await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, archBody, botUser)
+                    await upsertBotComment(forge, issueRepo, discoveredIssue.issue.number, STATUS_MARKER, archBody, botUser)
                   } else {
-                    await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.`)
+                    await forge.commentOnIssue(issueRepo, discoveredIssue.issue.number, `🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.`)
                   }
                   continue
                 }
 
-                if (!leaseManager.acquire(repoConfig.repo, discoveredIssue.issue.number, 'poller', 7200)) {
+                if (!leaseManager.acquire(issueRepo, discoveredIssue.issue.number, 'poller', 7200)) {
                   continue
                 }
 
@@ -236,6 +242,10 @@ export async function pollOnce(
                   branchName: branch,
                   branchSlug: slug,
                   worktreePath,
+                  phaseData: {
+                    ...(run.phaseData ?? {}),
+                    issueRepo,
+                  },
                   endedAt: null,
                   lastError: null,
                   blockReason: null,
@@ -244,12 +254,12 @@ export async function pollOnce(
                 // Label transition
                 await transitionLabels(
                   forge,
-                  repoConfig.repo,
+                  issueRepo,
                   discoveredIssue.issue.number,
                   discoveredIssue.issue.labels,
                   'queued',
                   'running',
-                  labelConfig,
+                  buildLabelConfig(repoConfig, discoveredIssue.issue.labels),
                 )
 
                 // Notify
@@ -286,7 +296,7 @@ export async function pollOnce(
                     worktreePath,
                     branch,
                     repoConfig.baseBranch,
-                    repoConfig.repo,
+                    issueRepo,
                     discoveredIssue.issue.number,
                     verifyCommands,
                   )
@@ -299,13 +309,21 @@ export async function pollOnce(
                       lastError: 'Rebase failed due to merge conflicts — retry will reset the branch and re-implement from scratch',
                       endedAt: new Date().toISOString(),
                     })
-                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
+                    const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                    await transitionLabels(
+                      forge,
+                      issueRepo,
+                      discoveredIssue.issue.number,
+                      latestIssue.labels,
+                      'running',
+                      'blocked',
+                      buildLabelConfig(repoConfig, latestIssue.labels),
+                    )
                     await notifier.dispatch(makePayload('blocked', repoConfig.repo, discoveredIssue.issue, {
                       summary: 'Rebase failed due to merge conflicts',
                       blockingReason: 'merge_conflict',
                     }))
-                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    leaseManager.release(issueRepo, discoveredIssue.issue.number)
                     repoErrors++
                     continue
                   }
@@ -318,12 +336,20 @@ export async function pollOnce(
                       endedAt: new Date().toISOString(),
                       lastError: null,
                     })
-                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
+                    const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                    await transitionLabels(
+                      forge,
+                      issueRepo,
+                      discoveredIssue.issue.number,
+                      latestIssue.labels,
+                      'running',
+                      'review_ready',
+                      buildLabelConfig(repoConfig, latestIssue.labels),
+                    )
                     await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
                       summary: 'Rebased successfully, verify passed',
                     }))
-                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    leaseManager.release(issueRepo, discoveredIssue.issue.number)
                     repoProcessed++
                     continue
                   }
@@ -336,9 +362,17 @@ export async function pollOnce(
                       endedAt: new Date().toISOString(),
                       lastError: null,
                     })
-                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
-                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                    await transitionLabels(
+                      forge,
+                      issueRepo,
+                      discoveredIssue.issue.number,
+                      latestIssue.labels,
+                      'running',
+                      'review_ready',
+                      buildLabelConfig(repoConfig, latestIssue.labels),
+                    )
+                    leaseManager.release(issueRepo, discoveredIssue.issue.number)
                     repoProcessed++
                     continue
                   }
@@ -377,6 +411,7 @@ export async function pollOnce(
                 const initialCtx: RunContext = {
                   runId: run.id,
                   repo: repoConfig.repo,
+                  issueRepo,
                   issueNumber: discoveredIssue.issue.number,
                   issue: discoveredIssue.issue,
                   repoConfig,
@@ -451,8 +486,16 @@ export async function pollOnce(
                     const allSucceeded = subResults.every((r) => r.success)
                     if (allSucceeded) {
                       runManager.update(run.id, { status: 'review_ready', endedAt: new Date().toISOString() })
-                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
+                      const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                      await transitionLabels(
+                        forge,
+                        issueRepo,
+                        discoveredIssue.issue.number,
+                        latestIssue.labels,
+                        'running',
+                        'review_ready',
+                        buildLabelConfig(repoConfig, latestIssue.labels),
+                      )
                       await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
                         summary: `Decomposed into ${decomposition.subtasks.length} sub-tasks, all completed`,
                       }))
@@ -464,8 +507,16 @@ export async function pollOnce(
                         lastError: `${failed}/${decomposition.subtasks.length} sub-tasks failed`,
                         endedAt: new Date().toISOString(),
                       })
-                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
+                      const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                      await transitionLabels(
+                        forge,
+                        issueRepo,
+                        discoveredIssue.issue.number,
+                        latestIssue.labels,
+                        'running',
+                        'blocked',
+                        buildLabelConfig(repoConfig, latestIssue.labels),
+                      )
                       repoErrors++
                     }
                     continue
@@ -487,7 +538,7 @@ export async function pollOnce(
                   metrics,
                   onAgentEvent: (event) => observability.record(event),
                   onPlanReady: async (ctx) => {
-                    await postPlanSummaryComment(forge, ctx.repo, ctx.issueNumber, ctx.plan, botUser)
+                    await postPlanSummaryComment(forge, ctx.issueRepo ?? ctx.repo, ctx.issueNumber, ctx.plan, botUser)
                   },
                 })
 
@@ -498,8 +549,9 @@ export async function pollOnce(
                   issue: discoveredIssue.issue,
                   runDurationSec,
                   repo: repoConfig.repo,
+                  repoConfig,
+                  issueRepo,
                   issueNumber: discoveredIssue.issue.number,
-                  labelConfig,
                   db,
                   forge,
                   runManager,
@@ -531,8 +583,16 @@ export async function pollOnce(
                         'Infra error — auto-retrying (transitioning back to ready)',
                       )
                       try {
-                        const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                        await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'queued', labelConfig)
+                        const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                        await transitionLabels(
+                          forge,
+                          issueRepo,
+                          discoveredIssue.issue.number,
+                          latestIssue.labels,
+                          'running',
+                          'queued',
+                          buildLabelConfig(repoConfig, latestIssue.labels),
+                        )
                       } catch (labelErr) {
                         logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels for auto-retry')
                       }
@@ -543,17 +603,25 @@ export async function pollOnce(
                         'Auto-retry limit reached — marking as error',
                       )
                       try {
-                        const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-                        await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'error', labelConfig)
+                        const latestIssue = await forge.getIssue(issueRepo, discoveredIssue.issue.number)
+                        await transitionLabels(
+                          forge,
+                          issueRepo,
+                          discoveredIssue.issue.number,
+                          latestIssue.labels,
+                          'running',
+                          'error',
+                          buildLabelConfig(repoConfig, latestIssue.labels),
+                        )
                         const errorBody = formatStatusComment({
                           error: `Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}`,
                           retryCount: recentErrors + 1,
                           maxRetries: maxRetries,
                         })
                         if (botUser) {
-                          await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, errorBody, botUser)
+                          await upsertBotComment(forge, issueRepo, discoveredIssue.issue.number, STATUS_MARKER, errorBody, botUser)
                         } else {
-                          await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}\n\nRemove \`orch:error\` and add \`orch:ready\` to retry.`)
+                          await forge.commentOnIssue(issueRepo, discoveredIssue.issue.number, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}\n\nRemove \`orch:error\` and add \`orch:ready\` to retry.`)
                         }
                       } catch (labelErr) {
                         logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels after retry exhaustion')
@@ -582,7 +650,7 @@ export async function pollOnce(
                       logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: envErr }, 'Failed to tear down environment')
                     }
                   }
-                  leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                  leaseManager.release(issueRepo, discoveredIssue.issue.number)
                 }
               }
             }),
@@ -617,8 +685,9 @@ interface FinalizeRunOutcomeParams {
   }
   runDurationSec: number
   repo: string
+  repoConfig: Config['repos'][0]
+  issueRepo: string
   issueNumber: number
-  labelConfig: ReturnType<typeof buildLabelConfig>
   db: Database.Database
   forge: ReturnType<typeof createForgeAdapter>
   runManager: RunManager
@@ -635,8 +704,9 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
     issue,
     runDurationSec,
     repo,
+    repoConfig,
+    issueRepo,
     issueNumber,
-    labelConfig,
     db,
     forge,
     runManager,
@@ -655,15 +725,15 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
         prTitle: publishResult.prTitle,
         endedAt: new Date().toISOString(),
       })
-      const latestIssue = await forge.getIssue(repo, issueNumber)
+      const latestIssue = await forge.getIssue(issueRepo, issueNumber)
       await transitionLabels(
         forge,
-        repo,
+        issueRepo,
         issueNumber,
         latestIssue.labels,
         'running',
         'review_ready',
-        labelConfig,
+        buildLabelConfig(repoConfig, latestIssue.labels),
       )
       const notifyResult = await notifier.dispatch(makePayload('pr_ready', repo, issue, {
         prUrl: publishResult.prUrl,
@@ -690,8 +760,16 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
           lastError: err.message,
           endedAt: new Date().toISOString(),
         })
-        const latestIssue = await forge.getIssue(repo, issueNumber)
-        await transitionLabels(forge, repo, issueNumber, latestIssue.labels, 'running', 'blocked', labelConfig)
+        const latestIssue = await forge.getIssue(issueRepo, issueNumber)
+        await transitionLabels(
+          forge,
+          issueRepo,
+          issueNumber,
+          latestIssue.labels,
+          'running',
+          'blocked',
+          buildLabelConfig(repoConfig, latestIssue.labels),
+        )
         try {
           metrics?.incRunsTotal('blocked')
           metrics?.observeRunDuration(runDurationSec)
@@ -701,12 +779,28 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
 
       runManager.update(runId, { status: 'error', lastError: String(err), endedAt: new Date().toISOString() })
       const recentErrors = new RunManager(db).countRecentErrors(repo, issueNumber)
-      const latestIssue = await forge.getIssue(repo, issueNumber)
+      const latestIssue = await forge.getIssue(issueRepo, issueNumber)
       if (recentErrors < maxAutoRetries) {
-        await transitionLabels(forge, repo, issueNumber, latestIssue.labels, 'running', 'queued', labelConfig)
+        await transitionLabels(
+          forge,
+          issueRepo,
+          issueNumber,
+          latestIssue.labels,
+          'running',
+          'queued',
+          buildLabelConfig(repoConfig, latestIssue.labels),
+        )
         logger.info({ repo, issueNumber, recentErrors }, 'Publish failed — auto-retrying')
       } else {
-        await transitionLabels(forge, repo, issueNumber, latestIssue.labels, 'running', 'error', labelConfig)
+        await transitionLabels(
+          forge,
+          issueRepo,
+          issueNumber,
+          latestIssue.labels,
+          'running',
+          'error',
+          buildLabelConfig(repoConfig, latestIssue.labels),
+        )
       }
       try {
         metrics?.incRunsTotal('error')
@@ -719,15 +813,15 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
   if (finalCtx.terminalStatus === 'blocked') {
     const blockReason = buildBlockReason(finalCtx)
     runManager.update(runId, { status: 'blocked', lastError: blockReason, blockReason: finalCtx.blockReason, endedAt: new Date().toISOString() })
-    const latestIssue = await forge.getIssue(repo, issueNumber)
+    const latestIssue = await forge.getIssue(issueRepo, issueNumber)
     await transitionLabels(
       forge,
-      repo,
+      issueRepo,
       issueNumber,
       latestIssue.labels,
       'running',
       'blocked',
-      labelConfig,
+      buildLabelConfig(repoConfig, latestIssue.labels),
     )
 
     // Upsert status comment with block reason
@@ -739,9 +833,9 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
         cost: finalCtx.estimatedCostUsd,
       })
       if (botUser) {
-        await upsertBotComment(forge, repo, issueNumber, STATUS_MARKER, statusBody, botUser)
+        await upsertBotComment(forge, issueRepo, issueNumber, STATUS_MARKER, statusBody, botUser)
       } else {
-        await forge.commentOnIssue(repo, issueNumber, formatBlockComment(blockReason, finalCtx))
+        await forge.commentOnIssue(issueRepo, issueNumber, formatBlockComment(blockReason, finalCtx))
       }
     } catch (commentErr) {
       logger.warn({ repo, issueNumber, err: commentErr }, 'Failed to post block reason comment')
@@ -765,18 +859,34 @@ async function finalizeRunOutcome(params: FinalizeRunOutcomeParams): Promise<'pr
   const unexpectedError = `Loop ended in unexpected state: ${finalCtx.terminalStatus}/${finalCtx.currentPhase}`
   runManager.update(runId, { status: 'error', lastError: unexpectedError, endedAt: new Date().toISOString() })
   const recentErrors = new RunManager(db).countRecentErrors(repo, issueNumber)
-  const latestIssue = await forge.getIssue(repo, issueNumber)
+  const latestIssue = await forge.getIssue(issueRepo, issueNumber)
   if (recentErrors < maxAutoRetries) {
-    await transitionLabels(forge, repo, issueNumber, latestIssue.labels, 'running', 'queued', labelConfig)
+    await transitionLabels(
+      forge,
+      issueRepo,
+      issueNumber,
+      latestIssue.labels,
+      'running',
+      'queued',
+      buildLabelConfig(repoConfig, latestIssue.labels),
+    )
     logger.info({ repo, issueNumber, recentErrors }, 'Unexpected state — auto-retrying')
   } else {
-    await transitionLabels(forge, repo, issueNumber, latestIssue.labels, 'running', 'error', labelConfig)
+    await transitionLabels(
+      forge,
+      issueRepo,
+      issueNumber,
+      latestIssue.labels,
+      'running',
+      'error',
+      buildLabelConfig(repoConfig, latestIssue.labels),
+    )
     try {
       const unexpectedBody = formatStatusComment({ error: `Failed after ${recentErrors + 1} attempts. Last error: ${unexpectedError}` })
       if (botUser) {
-        await upsertBotComment(forge, repo, issueNumber, STATUS_MARKER, unexpectedBody, botUser)
+        await upsertBotComment(forge, issueRepo, issueNumber, STATUS_MARKER, unexpectedBody, botUser)
       } else {
-        await forge.commentOnIssue(repo, issueNumber, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${unexpectedError}`)
+        await forge.commentOnIssue(issueRepo, issueNumber, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${unexpectedError}`)
       }
     } catch { /* best-effort */ }
   }
@@ -853,7 +963,6 @@ interface ProcessCommentCommandsParams {
   runManager: RunManager
   leaseManager: LeaseManager
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
   botUser: string
 }
 
@@ -876,42 +985,42 @@ async function processCommentCommands(params: ProcessCommentCommandsParams): Pro
     runManager,
     leaseManager,
     repoConfig,
-    labelConfig,
     botUser,
   } = params
 
   const commandSettings = config.commentCommands ?? { enabled: true, requireCollaborator: false }
   if (!commandSettings.enabled) return
 
-  const activeIssueNumbers = new Set(
-    runManager
-      .getActive()
-      .filter((run) => run.repo === repoConfig.repo)
-      .map((run) => run.issueNumber),
-  )
+  const activeRuns = runManager
+    .getActive()
+    .filter((run) => run.repo === repoConfig.repo)
 
-  const issueRows = [...activeIssueNumbers]
-    .sort((a, b) => a - b)
-    .map((issue_number) => ({ issue_number }))
+  const issueRows = [...new Map(
+    activeRuns.map((run) => {
+      const issueRepo = resolveIssueRepo(run.phaseData, repoConfig.repo)
+      return [`${issueRepo}#${run.issueNumber}`, { issue_number: run.issueNumber, issue_repo: issueRepo }] as const
+    }),
+  ).values()]
+    .sort((a, b) => a.issue_repo.localeCompare(b.issue_repo) || a.issue_number - b.issue_number)
 
   if (issueRows.length === 0) return
 
   const collaboratorCache = new Map<string, boolean>()
 
   for (const row of issueRows) {
-    const issueKey = `${repoConfig.repo}#${row.issue_number}`
+    const issueKey = `${row.issue_repo}#${row.issue_number}`
     if (missingCommentCommandIssues.has(issueKey)) {
       continue
     }
 
     let comments: Awaited<ReturnType<typeof forge.listIssueComments>>
     try {
-      comments = await forge.listIssueComments(repoConfig.repo, row.issue_number)
+      comments = await forge.listIssueComments(row.issue_repo, row.issue_number)
     } catch (err) {
       if (getHttpStatus(err) === 404) {
         missingCommentCommandIssues.add(issueKey)
         logger.debug(
-          { repo: repoConfig.repo, issueNumber: row.issue_number },
+          { repo: row.issue_repo, issueNumber: row.issue_number },
           'Skipping comment command scan for missing or inaccessible issue',
         )
         continue
@@ -921,13 +1030,13 @@ async function processCommentCommands(params: ProcessCommentCommandsParams): Pro
     const parsed = parseOrchCommands(comments, '1970-01-01T00:00:00Z')
 
     for (const item of parsed) {
-      if (isCommandProcessed(db, repoConfig.repo, row.issue_number, item.commentId)) continue
+      if (isCommandProcessed(db, row.issue_repo, row.issue_number, item.commentId)) continue
 
       let commandStatus = 'applied'
       try {
         const allowed = await canExecuteCommentCommand({
           forge,
-          repo: repoConfig.repo,
+          repo: row.issue_repo,
           user: item.user,
           requireCollaborator: commandSettings.requireCollaborator,
           cache: collaboratorCache,
@@ -949,7 +1058,7 @@ async function processCommentCommands(params: ProcessCommentCommandsParams): Pro
           runManager,
           leaseManager,
           repoConfig,
-          labelConfig,
+          issueRepo: row.issue_repo,
           issueNumber: row.issue_number,
           botUser,
           user: item.user,
@@ -976,7 +1085,7 @@ async function processCommentCommands(params: ProcessCommentCommandsParams): Pro
       } finally {
         markCommandProcessed(
           db,
-          repoConfig.repo,
+          row.issue_repo,
           row.issue_number,
           item.commentId,
           `${item.command.type}:${commandStatus}`,
@@ -1026,7 +1135,7 @@ interface ExecuteCommentCommandParams {
   runManager: RunManager
   leaseManager: LeaseManager
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
+  issueRepo: string
   issueNumber: number
   botUser: string
   user: string
@@ -1042,7 +1151,7 @@ async function executeCommentCommand(params: ExecuteCommentCommandParams): Promi
     runManager,
     leaseManager,
     repoConfig,
-    labelConfig,
+    issueRepo,
     issueNumber,
     botUser,
     user,
@@ -1055,7 +1164,7 @@ async function executeCommentCommand(params: ExecuteCommentCommandParams): Promi
         leaseManager,
         forge,
         repoConfig,
-        labelConfig,
+        issueRepo,
         issueNumber,
         resetPlan: command.resetPlan,
       })
@@ -1065,7 +1174,7 @@ async function executeCommentCommand(params: ExecuteCommentCommandParams): Promi
         leaseManager,
         forge,
         repoConfig,
-        labelConfig,
+        issueRepo,
         issueNumber,
       })
     case 'rebase': {
@@ -1079,7 +1188,7 @@ async function executeCommentCommand(params: ExecuteCommentCommandParams): Promi
         leaseManager,
         forge,
         repoConfig,
-        labelConfig,
+        issueRepo,
         issueNumber,
         user,
       })
@@ -1095,13 +1204,13 @@ interface QueueRetryFromCommentParams {
   leaseManager: LeaseManager
   forge: ReturnType<typeof createForgeAdapter>
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
+  issueRepo: string
   issueNumber: number
   resetPlan: boolean
 }
 
 async function queueRetryFromComment(params: QueueRetryFromCommentParams): Promise<CommandExecutionResult> {
-  const { runManager, leaseManager, forge, repoConfig, labelConfig, issueNumber, resetPlan } = params
+  const { runManager, leaseManager, forge, repoConfig, issueRepo, issueNumber, resetPlan } = params
   const run = runManager.getByRepoAndIssue(repoConfig.repo, issueNumber)
   if (!run) return { ok: false, reason: 'No run found for issue' }
   if (run.status === 'running') return { ok: false, reason: 'Run is currently running' }
@@ -1117,17 +1226,20 @@ async function queueRetryFromComment(params: QueueRetryFromCommentParams): Promi
     phaseData: resetPlan ? null : run.phaseData,
     blockReason: null,
   })
-  leaseManager.release(repoConfig.repo, issueNumber)
+  leaseManager.release(issueRepo, issueNumber)
+  if (issueRepo !== repoConfig.repo) {
+    leaseManager.release(repoConfig.repo, issueNumber)
+  }
 
-  const issue = await forge.getIssue(repoConfig.repo, issueNumber)
+  const issue = await forge.getIssue(issueRepo, issueNumber)
   await transitionLabels(
     forge,
-    repoConfig.repo,
+    issueRepo,
     issueNumber,
     issue.labels,
     run.status,
     'queued',
-    labelConfig,
+    buildLabelConfig(repoConfig, issue.labels),
   )
   return { ok: true }
 }
@@ -1137,12 +1249,12 @@ interface QueueContinueFromCommentParams {
   leaseManager: LeaseManager
   forge: ReturnType<typeof createForgeAdapter>
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
+  issueRepo: string
   issueNumber: number
 }
 
 async function queueContinueFromComment(params: QueueContinueFromCommentParams): Promise<CommandExecutionResult> {
-  const { runManager, leaseManager, forge, repoConfig, labelConfig, issueNumber } = params
+  const { runManager, leaseManager, forge, repoConfig, issueRepo, issueNumber } = params
   const run = runManager.getByRepoAndIssue(repoConfig.repo, issueNumber)
   if (!run) return { ok: false, reason: 'No run found for issue' }
   if (run.status !== 'blocked') {
@@ -1156,17 +1268,20 @@ async function queueContinueFromComment(params: QueueContinueFromCommentParams):
     lastError: null,
     blockReason: null,
   })
-  leaseManager.release(repoConfig.repo, issueNumber)
+  leaseManager.release(issueRepo, issueNumber)
+  if (issueRepo !== repoConfig.repo) {
+    leaseManager.release(repoConfig.repo, issueNumber)
+  }
 
-  const issue = await forge.getIssue(repoConfig.repo, issueNumber)
+  const issue = await forge.getIssue(issueRepo, issueNumber)
   await transitionLabels(
     forge,
-    repoConfig.repo,
+    issueRepo,
     issueNumber,
     issue.labels,
     'blocked',
     'queued',
-    labelConfig,
+    buildLabelConfig(repoConfig, issue.labels),
   )
   return { ok: true }
 }
@@ -1176,13 +1291,13 @@ interface CancelRunFromCommentParams {
   leaseManager: LeaseManager
   forge: ReturnType<typeof createForgeAdapter>
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
+  issueRepo: string
   issueNumber: number
   user: string
 }
 
 async function cancelRunFromComment(params: CancelRunFromCommentParams): Promise<CommandExecutionResult> {
-  const { runManager, leaseManager, forge, repoConfig, labelConfig, issueNumber, user } = params
+  const { runManager, leaseManager, forge, repoConfig, issueRepo, issueNumber, user } = params
   const run = runManager.getByRepoAndIssue(repoConfig.repo, issueNumber)
   if (!run) return { ok: false, reason: 'No run found for issue' }
   if (run.status !== 'running' && run.status !== 'queued') {
@@ -1195,17 +1310,20 @@ async function cancelRunFromComment(params: CancelRunFromCommentParams): Promise
     lastError: `Cancelled by @${user} via comment command`,
     blockReason: null,
   })
-  leaseManager.release(repoConfig.repo, issueNumber)
+  leaseManager.release(issueRepo, issueNumber)
+  if (issueRepo !== repoConfig.repo) {
+    leaseManager.release(repoConfig.repo, issueNumber)
+  }
 
-  const issue = await forge.getIssue(repoConfig.repo, issueNumber)
+  const issue = await forge.getIssue(issueRepo, issueNumber)
   await transitionLabels(
     forge,
-    repoConfig.repo,
+    issueRepo,
     issueNumber,
     issue.labels,
     run.status,
     'blocked',
-    labelConfig,
+    buildLabelConfig(repoConfig, issue.labels),
   )
   return { ok: true }
 }
@@ -1228,12 +1346,11 @@ interface ScanAndHandleReactionsParams {
   forge: ReturnType<typeof createForgeAdapter>
   runManager: RunManager
   repoConfig: Config['repos'][0]
-  labelConfig: ReturnType<typeof buildLabelConfig>
   botUser: string
 }
 
 async function scanAndHandleReactions(params: ScanAndHandleReactionsParams): Promise<void> {
-  const { db, forge, runManager, repoConfig, labelConfig, botUser } = params
+  const { db, forge, runManager, repoConfig, botUser } = params
 
   // Find review_ready issues with PRs for this repo.
   const rows = runManager
@@ -1265,7 +1382,7 @@ async function scanAndHandleReactions(params: ScanAndHandleReactionsParams): Pro
     // Handle each reaction
     for (const reaction of result.reactions) {
       try {
-        await handleReaction(reaction, { db, forge, runManager, labelConfig })
+        await handleReaction(reaction, { db, forge, runManager, repoConfig })
       } catch (err) {
         logger.warn(
           { repo: row.repo, issueNumber: row.issue_number, reactionType: reaction.type, err },

--- a/src/utils/issue-repo.ts
+++ b/src/utils/issue-repo.ts
@@ -1,0 +1,9 @@
+export function resolveIssueRepo(
+  phaseData: Record<string, unknown> | null | undefined,
+  fallbackRepo: string,
+): string {
+  const issueRepo = phaseData?.['issueRepo']
+  return typeof issueRepo === 'string' && issueRepo.length > 0
+    ? issueRepo
+    : fallbackRepo
+}

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -189,4 +189,40 @@ describe('ConfigSchema', () => {
     const result = ConfigSchema.safeParse(raw)
     expect(result.success).toBe(false)
   })
+
+  it('accepts linkedProjects and kanban label flow config', () => {
+    const raw = loadExampleConfig()
+    raw.repos[0].linkedProjects = ['org/tracker', 'org/platform-triage']
+    raw.repos[0].kanban = {
+      triggerLabel: 'flow:kanban',
+      labels: {
+        ready: ['kanban:todo'],
+        running: 'kanban:doing',
+        blocked: 'kanban:blocked',
+        needsHuman: 'kanban:needs-human',
+        reviewReady: 'kanban:review',
+        error: 'kanban:error',
+        retry: 'kanban:retry',
+        planning: 'kanban:planning',
+        mergeQueued: 'kanban:merge-queued',
+        merging: 'kanban:merging',
+        mergeFailed: 'kanban:merge-failed',
+      },
+    }
+
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.repos[0]?.linkedProjects).toEqual(['org/tracker', 'org/platform-triage'])
+      expect(result.data.repos[0]?.kanban?.triggerLabel).toBe('flow:kanban')
+      expect(result.data.repos[0]?.kanban?.labels.ready).toEqual(['kanban:todo'])
+    }
+  })
+
+  it('rejects invalid linkedProjects format', () => {
+    const raw = loadExampleConfig()
+    raw.repos[0].linkedProjects = ['invalid-project-slug']
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(false)
+  })
 })

--- a/test/discovery/discover.test.ts
+++ b/test/discovery/discover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { discoverEligibleIssues, type DiscoveredIssue } from '../../src/discovery/discover.js'
+import { discoverEligibleIssues, isIssueEligibleForRepo, type DiscoveredIssue } from '../../src/discovery/discover.js'
 import type { ForgeAdapter, ForgeIssue } from '../../src/forge/types.js'
 import type { LeaseManager } from '../../src/state/leases.js'
 import type { RepoConfig } from '../../src/config/schema.js'
@@ -24,6 +24,7 @@ function makeIssue(overrides: Partial<ForgeIssue> = {}): ForgeIssue {
   return {
     number: 1,
     nodeId: 'MDU6SXNzdWUx',
+    repo: 'org/repo',
     title: 'Test issue',
     body: 'Fix the thing',
     labels: ['orch:ready'],
@@ -47,9 +48,14 @@ function makeRepoConfig(overrides: Partial<RepoConfig> = {}): RepoConfig {
       ready: ['orch:ready'],
       running: 'orch:running',
       blocked: ['orch:blocked', 'orch:needs-human'],
+      needsHuman: 'orch:needs-human',
       reviewReady: 'orch:review-ready',
       error: 'orch:error',
       retry: 'orch:retry',
+      planning: 'orch:planning',
+      mergeQueued: 'orch:merge-queued',
+      merging: 'orch:merging',
+      mergeFailed: 'orch:merge-failed',
     },
     defaults: {
       planner: 'claude',
@@ -65,6 +71,7 @@ function makeRepoConfig(overrides: Partial<RepoConfig> = {}): RepoConfig {
       excludeLabelsAny: ['orch:blocked'],
     },
     agents: {},
+    linkedProjects: [],
     ...overrides,
   } as RepoConfig
 }
@@ -201,6 +208,53 @@ describe('discoverEligibleIssues', () => {
 
     expect(leaseManager.isLeased).toHaveBeenCalledWith('org/repo', 1)
     expect(leaseManager.isLeased).toHaveBeenCalledWith('org/repo', 2)
+  })
+
+  it('uses issue.repo when checking leases and storing issueRepo', async () => {
+    const issue = makeIssue({
+      number: 7,
+      repo: 'org/tracker',
+      url: 'https://github.com/org/tracker/issues/7',
+      labels: ['orch:ready'],
+    })
+    const forge = makeMockForge([issue])
+    const leaseManager = makeMockLeaseManager()
+
+    const result = await discoverEligibleIssues(makeRepoConfig(), forge, leaseManager)
+
+    expect(leaseManager.isLeased).toHaveBeenCalledWith('org/tracker', 7)
+    expect(result[0]?.issueRepo).toBe('org/tracker')
+  })
+
+  it('applies kanban selectors when trigger label is present', () => {
+    const repoConfig = makeRepoConfig({
+      selectors: {
+        includeLabelsAny: ['orch:ready'],
+        excludeLabelsAny: ['orch:blocked'],
+      },
+      kanban: {
+        triggerLabel: 'flow:kanban',
+        labels: {
+          ready: ['kanban:todo'],
+          running: 'kanban:doing',
+          blocked: 'kanban:blocked',
+          needsHuman: 'kanban:needs-human',
+          reviewReady: 'kanban:review',
+          error: 'kanban:error',
+          retry: 'kanban:retry',
+          planning: 'kanban:planning',
+          mergeQueued: 'kanban:merge-queued',
+          merging: 'kanban:merging',
+          mergeFailed: 'kanban:merge-failed',
+        },
+      },
+    })
+
+    const kanbanEligible = makeIssue({ labels: ['flow:kanban', 'kanban:todo'] })
+    const nonKanbanReady = makeIssue({ labels: ['flow:kanban', 'orch:ready'] })
+
+    expect(isIssueEligibleForRepo(kanbanEligible, repoConfig)).toBe(true)
+    expect(isIssueEligibleForRepo(nonKanbanReady, repoConfig)).toBe(false)
   })
 
   it('handles all issues being leased', async () => {

--- a/test/forge/forgejo.test.ts
+++ b/test/forge/forgejo.test.ts
@@ -111,6 +111,7 @@ describe('ForgejoForgeAdapter', () => {
       expect(issue).toEqual({
         number: 1,
         nodeId: null,
+        repo: 'org/repo',
         title: 'Test issue',
         body: 'Test body',
         labels: ['orch:ready'],
@@ -196,6 +197,26 @@ describe('ForgejoForgeAdapter', () => {
       expect(issues).toHaveLength(1)
       const calledUrl = mockFetch.mock.calls[0]![0] as string
       expect(calledUrl).toContain('/repos/org/repo/issues')
+    })
+
+    it('discovers issues from linkedProjects', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse([makeForgejoIssue({ number: 1, html_url: 'https://forgejo.example.com/org/repo/issues/1' })]))
+        .mockResolvedValueOnce(jsonResponse([makeForgejoIssue({ number: 2, html_url: 'https://forgejo.example.com/org/tracker/issues/2' })]))
+
+      const config = makeRepoConfig({
+        linkedProjects: ['org/tracker'],
+        selectors: {
+          includeLabelsAny: [],
+          excludeLabelsAny: [],
+        },
+      })
+
+      const issues = await adapter.listEligibleIssues(config)
+      expect(issues).toHaveLength(2)
+      expect(issues.map((i) => i.repo)).toEqual(['org/repo', 'org/tracker'])
+      const secondCalledUrl = mockFetch.mock.calls[1]![0] as string
+      expect(secondCalledUrl).toContain('/repos/org/tracker/issues')
     })
   })
 

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -154,6 +154,7 @@ describe('GitHubForgeAdapter', () => {
       expect(issue).toEqual({
         number: 1,
         nodeId: 'MDU6SXNzdWUx',
+        repo: 'org/repo',
         title: 'Test issue',
         body: 'Test body',
         labels: ['bug'],
@@ -255,6 +256,32 @@ describe('GitHubForgeAdapter', () => {
           repo: 'repo',
           state: 'open',
           per_page: 100,
+        }),
+      )
+    })
+
+    it('discovers issues from linkedProjects', async () => {
+      mockPaginate
+        .mockResolvedValueOnce([makeGitHubIssue({ number: 1, html_url: 'https://github.com/org/repo/issues/1' })])
+        .mockResolvedValueOnce([makeGitHubIssue({ number: 2, html_url: 'https://github.com/org/tracker/issues/2' })])
+
+      const config = makeRepoConfig({
+        linkedProjects: ['org/tracker'],
+        selectors: {
+          includeLabelsAny: [],
+          excludeLabelsAny: [],
+        },
+      })
+
+      const issues = await adapter.listEligibleIssues(config)
+      expect(issues).toHaveLength(2)
+      expect(issues.map((i) => i.repo)).toEqual(['org/repo', 'org/tracker'])
+      expect(mockPaginate).toHaveBeenNthCalledWith(
+        2,
+        mockIssuesListForRepo,
+        expect.objectContaining({
+          owner: 'org',
+          repo: 'tracker',
         }),
       )
     })

--- a/test/labels/bootstrap.test.ts
+++ b/test/labels/bootstrap.test.ts
@@ -12,6 +12,9 @@ describe('buildLabelBootstrapDefinitions', () => {
         error: 'orch:error',
         retry: 'orch:retry',
         planning: 'orch:planning',
+        mergeQueued: 'orch:merge-queued',
+        merging: 'orch:merging',
+        mergeFailed: 'orch:merge-failed',
       },
       labelConfig: {},
     })
@@ -25,6 +28,9 @@ describe('buildLabelBootstrapDefinitions', () => {
       'orch:error',
       'orch:retry',
       'orch:planning',
+      'orch:merge-queued',
+      'orch:merging',
+      'orch:merge-failed',
     ])
     expect(result.find((l) => l.name === 'orch:ready')).toEqual({
       name: 'orch:ready',
@@ -43,6 +49,9 @@ describe('buildLabelBootstrapDefinitions', () => {
         error: 'team:error',
         retry: 'team:retry',
         planning: 'team:planning',
+        mergeQueued: 'team:merge-queued',
+        merging: 'team:merging',
+        mergeFailed: 'team:merge-failed',
       },
       labelConfig: {
         'team:triage': { color: 'abcdef', description: 'Ready in team workflow' },
@@ -72,11 +81,64 @@ describe('buildLabelBootstrapDefinitions', () => {
         error: 'orch:shared',
         retry: 'orch:shared',
         planning: 'orch:shared',
+        mergeQueued: 'orch:shared',
+        merging: 'orch:shared',
+        mergeFailed: 'orch:shared',
       },
       labelConfig: {},
     })
 
     expect(result).toHaveLength(1)
     expect(result[0]?.name).toBe('orch:shared')
+  })
+
+  it('includes kanban trigger and kanban state labels when configured', () => {
+    const result = buildLabelBootstrapDefinitions({
+      labels: {
+        ready: ['orch:ready'],
+        running: 'orch:running',
+        blocked: ['orch:blocked'],
+        needsHuman: 'orch:needs-human',
+        reviewReady: 'orch:review-ready',
+        error: 'orch:error',
+        retry: 'orch:retry',
+        planning: 'orch:planning',
+        mergeQueued: 'orch:merge-queued',
+        merging: 'orch:merging',
+        mergeFailed: 'orch:merge-failed',
+      },
+      kanban: {
+        triggerLabel: 'flow:kanban',
+        labels: {
+          ready: ['kanban:todo'],
+          running: 'kanban:doing',
+          blocked: 'kanban:blocked',
+          needsHuman: 'kanban:needs-human',
+          reviewReady: 'kanban:review',
+          error: 'kanban:error',
+          retry: 'kanban:retry',
+          planning: 'kanban:planning',
+          mergeQueued: 'kanban:merge-queued',
+          merging: 'kanban:merging',
+          mergeFailed: 'kanban:merge-failed',
+        },
+      },
+      labelConfig: {},
+    })
+
+    expect(result.map((l) => l.name)).toEqual(expect.arrayContaining([
+      'flow:kanban',
+      'kanban:todo',
+      'kanban:doing',
+      'kanban:blocked',
+      'kanban:needs-human',
+      'kanban:review',
+      'kanban:error',
+      'kanban:retry',
+      'kanban:planning',
+      'kanban:merge-queued',
+      'kanban:merging',
+      'kanban:merge-failed',
+    ]))
   })
 })

--- a/test/labels/config.test.ts
+++ b/test/labels/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { buildLabelConfig, getDiscoveryIncludeLabels, isKanbanIssue } from '../../src/labels/config.js'
+
+describe('label flow config', () => {
+  const repoConfig = {
+    labels: {
+      ready: ['orch:ready'],
+      running: 'orch:running',
+      blocked: 'orch:blocked',
+      needsHuman: 'orch:needs-human',
+      reviewReady: 'orch:review-ready',
+      error: 'orch:error',
+      retry: 'orch:retry',
+      planning: 'orch:planning',
+      mergeQueued: 'orch:merge-queued',
+      merging: 'orch:merging',
+      mergeFailed: 'orch:merge-failed',
+    },
+    selectors: {
+      includeLabelsAny: ['orch:ready'],
+      excludeLabelsAny: [],
+    },
+    kanban: {
+      triggerLabel: 'flow:kanban',
+      labels: {
+        ready: ['kanban:todo'],
+        running: 'kanban:doing',
+        blocked: 'kanban:blocked',
+        needsHuman: 'kanban:needs-human',
+        reviewReady: 'kanban:review',
+        error: 'kanban:error',
+        retry: 'kanban:retry',
+        planning: 'kanban:planning',
+        mergeQueued: 'kanban:merge-queued',
+        merging: 'kanban:merging',
+        mergeFailed: 'kanban:merge-failed',
+      },
+    },
+  }
+
+  it('uses default labels when kanban trigger is absent', () => {
+    const result = buildLabelConfig(repoConfig, ['orch:ready'])
+    expect(result.running).toBe('orch:running')
+    expect(result.ready).toEqual(['orch:ready'])
+  })
+
+  it('uses kanban labels when trigger label is present', () => {
+    const result = buildLabelConfig(repoConfig, ['flow:kanban', 'kanban:todo'])
+    expect(result.running).toBe('kanban:doing')
+    expect(result.ready).toEqual(['kanban:todo'])
+  })
+
+  it('adds kanban ready labels to discovery include labels', () => {
+    const result = getDiscoveryIncludeLabels(repoConfig)
+    expect(result).toEqual(['orch:ready', 'kanban:todo'])
+  })
+
+  it('detects kanban trigger label', () => {
+    expect(isKanbanIssue(['flow:kanban'], repoConfig)).toBe(true)
+    expect(isKanbanIssue(['orch:ready'], repoConfig)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #13

## Plan
**Objective:** Enable issues from linked projects with configurable kanban-style label flow, re-applying prior work against the significantly refactored codebase

1. Add linkedProjects and kanban schema to RepoConfigSchema. Add LinkedProjectSchema (owner/name regex) and KanbanSchema (triggerLabel + LabelsSchema) Zod schemas. Add linkedProjects: z.array(LinkedProjectSchema).default([]) and kanban: KanbanSchema.optional() to RepoConfigSchema.
2. Extend buildLabelConfig() to accept optional issueLabels parameter and select kanban labels when trigger label is present. Add isKanbanIssue() and getDiscoveryIncludeLabels() helper functions. The function signature changes from (repoConfig: Pick<RepoConfig, 'labels'>) to (repoConfig: Pick<RepoConfig, 'labels' | 'kanban'>, issueLabels?: readonly string[]). Add normalizeString/normalizeStringArray helpers for safely extracting label values from the kanban or default label sources.
3. Update label bootstrap to include kanban trigger label and all kanban state labels when kanban config is present. Add 'kanbanTrigger' to LabelRole union.
4. Add issueRepo field to DiscoveredIssue interface. Replace filterEligible() call with per-issue isIssueEligibleForRepo() that uses kanban-aware selectors. Add resolveIssueRepo() to extract owner/repo from issue URL (supporting path-prefixed URLs like /git/org/repo/issues/1). Add buildSelectorForIssue() that returns kanban selectors when trigger label present. Update lease checks to use issueRepo. Export isIssueEligibleForRepo for use by MCP tools.
5. Update GitHub adapter's listEligibleIssues() to iterate over discoveryRepos = [repoConfig.repo, ...linkedProjects]. Use getDiscoveryIncludeLabels() to merge kanban ready labels into include list. Change deduplication key from issue number to repo#number composite key.
6. Apply same changes as step 5 to Forgejo adapter's listEligibleIssues().
7. Add issueRepo?: string to RunContext interface in loop/types.ts.
8. Update the poller (1328 lines) to thread issueRepo through all forge API calls. This is the largest and most conflict-prone change. Key changes: (1) In repo filtering, expand targetIssue check to include linkedProjects; (2) Compute issueRepo = discoveredIssue.issueRepo ?? repoConfig.repo early in each issue processing path; (3) Replace repoConfig.repo with issueRepo for all forge.getIssue(), forge.addLabels(), forge.commentOnIssue(), upsertBotComment(), transitionLabels(), notifier.dispatch(), leaseManager.acquire/release() calls; (4) Pass buildLabelConfig(repoConfig, issue.labels) instead of pre-computed labelConfig where issue labels are available; (5) Add issueRepo to RunContext initialization; (6) Update all extracted helper functions (processIssue, handleArchitecturalIssue, handleRebaseRun, finalizeRunOutcome, handleRetryOrError, scanAndHandleReactions) to accept and thread issueRepo; (7) Update FinalizeRunOutcomeParams and similar interfaces to include issueRepo.
9. Update reactions handler to accept repoConfig instead of labelConfig, and call buildLabelConfig(repoConfig, issue.labels) inline.
10. Update publisher's transitionToError() to use ctx.issueRepo ?? ctx.repo for forge calls and pass issue labels to buildLabelConfig().
11. Update all buildLabelConfig() calls in retry.ts, sync.ts, and rebase-and-check.ts to pass issue.labels as second parameter.
12. Update MCP tools list-issues handler to use isIssueEligibleForRepo() instead of filterEligible().
13. Add tests: (1) schema.test.ts — linkedProjects + kanban acceptance, invalid format rejection; (2) discover.test.ts — issueRepo from URL, prefixed URLs, kanban selector logic; (3) github.test.ts and forgejo.test.ts — linkedProjects fetching with composite dedup keys; (4) config.test.ts (new) — buildLabelConfig default vs kanban, getDiscoveryIncludeLabels; (5) bootstrap.test.ts — kanban labels in bootstrap definitions.
14. Update CONFIGURATION.md with linkedProjects and kanban sections. Update config.example.yaml with commented-out examples.
15. Run pnpm typecheck && pnpm lint && pnpm test to verify everything passes.

## Implementation
Implemented linked-project issue discovery and configurable kanban label flow across schema, discovery, forge adapters, poller/runtime operations, and docs. Added cross-repo issue provenance (`issueRepo`) handling (including lease keys and label transitions), centralized phase-data repo resolution via shared utility, replaced fragile/untyped label-config extraction with typed kanban/default selection logic, and updated MCP issue listing eligibility checks. Addressed all review findings and added/updated tests for kanban bootstrap/config/discovery and linked-project adapter behavior.

**Changed files:**
- `docs/CONFIGURATION.md`
- `examples/config.example.yaml`
- `src/config/schema.ts`
- `src/discovery/discover.ts`
- `src/forge/forgejo.ts`
- `src/forge/github.ts`
- `src/forge/types.ts`
- `src/labels/bootstrap.ts`
- `src/labels/config.ts`
- `src/loop/types.ts`
- `src/mcp/tools/index.ts`
- `src/ops/rebase-and-check.ts`
- `src/ops/retry.ts`
- `src/ops/sync.ts`
- `src/publishing/publisher.ts`
- `src/reactions/handler.ts`
- `src/runner/poller.ts`
- `src/utils/issue-repo.ts`
- `test/config/schema.test.ts`
- `test/discovery/discover.test.ts`
- `test/forge/forgejo.test.ts`
- `test/forge/github.test.ts`
- `test/labels/bootstrap.test.ts`
- `test/labels/config.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
All five prior review findings have been addressed. The shared resolveIssueRepo utility is extracted, buildLabelConfig uses typed access, lease acquisition uses issueRepo, and kanban bootstrap has test coverage. The implementation is clean and well-structured with comprehensive test coverage across schema, config, discovery, forge adapters, and label bootstrap.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=claude