### PR TITLE
[night-orch] #3 Parallel runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See `docs/specs-active/index.md` for the full implementation spec with dependenc
 
 - **GitHub issues are the queue** — no separate UI
 - **Always PR** — never push directly to base branch
-- **Serial processing** in v1 — one issue at a time
+- **Per-repo concurrency** — repos run in parallel; each repo defaults to one active run
 - **Orchestrator owns verification** — never trust agent claims that tests pass
 - **Forge abstraction** — GitHub first, Forgejo second via `ForgeAdapter` interface
 - **Review gates readiness** — PR only marked ready when reviewer approves AND verify passes

--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,7 @@ repos:
   - repo: shllg/night-orch
     forge: github
     localPath: ~/src/tools/ai-project-runner
+    maxConcurrentRuns: 1
     baseBranch: master
     branchPrefix: orch
     labels:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -286,6 +286,7 @@ Reference a workflow in `repos[].workflow` by name.
 | `forge` | `github` or `forgejo` | no | `github` | Forge implementation selector. |
 | `apiBaseUrl` | URL string | no | none | Required for `forgejo`; optional override for `github`. |
 | `tokenEnv` | string | no | none | Token env override per repo. |
+| `maxConcurrentRuns` | int 1-20 | no | `1` | Max issues processed concurrently for this repo per poll cycle. |
 | `localPath` | string path | yes | none | Local repo checkout path. |
 | `baseBranch` | string | no | `main` | PR target branch. |
 | `branchPrefix` | string | no | `orch` | Work branch prefix. |
@@ -300,6 +301,10 @@ Reference a workflow in `repos[].workflow` by name.
 | `agents` | record | no | `{}` | Maps agent names to worker profile names. |
 | `workflow` | string | no | none | Name of a workflow from `workflows` section. Uses default pipeline if omitted. |
 | `mergeQueue` | object | no | object with defaults | Merge queue configuration. |
+
+Poll execution model:
+- Repos are polled in parallel.
+- Each repo runs up to `maxConcurrentRuns` issues at once (default `1`).
 
 ### `repos[].labels`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -76,17 +76,19 @@ Night-orch handles multiple repos in a single instance:
 repos:
   - repo: myorg/frontend
     localPath: ~/code/frontend
+    maxConcurrentRuns: 1
     baseBranch: main
     verify: [pnpm lint, pnpm test]
 
   - repo: myorg/backend
     localPath: ~/code/backend
+    maxConcurrentRuns: 2  # optional: increase per-repo parallel issue runs
     baseBranch: main
     verify: [cargo test, cargo clippy]
     workflow: minimal  # different pipeline for this repo
 ```
 
-Each repo can have its own worker profiles, verify commands, workflow, merge queue settings, and labels.
+Repos are polled in parallel. By default, each repo runs one issue at a time; raise `maxConcurrentRuns` to process multiple issues concurrently in that repo.
 
 ---
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -114,6 +114,7 @@ repos:
   - repo: myorg/myrepo
     forge: github
     localPath: ~/code/myrepo
+    maxConcurrentRuns: 1
     baseBranch: main
     branchPrefix: orch
     labels:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -197,6 +197,7 @@ const RepoConfigSchema = z.object({
   forge: z.enum(['github', 'forgejo']).default('github'),
   apiBaseUrl: z.string().url().optional(),
   tokenEnv: z.string().optional(),
+  maxConcurrentRuns: z.number().int().min(1).max(20).default(1),
   localPath: z.string(),
   baseBranch: z.string().default('main'),
   branchPrefix: z.string().default('orch'),

--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -62,7 +62,8 @@ export interface PollTargetIssue {
 
 /**
  * Process one poll cycle: discover eligible issues, claim and process.
- * Serial processing — one issue at a time.
+ * Repositories are processed in parallel; each repo runs up to
+ * `repo.maxConcurrentRuns` issues concurrently (default: 1).
  */
 export async function pollOnce(
   config: Config,
@@ -82,473 +83,496 @@ export async function pollOnce(
   setActiveAgentObservability(observability)
 
   try {
+    // Update active runs gauge
+    try {
+      const activeRuns = runManager.getActive()
+      metrics?.setActiveRuns(activeRuns.length)
+      metrics?.setDailyCost(costTracker.getDailyCost())
+    } catch { /* best-effort */ }
 
-  // Update active runs gauge
-  try {
-    const activeRuns = runManager.getActive()
-    metrics?.setActiveRuns(activeRuns.length)
-    metrics?.setDailyCost(costTracker.getDailyCost())
-  } catch { /* best-effort */ }
+    // Clean expired leases
+    leaseManager.cleanExpired()
 
-  // Clean expired leases
-  leaseManager.cleanExpired()
-
-  for (const repoConfig of config.repos) {
-    if (targetIssue && repoConfig.repo !== targetIssue.repo) {
-      continue
-    }
-
-    const forge = createForgeAdapter(repoConfig, config)
-    const channels = createChannels(config.notifications, forge)
-    const notifier = new NotificationDispatcher(channels, config.notifications.events)
+    const reposToProcess = targetIssue
+      ? config.repos.filter((repoConfig) => repoConfig.repo === targetIssue.repo)
+      : config.repos
     const usedPortsInPass: number[] = []
 
-    // Resolve bot user for comment upserts (best-effort, fallback to empty string)
-    let botUser = ''
-    try {
-      const authInfo = await forge.validateAuth()
-      botUser = authInfo.user
-    } catch {
-      logger.debug({ repo: repoConfig.repo }, 'Could not resolve bot user for comment upserts')
-    }
+    const repoResults = await Promise.all(
+      reposToProcess.map(async (repoConfig): Promise<PollResult> => {
+        let repoProcessed = 0
+        let repoErrors = 0
 
-    const labelConfig = buildLabelConfig(repoConfig)
+        const forge = createForgeAdapter(repoConfig, config)
+        const channels = createChannels(config.notifications, forge)
+        const notifier = new NotificationDispatcher(channels, config.notifications.events)
 
-    // --- Reaction scan: check review_ready PRs for CI failures or human reviews ---
-    try {
-      await scanAndHandleReactions({
-        db, forge, runManager, repoConfig, labelConfig, botUser,
-      })
-    } catch (err) {
-      logger.warn({ repo: repoConfig.repo, err }, 'Reaction scan failed — continuing with issue discovery')
-    }
-
-    // --- Merge queue: process pending merges before discovering new work ---
-    try {
-      await processMergeQueue(db, forge, repoConfig)
-    } catch (err) {
-      logger.warn({ repo: repoConfig.repo, err }, 'Merge queue processing failed — continuing')
-    }
-
-    const discoveredAll = await discoverEligibleIssues(repoConfig, forge, leaseManager)
-    const discovered = targetIssue
-      ? discoveredAll.filter((d) => d.issue.number === targetIssue.issueNumber)
-      : discoveredAll
-    try { metrics?.setEligibleIssues(repoConfig.repo, discovered.length) } catch { /* best-effort */ }
-
-    if (discovered.length === 0) {
-      logger.info({ repo: repoConfig.repo }, 'No eligible issues')
-      continue
-    }
-
-    if (dryRun) {
-      for (const d of discovered) {
-        logger.info({ issue: d.issue.number, triage: d.triage.level, title: d.issue.title }, '[dry-run] Discovered issue')
-      }
-      continue
-    }
-
-    // Process all currently eligible issues serially for this repo.
-    for (const discoveredIssue of discovered) {
-      if (discoveredIssue.triage.level === 'architectural') {
-        await forge.addLabels(repoConfig.repo, discoveredIssue.issue.number, ['orch:needs-human'])
-        const archBody = formatStatusComment({ blockReason: 'This issue is classified as architectural and requires human guidance.' })
-        if (botUser) {
-          await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, archBody, botUser)
-        } else {
-          await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.`)
-        }
-        continue
-      }
-
-      if (!leaseManager.acquire(repoConfig.repo, discoveredIssue.issue.number, 'poller', 7200)) {
-        continue
-      }
-
-      let runId: string | null = null
-      let envSetup: EnvSetupResult | null = null
-      let activeWorktreePath: string | null = null
-
-      try {
-        const resolvedRoles = resolveRoles(discoveredIssue.issue.labels, repoConfig.defaults)
-        const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, discoveredIssue.issue.number)
-        const roles = queuedRun
-          ? {
-              planner: coerceAgentName(queuedRun.planner, resolvedRoles.planner),
-              coder: coerceAgentName(queuedRun.coder, resolvedRoles.coder),
-              reviewer: coerceAgentName(queuedRun.reviewer, resolvedRoles.reviewer),
-            }
-          : resolvedRoles
-        const slug = getOrPinSlug(db, repoConfig.repo, discoveredIssue.issue.number, discoveredIssue.issue.title)
-        const branch = branchName(repoConfig.branchPrefix, discoveredIssue.issue.number, slug)
-        const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, discoveredIssue.issue.number)
-        activeWorktreePath = worktreePath
-
-        const run = queuedRun ?? runManager.create({
-          repo: repoConfig.repo,
-          issueNumber: discoveredIssue.issue.number,
-          issueTitle: discoveredIssue.issue.title,
-          issueNodeId: discoveredIssue.issue.nodeId,
-          planner: roles.planner,
-          coder: roles.coder,
-          reviewer: roles.reviewer,
-        })
-        runId = run.id
-        runManager.update(run.id, {
-          status: 'running',
-          issueTitle: discoveredIssue.issue.title,
-          branchName: branch,
-          branchSlug: slug,
-          worktreePath,
-          endedAt: null,
-          lastError: null,
-          blockReason: null,
-        })
-
-        // Label transition
-        await transitionLabels(
-          forge,
-          repoConfig.repo,
-          discoveredIssue.issue.number,
-          discoveredIssue.issue.labels,
-          'queued',
-          'running',
-          labelConfig,
-        )
-
-        // Notify
-        await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
-
-        // Detect if this queued run needs a forced branch reset (e.g., after merge conflict)
-        const forceReset = queuedRun?.blockReason === 'merge_conflict'
-
-        // Detect rebase mode from queued run's phaseData
-        // If force-resetting, ignore stale rebase context — we're starting fresh
-        const isRebaseRun = !forceReset && queuedRun?.phaseData?.reactionType === 'rebase'
-
-        // Check if prior run left tainted work that should be discarded
-        // Never reset to base for rebase runs — we need the existing branch
-        const planningMode = isPlanningIssue(discoveredIssue.issue.labels, repoConfig)
-        const resetToBase = forceReset || (!isRebaseRun && (planningMode || shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)))
-
-        // Create worktree
-        await worktreeManager.ensure({
-          repoLocalPath: repoConfig.localPath,
-          baseBranch: repoConfig.baseBranch,
-          branchName: branch,
-          worktreePath,
-          resetToBase,
-        })
-
-        // Execute rebase if this is a rebase-queued run
-        if (isRebaseRun) {
-          logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, runId: run.id }, 'Executing rebase for queued rebase run')
-          const verifyCommands = repoConfig.verify ?? []
-          const rebaseResult = await executeRebase(
-            repoConfig.localPath,
-            worktreePath,
-            branch,
-            repoConfig.baseBranch,
-            repoConfig.repo,
-            discoveredIssue.issue.number,
-            verifyCommands,
-          )
-
-          if (rebaseResult.conflict) {
-            // Rebase had conflicts — block the run; retry will reset the branch and re-implement
-            runManager.update(run.id, {
-              status: 'blocked',
-              blockReason: 'merge_conflict',
-              lastError: 'Rebase failed due to merge conflicts — retry will reset the branch and re-implement from scratch',
-              endedAt: new Date().toISOString(),
-            })
-            const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-            await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
-            await notifier.dispatch(makePayload('blocked', repoConfig.repo, discoveredIssue.issue, {
-              summary: 'Rebase failed due to merge conflicts',
-              blockingReason: 'merge_conflict',
-            }))
-            leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
-            errors++
-            continue
-          }
-
-          if (rebaseResult.rebased && rebaseResult.verifyPassed) {
-            // Rebase succeeded and verify passes — done, transition back to review_ready
-            logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Rebase succeeded, verify passed — returning to review_ready')
-            runManager.update(run.id, {
-              status: 'review_ready',
-              endedAt: new Date().toISOString(),
-              lastError: null,
-            })
-            const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-            await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
-            await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
-              summary: 'Rebased successfully, verify passed',
-            }))
-            leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
-            processed++
-            continue
-          }
-
-          if (!rebaseResult.rebased && rebaseResult.verifyPassed) {
-            // Already up-to-date and verify passes — nothing to do
-            logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Branch already up to date — returning to review_ready')
-            runManager.update(run.id, {
-              status: 'review_ready',
-              endedAt: new Date().toISOString(),
-              lastError: null,
-            })
-            const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-            await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
-            leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
-            processed++
-            continue
-          }
-
-          // Rebase succeeded but verify failed — fall through to the loop engine
-          // so the coder can fix the issues introduced by upstream changes
-          logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Rebase done but verify failed — entering code loop to fix')
+        // Resolve bot user for comment upserts (best-effort, fallback to empty string)
+        let botUser = ''
+        try {
+          const authInfo = await forge.validateAuth()
+          botUser = authInfo.user
+        } catch {
+          logger.debug({ repo: repoConfig.repo }, 'Could not resolve bot user for comment upserts')
         }
 
-        if (repoConfig.environment) {
-          const mode = resolveEnvironmentMode(discoveredIssue.issue.labels, repoConfig)
-          envSetup = await setupEnvironment({
-            worktreePath,
-            issueNumber: discoveredIssue.issue.number,
-            repoConfig,
-            mode,
-            usedPorts: usedPortsInPass,
+        const labelConfig = buildLabelConfig(repoConfig)
+
+        // --- Reaction scan: check review_ready PRs for CI failures or human reviews ---
+        try {
+          await scanAndHandleReactions({
+            db, forge, runManager, repoConfig, labelConfig, botUser,
           })
+        } catch (err) {
+          logger.warn({ repo: repoConfig.repo, err }, 'Reaction scan failed — continuing with issue discovery')
         }
 
-        // Get worker adapters
-        const adjustedLimits = adjustLimitsForTriage(
-          config.loop,
-          config.workerProfiles[repoConfig.agents[roles.planner] ?? '']?.workerTimeoutSeconds ?? 1800,
-          discoveredIssue.triage,
-        )
-
-        const plannerProfile = config.workerProfiles[repoConfig.agents[roles.planner] ?? '']
-        const coderProfile = config.workerProfiles[repoConfig.agents[roles.coder] ?? '']
-        const reviewerProfile = config.workerProfiles[repoConfig.agents[roles.reviewer] ?? '']
-
-        if (!plannerProfile || !coderProfile || !reviewerProfile) {
-          throw new Error('Missing worker profiles for resolved roles')
+        // --- Merge queue: process pending merges before discovering new work ---
+        try {
+          await processMergeQueue(db, forge, repoConfig)
+        } catch (err) {
+          logger.warn({ repo: repoConfig.repo, err }, 'Merge queue processing failed — continuing')
         }
 
-        const initialCtx: RunContext = {
-          runId: run.id,
-          repo: repoConfig.repo,
-          issueNumber: discoveredIssue.issue.number,
-          issue: discoveredIssue.issue,
-          repoConfig,
-          roles,
-          triageResult: discoveredIssue.triage,
-          adjustedLimits,
-          branchName: branch,
-          worktreePath,
-          plan: null,
-          codeResult: null,
-          diff: null,
-          verifyResults: [],
-          reviewResult: null,
-          reviewFindings: [],
-          iteration: 1,
-          totalAgentPasses: 0,
-          estimatedCostUsd: 0,
-          currentPhase: 'plan',
-          terminalStatus: 'running',
-          phaseHistory: [],
-          dryRun: false,
-          runMode: isRebaseRun ? 'rebase' : 'fresh',
-          blockReason: null,
-          prReviewFeedback: null,
-          sessionIds: {},
-          stepOutputs: {},
+        const discoveredAll = await discoverEligibleIssues(repoConfig, forge, leaseManager)
+        const discovered = targetIssue
+          ? discoveredAll.filter((d) => d.issue.number === targetIssue.issueNumber)
+          : discoveredAll
+        try { metrics?.setEligibleIssues(repoConfig.repo, discovered.length) } catch { /* best-effort */ }
+
+        if (discovered.length === 0) {
+          logger.info({ repo: repoConfig.repo }, 'No eligible issues')
+          return { processed: repoProcessed, errors: repoErrors }
         }
 
-        // Check if decomposition is enabled and appropriate
-        const shouldDecompose = config.loop.decompose
-          && discoveredIssue.triage.level === 'standard'
-          && !planningMode
-          && shouldAttemptDecompose(discoveredIssue.issue)
-
-        if (shouldDecompose) {
-          logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Attempting issue decomposition')
-          const decomposition = await decomposeIssue(
-            discoveredIssue.issue,
-            createWorkerAdapter(plannerProfile),
-            plannerProfile,
-            buildWorkerEnv(plannerProfile, envSetup?.envOverrides ?? {}),
-            worktreePath,
-            config.loop.maxSubtasks,
-          )
-
-          if (decomposition.shouldDecompose && decomposition.subtasks.length > 1) {
-            logger.info(
-              { repo: repoConfig.repo, issue: discoveredIssue.issue.number, subtasks: decomposition.subtasks.length },
-              'Decomposed issue into sub-tasks — executing in parallel',
-            )
-
-            const loopDeps = {
-              db, config,
-              adapters: {
-                planner: createWorkerAdapter(plannerProfile),
-                coder: createWorkerAdapter(coderProfile),
-                reviewer: createWorkerAdapter(reviewerProfile),
-              },
-              workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
-              envOverrides: envSetup?.envOverrides ?? {},
-              metrics,
-              onAgentEvent: (event: AgentEvent) => observability.record(event),
-            }
-
-            const subResults = await executeParallelSubtasks(
-              initialCtx,
-              decomposition.subtasks,
-              loopDeps,
-              config.loop.maxConcurrentSubtasks,
-            )
-
-            const allSucceeded = subResults.every((r) => r.success)
-            if (allSucceeded) {
-              runManager.update(run.id, { status: 'review_ready', endedAt: new Date().toISOString() })
-              const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-              await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
-              await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
-                summary: `Decomposed into ${decomposition.subtasks.length} sub-tasks, all completed`,
-              }))
-              processed++
-            } else {
-              const failed = subResults.filter((r) => !r.success).length
-              runManager.update(run.id, {
-                status: 'blocked',
-                lastError: `${failed}/${decomposition.subtasks.length} sub-tasks failed`,
-                endedAt: new Date().toISOString(),
-              })
-              const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-              await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
-              errors++
-            }
-            continue
+        if (dryRun) {
+          for (const d of discovered) {
+            logger.info({ issue: d.issue.number, triage: d.triage.level, title: d.issue.title }, '[dry-run] Discovered issue')
           }
+          return { processed: repoProcessed, errors: repoErrors }
         }
 
-        // Execute loop (single-issue path)
-        const loopStart = Date.now()
-        const finalCtx = await executeLoop(initialCtx, {
-          db,
-          config,
-          adapters: {
-            planner: createWorkerAdapter(plannerProfile),
-            coder: createWorkerAdapter(coderProfile),
-            reviewer: createWorkerAdapter(reviewerProfile),
-          },
-          workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
-          envOverrides: envSetup?.envOverrides ?? {},
-          metrics,
-          onAgentEvent: (event) => observability.record(event),
-          onPlanReady: async (ctx) => {
-            await postPlanSummaryComment(forge, ctx.repo, ctx.issueNumber, ctx.plan, botUser)
-          },
-        })
+        const maxConcurrentRuns = targetIssue ? 1 : (repoConfig.maxConcurrentRuns ?? 1)
+        const discoveredQueue = [...discovered]
+        const workerCount = Math.min(maxConcurrentRuns, discoveredQueue.length)
 
-        const runDurationSec = (Date.now() - loopStart) / 1000
-        const outcome = await finalizeRunOutcome({
-          finalCtx,
-          runId: run.id,
-          issue: discoveredIssue.issue,
-          runDurationSec,
-          repo: repoConfig.repo,
-          issueNumber: discoveredIssue.issue.number,
-          labelConfig,
-          db,
-          forge,
-          runManager,
-          notifier,
-          metrics,
-          maxAutoRetries: config.loop.maxAutoRetries,
-          botUser,
-        })
-
-        if (outcome === 'processed') processed++
-        else errors++
-      } catch (err) {
-        logger.error({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err }, 'Failed to process issue')
-        if (runId) {
-          const recentErrors = runManager.countRecentErrors(repoConfig.repo, discoveredIssue.issue.number)
-          const maxRetries = config.loop.maxAutoRetries
-          const canAutoRetry = recentErrors < maxRetries
-
-          runManager.update(runId, {
-            status: 'error',
-            lastError: String(err),
-            endedAt: new Date().toISOString(),
-          })
-
-          if (canAutoRetry) {
-            // Auto-retry: transition back to queued so the next poll picks it up
-            logger.info(
-              { repo: repoConfig.repo, issue: discoveredIssue.issue.number, recentErrors, maxRetries },
-              'Infra error — auto-retrying (transitioning back to ready)',
-            )
-            try {
-              const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-              await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'queued', labelConfig)
-            } catch (labelErr) {
-              logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels for auto-retry')
-            }
-          } else {
-            // Retries exhausted: mark as error, require human
-            logger.warn(
-              { repo: repoConfig.repo, issue: discoveredIssue.issue.number, recentErrors, maxRetries },
-              'Auto-retry limit reached — marking as error',
-            )
-            try {
-              const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
-              await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'error', labelConfig)
-              const errorBody = formatStatusComment({
-                error: `Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}`,
-                retryCount: recentErrors + 1,
-                maxRetries: maxRetries,
-              })
-              if (botUser) {
-                await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, errorBody, botUser)
-              } else {
-                await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}\n\nRemove \`orch:error\` and add \`orch:ready\` to retry.`)
+        await Promise.all(
+          Array.from({ length: workerCount }, async () => {
+            while (true) {
+              const discoveredIssue = discoveredQueue.shift()
+              if (!discoveredIssue) {
+                break
               }
-            } catch (labelErr) {
-              logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels after retry exhaustion')
+
+              if (discoveredIssue.triage.level === 'architectural') {
+                await forge.addLabels(repoConfig.repo, discoveredIssue.issue.number, ['orch:needs-human'])
+                const archBody = formatStatusComment({ blockReason: 'This issue is classified as architectural and requires human guidance.' })
+                if (botUser) {
+                  await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, archBody, botUser)
+                } else {
+                  await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `🏗️ **night-orch**: This issue is classified as architectural and requires human guidance.`)
+                }
+                continue
+              }
+
+              if (!leaseManager.acquire(repoConfig.repo, discoveredIssue.issue.number, 'poller', 7200)) {
+                continue
+              }
+
+              let runId: string | null = null
+              let envSetup: EnvSetupResult | null = null
+              let activeWorktreePath: string | null = null
+
+              try {
+                const resolvedRoles = resolveRoles(discoveredIssue.issue.labels, repoConfig.defaults)
+                const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, discoveredIssue.issue.number)
+                const roles = queuedRun
+                  ? {
+                      planner: coerceAgentName(queuedRun.planner, resolvedRoles.planner),
+                      coder: coerceAgentName(queuedRun.coder, resolvedRoles.coder),
+                      reviewer: coerceAgentName(queuedRun.reviewer, resolvedRoles.reviewer),
+                    }
+                  : resolvedRoles
+                const slug = getOrPinSlug(db, repoConfig.repo, discoveredIssue.issue.number, discoveredIssue.issue.title)
+                const branch = branchName(repoConfig.branchPrefix, discoveredIssue.issue.number, slug)
+                const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, discoveredIssue.issue.number)
+                activeWorktreePath = worktreePath
+
+                const run = queuedRun ?? runManager.create({
+                  repo: repoConfig.repo,
+                  issueNumber: discoveredIssue.issue.number,
+                  issueTitle: discoveredIssue.issue.title,
+                  issueNodeId: discoveredIssue.issue.nodeId,
+                  planner: roles.planner,
+                  coder: roles.coder,
+                  reviewer: roles.reviewer,
+                })
+                runId = run.id
+                runManager.update(run.id, {
+                  status: 'running',
+                  issueTitle: discoveredIssue.issue.title,
+                  branchName: branch,
+                  branchSlug: slug,
+                  worktreePath,
+                  endedAt: null,
+                  lastError: null,
+                  blockReason: null,
+                })
+
+                // Label transition
+                await transitionLabels(
+                  forge,
+                  repoConfig.repo,
+                  discoveredIssue.issue.number,
+                  discoveredIssue.issue.labels,
+                  'queued',
+                  'running',
+                  labelConfig,
+                )
+
+                // Notify
+                await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
+
+                // Detect if this queued run needs a forced branch reset (e.g., after merge conflict)
+                const forceReset = queuedRun?.blockReason === 'merge_conflict'
+
+                // Detect rebase mode from queued run's phaseData
+                // If force-resetting, ignore stale rebase context — we're starting fresh
+                const isRebaseRun = !forceReset && queuedRun?.phaseData?.reactionType === 'rebase'
+
+                // Check if prior run left tainted work that should be discarded
+                // Never reset to base for rebase runs — we need the existing branch
+                const planningMode = isPlanningIssue(discoveredIssue.issue.labels, repoConfig)
+                const resetToBase = forceReset || (!isRebaseRun && (planningMode || shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)))
+
+                // Create worktree
+                await worktreeManager.ensure({
+                  repoLocalPath: repoConfig.localPath,
+                  baseBranch: repoConfig.baseBranch,
+                  branchName: branch,
+                  worktreePath,
+                  resetToBase,
+                })
+
+                // Execute rebase if this is a rebase-queued run
+                if (isRebaseRun) {
+                  logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, runId: run.id }, 'Executing rebase for queued rebase run')
+                  const verifyCommands = repoConfig.verify ?? []
+                  const rebaseResult = await executeRebase(
+                    repoConfig.localPath,
+                    worktreePath,
+                    branch,
+                    repoConfig.baseBranch,
+                    repoConfig.repo,
+                    discoveredIssue.issue.number,
+                    verifyCommands,
+                  )
+
+                  if (rebaseResult.conflict) {
+                    // Rebase had conflicts — block the run; retry will reset the branch and re-implement
+                    runManager.update(run.id, {
+                      status: 'blocked',
+                      blockReason: 'merge_conflict',
+                      lastError: 'Rebase failed due to merge conflicts — retry will reset the branch and re-implement from scratch',
+                      endedAt: new Date().toISOString(),
+                    })
+                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
+                    await notifier.dispatch(makePayload('blocked', repoConfig.repo, discoveredIssue.issue, {
+                      summary: 'Rebase failed due to merge conflicts',
+                      blockingReason: 'merge_conflict',
+                    }))
+                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    repoErrors++
+                    continue
+                  }
+
+                  if (rebaseResult.rebased && rebaseResult.verifyPassed) {
+                    // Rebase succeeded and verify passes — done, transition back to review_ready
+                    logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Rebase succeeded, verify passed — returning to review_ready')
+                    runManager.update(run.id, {
+                      status: 'review_ready',
+                      endedAt: new Date().toISOString(),
+                      lastError: null,
+                    })
+                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
+                    await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
+                      summary: 'Rebased successfully, verify passed',
+                    }))
+                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    repoProcessed++
+                    continue
+                  }
+
+                  if (!rebaseResult.rebased && rebaseResult.verifyPassed) {
+                    // Already up-to-date and verify passes — nothing to do
+                    logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Branch already up to date — returning to review_ready')
+                    runManager.update(run.id, {
+                      status: 'review_ready',
+                      endedAt: new Date().toISOString(),
+                      lastError: null,
+                    })
+                    const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                    await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
+                    leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+                    repoProcessed++
+                    continue
+                  }
+
+                  // Rebase succeeded but verify failed — fall through to the loop engine
+                  // so the coder can fix the issues introduced by upstream changes
+                  logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Rebase done but verify failed — entering code loop to fix')
+                }
+
+                if (repoConfig.environment) {
+                  const mode = resolveEnvironmentMode(discoveredIssue.issue.labels, repoConfig)
+                  envSetup = await setupEnvironment({
+                    worktreePath,
+                    issueNumber: discoveredIssue.issue.number,
+                    repoConfig,
+                    mode,
+                    usedPorts: usedPortsInPass,
+                  })
+                }
+
+                // Get worker adapters
+                const adjustedLimits = adjustLimitsForTriage(
+                  config.loop,
+                  config.workerProfiles[repoConfig.agents[roles.planner] ?? '']?.workerTimeoutSeconds ?? 1800,
+                  discoveredIssue.triage,
+                )
+
+                const plannerProfile = config.workerProfiles[repoConfig.agents[roles.planner] ?? '']
+                const coderProfile = config.workerProfiles[repoConfig.agents[roles.coder] ?? '']
+                const reviewerProfile = config.workerProfiles[repoConfig.agents[roles.reviewer] ?? '']
+
+                if (!plannerProfile || !coderProfile || !reviewerProfile) {
+                  throw new Error('Missing worker profiles for resolved roles')
+                }
+
+                const initialCtx: RunContext = {
+                  runId: run.id,
+                  repo: repoConfig.repo,
+                  issueNumber: discoveredIssue.issue.number,
+                  issue: discoveredIssue.issue,
+                  repoConfig,
+                  roles,
+                  triageResult: discoveredIssue.triage,
+                  adjustedLimits,
+                  branchName: branch,
+                  worktreePath,
+                  plan: null,
+                  codeResult: null,
+                  diff: null,
+                  verifyResults: [],
+                  reviewResult: null,
+                  reviewFindings: [],
+                  iteration: 1,
+                  totalAgentPasses: 0,
+                  estimatedCostUsd: 0,
+                  currentPhase: 'plan',
+                  terminalStatus: 'running',
+                  phaseHistory: [],
+                  dryRun: false,
+                  runMode: isRebaseRun ? 'rebase' : 'fresh',
+                  blockReason: null,
+                  prReviewFeedback: null,
+                  sessionIds: {},
+                  stepOutputs: {},
+                }
+
+                // Check if decomposition is enabled and appropriate
+                const shouldDecompose = config.loop.decompose
+                  && discoveredIssue.triage.level === 'standard'
+                  && !planningMode
+                  && shouldAttemptDecompose(discoveredIssue.issue)
+
+                if (shouldDecompose) {
+                  logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Attempting issue decomposition')
+                  const decomposition = await decomposeIssue(
+                    discoveredIssue.issue,
+                    createWorkerAdapter(plannerProfile),
+                    plannerProfile,
+                    buildWorkerEnv(plannerProfile, envSetup?.envOverrides ?? {}),
+                    worktreePath,
+                    config.loop.maxSubtasks,
+                  )
+
+                  if (decomposition.shouldDecompose && decomposition.subtasks.length > 1) {
+                    logger.info(
+                      { repo: repoConfig.repo, issue: discoveredIssue.issue.number, subtasks: decomposition.subtasks.length },
+                      'Decomposed issue into sub-tasks — executing in parallel',
+                    )
+
+                    const loopDeps = {
+                      db, config,
+                      adapters: {
+                        planner: createWorkerAdapter(plannerProfile),
+                        coder: createWorkerAdapter(coderProfile),
+                        reviewer: createWorkerAdapter(reviewerProfile),
+                      },
+                      workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
+                      envOverrides: envSetup?.envOverrides ?? {},
+                      metrics,
+                      onAgentEvent: (event: AgentEvent) => observability.record(event),
+                    }
+
+                    const subResults = await executeParallelSubtasks(
+                      initialCtx,
+                      decomposition.subtasks,
+                      loopDeps,
+                      config.loop.maxConcurrentSubtasks,
+                    )
+
+                    const allSucceeded = subResults.every((r) => r.success)
+                    if (allSucceeded) {
+                      runManager.update(run.id, { status: 'review_ready', endedAt: new Date().toISOString() })
+                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'review_ready', labelConfig)
+                      await notifier.dispatch(makePayload('pr_ready', repoConfig.repo, discoveredIssue.issue, {
+                        summary: `Decomposed into ${decomposition.subtasks.length} sub-tasks, all completed`,
+                      }))
+                      repoProcessed++
+                    } else {
+                      const failed = subResults.filter((r) => !r.success).length
+                      runManager.update(run.id, {
+                        status: 'blocked',
+                        lastError: `${failed}/${decomposition.subtasks.length} sub-tasks failed`,
+                        endedAt: new Date().toISOString(),
+                      })
+                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'blocked', labelConfig)
+                      repoErrors++
+                    }
+                    continue
+                  }
+                }
+
+                // Execute loop (single-issue path)
+                const loopStart = Date.now()
+                const finalCtx = await executeLoop(initialCtx, {
+                  db,
+                  config,
+                  adapters: {
+                    planner: createWorkerAdapter(plannerProfile),
+                    coder: createWorkerAdapter(coderProfile),
+                    reviewer: createWorkerAdapter(reviewerProfile),
+                  },
+                  workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
+                  envOverrides: envSetup?.envOverrides ?? {},
+                  metrics,
+                  onAgentEvent: (event) => observability.record(event),
+                  onPlanReady: async (ctx) => {
+                    await postPlanSummaryComment(forge, ctx.repo, ctx.issueNumber, ctx.plan, botUser)
+                  },
+                })
+
+                const runDurationSec = (Date.now() - loopStart) / 1000
+                const outcome = await finalizeRunOutcome({
+                  finalCtx,
+                  runId: run.id,
+                  issue: discoveredIssue.issue,
+                  runDurationSec,
+                  repo: repoConfig.repo,
+                  issueNumber: discoveredIssue.issue.number,
+                  labelConfig,
+                  db,
+                  forge,
+                  runManager,
+                  notifier,
+                  metrics,
+                  maxAutoRetries: config.loop.maxAutoRetries,
+                  botUser,
+                })
+
+                if (outcome === 'processed') repoProcessed++
+                else repoErrors++
+              } catch (err) {
+                logger.error({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err }, 'Failed to process issue')
+                if (runId) {
+                  const recentErrors = runManager.countRecentErrors(repoConfig.repo, discoveredIssue.issue.number)
+                  const maxRetries = config.loop.maxAutoRetries
+                  const canAutoRetry = recentErrors < maxRetries
+
+                  runManager.update(runId, {
+                    status: 'error',
+                    lastError: String(err),
+                    endedAt: new Date().toISOString(),
+                  })
+
+                  if (canAutoRetry) {
+                    // Auto-retry: transition back to queued so the next poll picks it up
+                    logger.info(
+                      { repo: repoConfig.repo, issue: discoveredIssue.issue.number, recentErrors, maxRetries },
+                      'Infra error — auto-retrying (transitioning back to ready)',
+                    )
+                    try {
+                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'queued', labelConfig)
+                    } catch (labelErr) {
+                      logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels for auto-retry')
+                    }
+                  } else {
+                    // Retries exhausted: mark as error, require human
+                    logger.warn(
+                      { repo: repoConfig.repo, issue: discoveredIssue.issue.number, recentErrors, maxRetries },
+                      'Auto-retry limit reached — marking as error',
+                    )
+                    try {
+                      const latestIssue = await forge.getIssue(repoConfig.repo, discoveredIssue.issue.number)
+                      await transitionLabels(forge, repoConfig.repo, discoveredIssue.issue.number, latestIssue.labels, 'running', 'error', labelConfig)
+                      const errorBody = formatStatusComment({
+                        error: `Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}`,
+                        retryCount: recentErrors + 1,
+                        maxRetries: maxRetries,
+                      })
+                      if (botUser) {
+                        await upsertBotComment(forge, repoConfig.repo, discoveredIssue.issue.number, STATUS_MARKER, errorBody, botUser)
+                      } else {
+                        await forge.commentOnIssue(repoConfig.repo, discoveredIssue.issue.number, `⚠️ **night-orch**: Failed after ${recentErrors + 1} attempts. Last error: ${(err as Error).message}\n\nRemove \`orch:error\` and add \`orch:ready\` to retry.`)
+                      }
+                    } catch (labelErr) {
+                      logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: labelErr }, 'Failed to transition labels after retry exhaustion')
+                    }
+                    try {
+                      await notifier.dispatch(makePayload('retry_exhausted', repoConfig.repo, discoveredIssue.issue, {
+                        summary: `Failed after ${recentErrors + 1} attempts: ${(err as Error).message}`,
+                      }))
+                    } catch (notifyErr) {
+                      logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: notifyErr }, 'Failed to send retry exhaustion notification')
+                    }
+                  }
+                }
+                repoErrors++
+              } finally {
+                if (envSetup && activeWorktreePath) {
+                  try {
+                    await teardownEnvironment({
+                      worktreePath: activeWorktreePath,
+                      issueNumber: discoveredIssue.issue.number,
+                      repoConfig,
+                      mode: envSetup.mode,
+                      composeProjectName: envSetup.composeProjectName,
+                    })
+                  } catch (envErr) {
+                    logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: envErr }, 'Failed to tear down environment')
+                  }
+                }
+                leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
+              }
             }
-            try {
-              await notifier.dispatch(makePayload('retry_exhausted', repoConfig.repo, discoveredIssue.issue, {
-                summary: `Failed after ${recentErrors + 1} attempts: ${(err as Error).message}`,
-              }))
-            } catch (notifyErr) {
-              logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: notifyErr }, 'Failed to send retry exhaustion notification')
-            }
-          }
-        }
-        errors++
-      } finally {
-        if (envSetup && activeWorktreePath) {
-          try {
-            await teardownEnvironment({
-              worktreePath: activeWorktreePath,
-              issueNumber: discoveredIssue.issue.number,
-              repoConfig,
-              mode: envSetup.mode,
-              composeProjectName: envSetup.composeProjectName,
-            })
-          } catch (envErr) {
-            logger.warn({ repo: repoConfig.repo, issue: discoveredIssue.issue.number, err: envErr }, 'Failed to tear down environment')
-          }
-        }
-        leaseManager.release(repoConfig.repo, discoveredIssue.issue.number)
-      }
+          }),
+        )
+
+        return { processed: repoProcessed, errors: repoErrors }
+      }),
+    )
+
+    for (const repoResult of repoResults) {
+      processed += repoResult.processed
+      errors += repoResult.errors
     }
-  }
 
     return { processed, errors }
   } finally {

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -96,9 +96,17 @@ describe('ConfigSchema', () => {
       expect(result.data.github.pollIntervalSeconds).toBe(300)
       expect(result.data.loop.maxReviewIterations).toBe(4)
       expect(result.data.security.maxDailyCostUsd).toBe(50)
+      expect(result.data.repos[0]?.maxConcurrentRuns).toBe(1)
       expect(result.data.repos[0]?.baseBranch).toBe('main')
       expect(result.data.repos[0]?.branchPrefix).toBe('orch')
     }
+  })
+
+  it('validates repos[].maxConcurrentRuns range', () => {
+    const raw = loadExampleConfig()
+    raw.repos[0].maxConcurrentRuns = 0
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(false)
   })
 
   it('normalizes ready labels from string to array', () => {

--- a/test/poller/poller.test.ts
+++ b/test/poller/poller.test.ts
@@ -89,6 +89,27 @@ vi.mock('../../src/state/leases.js', () => {
   return actual
 })
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('Timed out waiting for condition')
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10))
+  }
+}
+
 function makeConfig(dbPath: string): Config {
   return {
     version: 1,
@@ -99,7 +120,7 @@ function makeConfig(dbPath: string): Config {
     security: { maxChangedFiles: 50, maxChangedLines: 5000, maxDailyCostUsd: 50, maxCostPerRunUsd: 10 },
     metrics: { enabled: false, port: 9090, host: '127.0.0.1' },
     repos: [{
-      repo: 'org/repo', forge: 'github', localPath: '/tmp/repo', baseBranch: 'main',
+      repo: 'org/repo', forge: 'github', localPath: '/tmp/repo', maxConcurrentRuns: 1, baseBranch: 'main',
       branchPrefix: 'orch', labels: { ready: ['orch:ready'], running: 'orch:running', blocked: ['orch:blocked'], reviewReady: 'orch:review-ready', error: 'orch:error', retry: 'orch:retry', planning: 'orch:planning' },
       defaults: { planner: 'claude', coder: 'claude', reviewer: 'claude', doneMode: 'pr-ready', notifyPriority: 'normal', prMentions: [] },
       planning: { prdDirectory: 'docs/prd' },
@@ -321,6 +342,119 @@ describe('pollOnce', () => {
       { issue_number: 1, status: 'blocked' },
       { issue_number: 2, status: 'blocked' },
     ])
+  })
+
+  it('processes one issue per repo in parallel by default', async () => {
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    config.repos = [
+      {
+        ...config.repos[0]!,
+        repo: 'org/repo-a',
+        localPath: '/tmp/repo-a',
+      },
+      {
+        ...config.repos[0]!,
+        repo: 'org/repo-b',
+        localPath: '/tmp/repo-b',
+      },
+    ]
+
+    mockDiscoverEligibleIssues.mockImplementation(async (repoConfig: { repo: string }) => {
+      if (repoConfig.repo === 'org/repo-a') {
+        return [{
+          issue: { number: 1, nodeId: '', title: 'A', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+          triage: { level: 'standard', reason: '' },
+        }]
+      }
+      return [{
+        issue: { number: 2, nodeId: '', title: 'B', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      }]
+    })
+
+    const issue1Gate = deferred<void>()
+    const issue2Gate = deferred<void>()
+    mockExecuteLoop.mockImplementation(async (ctx: { issueNumber: number }) => {
+      if (ctx.issueNumber === 1) {
+        await issue1Gate.promise
+      } else if (ctx.issueNumber === 2) {
+        await issue2Gate.promise
+      }
+      return {
+        currentPhase: 'publish',
+        terminalStatus: 'blocked',
+      }
+    })
+
+    const pollPromise = pollOnce(config, db, false)
+    await waitForCondition(() => mockExecuteLoop.mock.calls.length === 2)
+
+    issue1Gate.resolve()
+    issue2Gate.resolve()
+
+    const result = await pollPromise
+    expect(result.processed).toBe(2)
+    expect(result.errors).toBe(0)
+    expect(mockExecuteLoop).toHaveBeenCalledTimes(2)
+
+    const reposStarted = new Set(
+      mockExecuteLoop.mock.calls.map((call) => (call[0] as { repo: string }).repo),
+    )
+    expect(reposStarted).toEqual(new Set(['org/repo-a', 'org/repo-b']))
+  })
+
+  it('respects repos[].maxConcurrentRuns for per-repo parallelism', async () => {
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    config.repos[0]!.maxConcurrentRuns = 2
+
+    mockDiscoverEligibleIssues.mockResolvedValue([
+      {
+        issue: { number: 1, nodeId: '', title: 'First', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      },
+      {
+        issue: { number: 2, nodeId: '', title: 'Second', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      },
+      {
+        issue: { number: 3, nodeId: '', title: 'Third', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+        triage: { level: 'standard', reason: '' },
+      },
+    ])
+
+    const gate1 = deferred<void>()
+    const gate2 = deferred<void>()
+    const gate3 = deferred<void>()
+    mockExecuteLoop.mockImplementation(async (ctx: { issueNumber: number }) => {
+      if (ctx.issueNumber === 1) await gate1.promise
+      if (ctx.issueNumber === 2) await gate2.promise
+      if (ctx.issueNumber === 3) await gate3.promise
+      return {
+        currentPhase: 'publish',
+        terminalStatus: 'blocked',
+      }
+    })
+
+    const pollPromise = pollOnce(config, db, false)
+
+    await waitForCondition(() => mockExecuteLoop.mock.calls.length === 2)
+    const firstWaveIssues = mockExecuteLoop.mock.calls
+      .slice(0, 2)
+      .map((call) => (call[0] as { issueNumber: number }).issueNumber)
+    expect(firstWaveIssues.sort((a, b) => a - b)).toEqual([1, 2])
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50))
+    expect(mockExecuteLoop).toHaveBeenCalledTimes(2)
+
+    gate1.resolve()
+    await waitForCondition(() => mockExecuteLoop.mock.calls.length === 3)
+
+    gate2.resolve()
+    gate3.resolve()
+
+    const result = await pollPromise
+    expect(result.processed).toBe(3)
+    expect(result.errors).toBe(0)
   })
 
   it('processes only the targeted issue when targetIssue is provided', async () => {


### PR DESCRIPTION
Closes #3

## Plan
**Objective:** Enable parallel issue processing across repos (default 1 per repo) with per-repo configurable concurrency

1. Add `maxConcurrentRuns` field to RepoConfigSchema (int 1-10, default 1). This controls how many issues a single repo can process in parallel within one poll cycle.
2. Refactor pollOnce() to process repos in parallel. Extract the per-issue processing block (lines 152-550) into a standalone async function (e.g., `processIssue()`). Replace the sequential `for (const repo of config.repos)` loop with `Promise.allSettled()` over all repos. Within each repo, replace the sequential `for (const discoveredIssue of discovered)` loop with chunked parallel execution using `Promise.allSettled()`, limited by `repoConfig.maxConcurrentRuns`. The usedPortsInPass array must be shared across concurrent issues within a repo and protected from race conditions (not needed since better-sqlite3 is sync and port allocation is sync too — just need to collect ports before launching the batch).
3. Ensure port allocation safety: since setupEnvironment() is async but allocatePort() itself is synchronous, and we're in a single-threaded Node.js event loop, the usedPortsInPass array is safe as long as we don't yield between reading and pushing. Verify this is the case in the current code. If environment setup needs ports, each concurrent batch should pre-allocate ports before launching parallel work, or track them in a synchronized way.
4. Aggregate PollResult correctly: each concurrent repo/issue processor returns its own processed/errors counts, which must be summed into the final PollResult. Use the same pattern as parallel subtasks.
5. Update existing tests and add new tests: (a) test that multiple repos are processed in the same poll cycle, (b) test that maxConcurrentRuns limits concurrent issues per repo, (c) test that issues across repos run concurrently, (d) update makeConfig helper to include the new field.
6. Update docs/CONFIGURATION.md: add `maxConcurrentRuns` to the repo config table, explain the default (1 = one issue per repo per poll), and document the interaction with port allocation and environment modes.

## Implementation
Implemented parallel issue processing across repositories with per-repo concurrency control. Added `repos[].maxConcurrentRuns` to config schema (default `1`), updated `pollOnce` to process repos in parallel and run a bounded worker pool per repo, kept target-issue behavior constrained to one run, added regression/behavior tests for cross-repo parallelism and per-repo concurrency limits, and updated configuration/docs/examples to document the new setting.

**Changed files:**
- `src/runner/poller.ts`
- `src/config/schema.ts`
- `test/poller/poller.test.ts`
- `test/config/schema.test.ts`
- `docs/CONFIGURATION.md`
- `docs/USAGE.md`
- `examples/config.example.yaml`
- `config.yaml`
- `README.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Well-implemented parallel runs feature. Repos process in parallel via Promise.all; per-repo concurrency uses a clean worker-pool pattern with shared queue. Schema, docs, tests all consistent. No concurrency bugs — Node.js single-threaded model makes the shift()/port-allocation patterns safe.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude