### PR TITLE
[night-orch] #24 TUI - fix issue titles and apply layout

### DIFF
--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -4,21 +4,42 @@ import { Box, Text } from 'ink'
 interface ActionsBarProps {
   activeTab: 'runs' | 'stats'
   busy: boolean
+  runFocused: boolean
+  autoRefresh: boolean
 }
 
-export function ActionsBar({ activeTab, busy }: ActionsBarProps): React.ReactElement {
-  const tabHints = '[1]runs  [2]stats  [h/l] switch tab'
-  const listHints = activeTab === 'runs' ? '  [j/k] select run' : ''
-  const actionHints = busy
-    ? 'actions locked while task is running'
-    : '[r]etry  [b]rebase  [s]ync  [c]leanup  [p]oll'
+interface ActionHints {
+  line1: string
+  line2: string
+}
+
+export function buildActionHints(props: ActionsBarProps): ActionHints {
+  const tabHints = '[1]runs  [2]stats  [h/l]tabs'
+  if (props.activeTab === 'runs') {
+    const focusHint = props.runFocused ? '[esc]close' : '[o/enter]open'
+    const actionHints = props.busy
+      ? 'actions locked while task is running'
+      : '[r]etry  [b]rebase  [p]oll  [s]ync  [c]leanup'
+    return {
+      line1: `${tabHints}  [j/k]select  ${focusHint}`,
+      line2: `${actionHints}  [f]refresh  [q]quit`,
+    }
+  }
+
+  const polling = props.autoRefresh ? 'polling live' : 'polling paused'
+  return {
+    line1: `${tabHints}  [f]refresh now  [a]toggle auto-refresh`,
+    line2: `${polling}  [q]quit`,
+  }
+}
+
+export function ActionsBar(props: ActionsBarProps): React.ReactElement {
+  const hints = buildActionHints(props)
 
   return (
     <Box marginTop={1} flexDirection="column">
-      <Text color="gray">{tabHints}{listHints}</Text>
-      <Text color="gray">
-        {actionHints}  [f]refresh  [q]uit
-      </Text>
+      <Text color="gray">{hints.line1}</Text>
+      <Text color="gray">{hints.line2}</Text>
     </Box>
   )
 }

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { Box, Text, useApp, useInput } from 'ink'
 import type { Config } from '../../config/schema.js'
 import { RetryEngine } from '../../ops/retry.js'
@@ -10,6 +10,9 @@ import { createForgeAdapter } from '../../forge/factory.js'
 import type Database from 'better-sqlite3'
 import { loadTuiStats, type StatusAggregate, type TuiStatsSnapshot } from '../../state/stats.js'
 import { ActionsBar } from './actions-bar.js'
+import { loadRuns, loadAgentEvents, loadMergeBatches, type AgentEventRow, type MergeBatchRow, type RunListRow } from './data.js'
+import { collectMissingTitleTargets, hasReadableTitle, resolveIssueTitle, resolvePrTitle, type TitleLookup } from './titles.js'
+import { buildSparkline, sliceWindow } from './view-model.js'
 
 interface AppProps {
   db: Database.Database
@@ -18,43 +21,13 @@ interface AppProps {
   dryRun?: boolean
 }
 
-interface RunListRow {
-  id: string
-  repo: string
-  issue_number: number
-  issue_title: string | null
-  status: string
-  current_phase: string | null
-  iteration_count: number | null
-  estimated_cost_usd: number | null
-  last_error: string | null
-  pr_number: number | null
-  pr_title: string | null
-  updated_at: string
-}
-
-interface AgentEventRow {
-  id: number
-  run_id: string
-  role: string
-  event_type: string
-  data: string | null
-  created_at: string
-}
-
-interface MergeBatchRow {
-  id: string
-  repo: string
-  status: string
-  pr_numbers: string
-}
-
 interface ActionState {
   busy: boolean
   action: string | null
 }
 
 type TabId = 'runs' | 'stats'
+type RunsViewMode = 'list' | 'focus'
 
 const TABS: Array<{ id: TabId; hotkey: string; label: string }> = [
   { id: 'runs', hotkey: '1', label: 'Runs' },
@@ -83,23 +56,47 @@ const EVENT_COLORS: Record<string, 'gray' | 'cyan' | 'green' | 'yellow' | 'red' 
 
 export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppProps): React.ReactElement {
   const { exit } = useApp()
+
   const [tick, setTick] = useState(0)
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
   const [statusLine, setStatusLine] = useState('Ready')
   const [actionState, setActionState] = useState<ActionState>({ busy: false, action: null })
   const [activeTab, setActiveTab] = useState<TabId>('runs')
+  const [runsViewMode, setRunsViewMode] = useState<RunsViewMode>('list')
+  const [autoRefresh, setAutoRefresh] = useState(true)
+  const [lastRefreshAt, setLastRefreshAt] = useState(new Date().toISOString())
+  const [titleLookup, setTitleLookup] = useState<TitleLookup>({ issues: {}, prs: {} })
+
+  const attemptedIssueKeys = useRef<Set<string>>(new Set())
+  const attemptedPrKeys = useRef<Set<string>>(new Set())
+  const lastHydrationAt = useRef(0)
+
+  const forgeByRepo = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof createForgeAdapter>>()
+    for (const repoConfig of config.repos) {
+      map.set(repoConfig.repo, createForgeAdapter(repoConfig, config))
+    }
+    return map
+  }, [config])
 
   useEffect(() => {
-    const timer = setInterval(() => setTick((t) => t + 1), pollIntervalMs)
+    if (!autoRefresh) return
+    const timer = setInterval(() => {
+      setTick((t) => t + 1)
+    }, pollIntervalMs)
     return () => clearInterval(timer)
-  }, [pollIntervalMs])
+  }, [autoRefresh, pollIntervalMs])
+
+  useEffect(() => {
+    setLastRefreshAt(new Date().toISOString())
+  }, [tick])
 
   const runs = useMemo(() => loadRuns(db), [db, tick])
   const selectedIndex = runs.findIndex((run) => run.id === selectedRunId)
   const selectedRun = selectedIndex >= 0 ? (runs[selectedIndex] ?? null) : (runs[0] ?? null)
   const selectedRunEvents = useMemo(
-    () => (selectedRun ? loadAgentEvents(db, selectedRun.id, 12) : []),
-    [db, tick, selectedRun?.id],
+    () => (selectedRun ? loadAgentEvents(db, selectedRun.id, runsViewMode === 'focus' ? 40 : 10) : []),
+    [db, tick, selectedRun?.id, runsViewMode],
   )
   const mergeBatches = useMemo(() => loadMergeBatches(db), [db, tick])
   const stats = useMemo(() => loadTuiStats(db), [db, tick])
@@ -113,6 +110,94 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       setSelectedRunId(runs[0]!.id)
     }
   }, [runs, selectedRunId])
+
+  useEffect(() => {
+    const now = Date.now()
+    if (now - lastHydrationAt.current < 3000) {
+      return
+    }
+
+    const missing = collectMissingTitleTargets(
+      runs,
+      titleLookup,
+      attemptedIssueKeys.current,
+      attemptedPrKeys.current,
+      6,
+    )
+
+    if (missing.issues.length === 0 && missing.prs.length === 0) {
+      return
+    }
+
+    lastHydrationAt.current = now
+
+    for (const issue of missing.issues) {
+      attemptedIssueKeys.current.add(issue.key)
+    }
+    for (const pr of missing.prs) {
+      attemptedPrKeys.current.add(pr.key)
+    }
+
+    void (async () => {
+      const nextIssueTitles: Record<string, string> = {}
+      const nextPrTitles: Record<string, string> = {}
+
+      const updateIssueStmt = db.prepare(
+        `UPDATE runs
+         SET issue_title = ?
+         WHERE repo = ?
+           AND issue_number = ?
+           AND (issue_title IS NULL OR TRIM(issue_title) = '')`,
+      )
+      const updatePrStmt = db.prepare(
+        `UPDATE runs
+         SET pr_title = ?
+         WHERE repo = ?
+           AND pr_number = ?
+           AND (pr_title IS NULL OR TRIM(pr_title) = '')`,
+      )
+
+      for (const target of missing.issues) {
+        const forge = forgeByRepo.get(target.repo)
+        if (!forge) continue
+        try {
+          const issue = await forge.getIssue(target.repo, target.issueNumber)
+          if (hasReadableTitle(issue.title)) {
+            const title = issue.title.trim()
+            nextIssueTitles[target.key] = title
+            updateIssueStmt.run(title, target.repo, target.issueNumber)
+          }
+        } catch {
+          // Best effort title hydration; keep previous UI value when unavailable.
+        }
+      }
+
+      for (const target of missing.prs) {
+        const forge = forgeByRepo.get(target.repo)
+        if (!forge?.getPR) continue
+        try {
+          const pr = await forge.getPR(target.repo, target.prNumber)
+          if (hasReadableTitle(pr.title)) {
+            const title = pr.title.trim()
+            nextPrTitles[target.key] = title
+            updatePrStmt.run(title, target.repo, target.prNumber)
+          }
+        } catch {
+          // Best effort title hydration; keep previous UI value when unavailable.
+        }
+      }
+
+      if (Object.keys(nextIssueTitles).length === 0 && Object.keys(nextPrTitles).length === 0) {
+        return
+      }
+
+      setTitleLookup((current) => ({
+        issues: { ...current.issues, ...nextIssueTitles },
+        prs: { ...current.prs, ...nextPrTitles },
+      }))
+      setTick((t) => t + 1)
+    })()
+  }, [db, forgeByRepo, runs, titleLookup])
 
   const moveSelection = useCallback((direction: -1 | 1) => {
     if (runs.length === 0) return
@@ -257,6 +342,16 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
         moveSelection(-1)
         return
       }
+      if (input === 'o' || key.return) {
+        if (selectedRun) {
+          setRunsViewMode((mode) => (mode === 'list' ? 'focus' : 'list'))
+        }
+        return
+      }
+      if (key.escape && runsViewMode === 'focus') {
+        setRunsViewMode('list')
+        return
+      }
     }
 
     if (input === 'f') {
@@ -264,9 +359,23 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       return
     }
 
+    if (activeTab === 'stats' && input === 'a') {
+      setAutoRefresh((current) => {
+        const next = !current
+        setStatusLine(next ? 'Auto-refresh enabled' : 'Auto-refresh paused')
+        return next
+      })
+      return
+    }
+
     if (actionState.busy) {
       return
     }
+
+    if (activeTab !== 'runs') {
+      return
+    }
+
     if (input === 'r') {
       void runRetry()
       return
@@ -288,15 +397,18 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
     }
   })
 
+  const runsVisible = runsViewMode === 'focus' ? 8 : 10
+
   return (
     <Box flexDirection="column" padding={1}>
       <Header
+        activeTab={activeTab}
         pollIntervalMs={pollIntervalMs}
         dryRun={dryRun}
         status={stats}
+        autoRefresh={autoRefresh}
+        lastRefreshAt={lastRefreshAt}
       />
-
-      <TabBar activeTab={activeTab} />
 
       <Box marginBottom={1}>
         <Text color={actionState.busy ? 'yellow' : 'gray'}>
@@ -308,167 +420,192 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
         ? (
             <RunsView
               runs={runs}
+              selectedIndex={selectedIndex < 0 ? 0 : selectedIndex}
               selectedRun={selectedRun}
               selectedRunEvents={selectedRunEvents}
               mergeBatches={mergeBatches}
               stats={stats}
+              titleLookup={titleLookup}
+              mode={runsViewMode}
+              maxVisibleRuns={runsVisible}
             />
           )
         : (
-            <StatsView stats={stats} />
+            <StatsView
+              stats={stats}
+              autoRefresh={autoRefresh}
+              pollIntervalMs={pollIntervalMs}
+              lastRefreshAt={lastRefreshAt}
+            />
           )}
 
-      <ActionsBar activeTab={activeTab} busy={actionState.busy} />
+      <ActionsBar
+        activeTab={activeTab}
+        busy={actionState.busy}
+        runFocused={runsViewMode === 'focus'}
+        autoRefresh={autoRefresh}
+      />
     </Box>
   )
 }
 
 interface HeaderProps {
+  activeTab: TabId
   pollIntervalMs: number
   dryRun: boolean
   status: TuiStatsSnapshot
+  autoRefresh: boolean
+  lastRefreshAt: string
 }
 
-function Header({ pollIntervalMs, dryRun, status }: HeaderProps): React.ReactElement {
+function Header({ activeTab, pollIntervalMs, dryRun, status, autoRefresh, lastRefreshAt }: HeaderProps): React.ReactElement {
   return (
-    <Box flexDirection="column" marginBottom={1}>
+    <Box flexDirection="column" marginBottom={1} borderStyle="round" borderColor="cyan" paddingX={1}>
       <Box>
-        <Text bold color="cyan">night-orch monitor</Text>
+        <Text bold color="cyan">NIGHT-ORCH CONTROL ROOM</Text>
         <Text color="gray">  refresh {pollIntervalMs / 1000}s</Text>
         {dryRun && <Text color="yellow">  [dry-run]</Text>}
-        <Text color="gray">  updated {formatTime(status.updatedAt)}</Text>
+        <Text color={autoRefresh ? 'green' : 'yellow'}>  {autoRefresh ? '● live' : '○ paused'}</Text>
+        <Text color="gray">  updated {formatTime(lastRefreshAt)}</Text>
+      </Box>
+      <Box>
+        {TABS.map((tab) => (
+          <Box key={tab.id} marginRight={2}>
+            <Text color={activeTab === tab.id ? 'cyan' : 'gray'}>
+              {activeTab === tab.id ? '▸' : ' '}[{tab.hotkey}] {tab.label}
+            </Text>
+          </Box>
+        ))}
       </Box>
       <Text color="gray">
-        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  daily cost ${status.cost.todayCostUsd.toFixed(2)}
+        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  running {status.overview.runningRuns}  cost today ${status.cost.todayCostUsd.toFixed(2)}
       </Text>
-    </Box>
-  )
-}
-
-interface TabBarProps {
-  activeTab: TabId
-}
-
-function TabBar({ activeTab }: TabBarProps): React.ReactElement {
-  return (
-    <Box marginBottom={1}>
-      {TABS.map((tab, index) => (
-        <Box key={tab.id} marginRight={2}>
-          <Text color={activeTab === tab.id ? 'cyan' : 'gray'}>
-            {activeTab === tab.id ? '▸' : ' '}[{tab.hotkey}] {tab.label}
-          </Text>
-          {index < TABS.length - 1 && <Text color="gray"> </Text>}
-        </Box>
-      ))}
     </Box>
   )
 }
 
 interface RunsViewProps {
   runs: RunListRow[]
+  selectedIndex: number
   selectedRun: RunListRow | null
   selectedRunEvents: AgentEventRow[]
   mergeBatches: MergeBatchRow[]
   stats: TuiStatsSnapshot
+  titleLookup: TitleLookup
+  mode: RunsViewMode
+  maxVisibleRuns: number
 }
 
-function RunsView({ runs, selectedRun, selectedRunEvents, mergeBatches, stats }: RunsViewProps): React.ReactElement {
+function RunsView({
+  runs,
+  selectedIndex,
+  selectedRun,
+  selectedRunEvents,
+  mergeBatches,
+  stats,
+  titleLookup,
+  mode,
+  maxVisibleRuns,
+}: RunsViewProps): React.ReactElement {
+  if (mode === 'focus') {
+    return (
+      <FocusedRunView
+        selectedRun={selectedRun}
+        selectedRunEvents={selectedRunEvents}
+        titleLookup={titleLookup}
+        stats={stats}
+        mergeBatches={mergeBatches}
+      />
+    )
+  }
+
+  const windowed = sliceWindow(runs, selectedIndex, maxVisibleRuns)
+
   return (
     <>
       <Box marginBottom={1}>
-        <Box flexDirection="column" width="42%">
+        <Box width="72%" flexDirection="column" marginRight={1}>
           <Text bold>Runs ({runs.length})</Text>
           {runs.length === 0 && <Text color="gray">  No runs found</Text>}
-          {runs.map((run, index) => {
+          {windowed.rows.map((run, idx) => {
+            const absoluteIndex = windowed.start + idx
             const selected = selectedRun?.id === run.id
-            const marker = selected ? '>' : ' '
+            const issueTitle = resolveIssueTitle(run, titleLookup) ?? '(title unavailable)'
+            const prTitle = resolvePrTitle(run, titleLookup)
             const statusColor = STATUS_COLORS[run.status] ?? 'white'
-            const idShort = run.id.replace('run-', '').slice(0, 8)
+
             return (
-              <Text key={run.id}>
-                <Text color={selected ? 'cyan' : 'gray'}>{marker}</Text>
-                {' '}
-                <Text color="gray">{String(index + 1).padStart(2, '0')}</Text>
-                {' '}
-                <Text color={statusColor}>{run.status.padEnd(11)}</Text>
-                {' '}
-                <Text>{run.repo}#{run.issue_number}</Text>
-                {' '}
-                <Text color="gray">{truncate(run.issue_title ?? '(title unavailable)', 26)}</Text>
-                {' '}
-                {run.pr_number !== null && (
-                  <>
-                    <Text color="cyan">PR #{run.pr_number}</Text>
-                    {' '}
-                    <Text color="gray">{truncate(run.pr_title ?? '(title unavailable)', 18)}</Text>
-                    {' '}
-                  </>
-                )}
-                <Text color="gray">{idShort}</Text>
-              </Text>
+              <Box key={run.id} flexDirection="column">
+                <Text>
+                  <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
+                  {' '}
+                  <Text color="gray">{String(absoluteIndex + 1).padStart(2, '0')}</Text>
+                  {' '}
+                  <Text color={statusColor}>{run.status.padEnd(11)}</Text>
+                  {' '}
+                  <Text>{run.repo}#{run.issue_number}</Text>
+                  {'  '}
+                  <Text>{truncate(issueTitle, 58)}</Text>
+                </Text>
+                <Text color="gray">
+                  {'    '}
+                  <Text>{run.pr_number !== null ? `PR #${run.pr_number} ${truncate(prTitle ?? '(title unavailable)', 40)}` : 'No PR yet'}</Text>
+                  {'  '}
+                  <Text>phase {run.current_phase ?? '-'}</Text>
+                  {'  '}
+                  <Text>iter {run.iteration_count ?? 0}</Text>
+                  {'  '}
+                  <Text>cost ${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+                  {'  '}
+                  <Text>{formatTime(run.updated_at)}</Text>
+                </Text>
+              </Box>
             )
           })}
+          {runs.length > windowed.rows.length && (
+            <Text color="gray">  showing {windowed.start + 1}-{windowed.start + windowed.rows.length} of {runs.length}</Text>
+          )}
         </Box>
 
-        <Box flexDirection="column" width="58%">
-          <Text bold>Selected Run</Text>
-          {!selectedRun && <Text color="gray">  Select a run to inspect</Text>}
+        <Box width="28%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+          <Text bold color="cyan">Issue Preview</Text>
+          {!selectedRun && <Text color="gray">Select a run to inspect</Text>}
           {selectedRun && (
             <>
-              <Text>
-                {'  '}
-                <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
-                {'  '}
-                <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
-              </Text>
-              <Text color="gray">
-                {'  '}
-                {selectedRun.issue_title ?? '(title unavailable)'}
-              </Text>
+              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
+              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
+              <Text>{truncate(resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)', 46)}</Text>
               {selectedRun.pr_number !== null && (
-                <Text color="gray">
-                  {'  '}
-                  PR #{selectedRun.pr_number}: {selectedRun.pr_title ?? '(title unavailable)'}
-                </Text>
-              )}
-              <Text color="gray">
-                {'  '}phase {selectedRun.current_phase ?? '-'}  iter {selectedRun.iteration_count ?? 0}  cost ${(selectedRun.estimated_cost_usd ?? 0).toFixed(2)}
-              </Text>
-              <Text color="gray">
-                {'  '}run {selectedRun.id}  updated {formatTime(selectedRun.updated_at)}
-              </Text>
-              {selectedRun.last_error && (
-                <Text color="red">{'  '}last error: {truncate(selectedRun.last_error, 96)}</Text>
+                <Text color="gray">PR #{selectedRun.pr_number}: {truncate(resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)', 36)}</Text>
               )}
 
               <Box marginTop={1} flexDirection="column">
-                <Text bold>Agent Stream</Text>
-                {selectedRunEvents.length === 0 && <Text color="gray">  No agent events</Text>}
-                {selectedRunEvents.map((event) => {
+                <Text bold>Log Glimpse</Text>
+                {selectedRunEvents.length === 0 && <Text color="gray">No agent events yet</Text>}
+                {selectedRunEvents.slice(-5).map((event) => {
                   const color = EVENT_COLORS[event.event_type] ?? 'gray'
                   return (
                     <Text key={event.id}>
-                      {'  '}
-                      <Text color="gray">[{formatTime(event.created_at)}]</Text>
+                      <Text color="gray">{formatTime(event.created_at)}</Text>
                       {' '}
-                      <Text color="gray">{event.role}</Text>
+                      <Text color={color}>{truncate(event.event_type, 10)}</Text>
                       {' '}
-                      <Text color={color}>{event.event_type}</Text>
-                      {' '}
-                      <Text>{formatEventSummary(event)}</Text>
+                      <Text>{truncate(formatEventSummary(event), 22)}</Text>
                     </Text>
                   )
                 })}
               </Box>
+
+              <Text color="gray">Press o or Enter for expanded view</Text>
             </>
           )}
         </Box>
       </Box>
 
       <Box marginBottom={1} flexDirection="column">
-        <Text bold>System</Text>
+        <Text bold>System Snapshot</Text>
         <Text color="gray">
-          {'  '}active {stats.overview.activeRuns}  daily cost ${stats.cost.todayCostUsd.toFixed(2)}  merge queue {mergeBatches.length}
+          {'  '}active {stats.overview.activeRuns}  running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}  merge queue {mergeBatches.length}
         </Text>
         {mergeBatches.slice(0, 3).map((batch) => (
           <Text key={batch.id}>
@@ -485,150 +622,182 @@ function RunsView({ runs, selectedRun, selectedRunEvents, mergeBatches, stats }:
   )
 }
 
-interface StatsViewProps {
+interface FocusedRunViewProps {
+  selectedRun: RunListRow | null
+  selectedRunEvents: AgentEventRow[]
+  titleLookup: TitleLookup
   stats: TuiStatsSnapshot
+  mergeBatches: MergeBatchRow[]
 }
 
-function StatsView({ stats }: StatsViewProps): React.ReactElement {
+function FocusedRunView({ selectedRun, selectedRunEvents, titleLookup, stats, mergeBatches }: FocusedRunViewProps): React.ReactElement {
+  return (
+    <Box marginBottom={1} flexDirection="column">
+      <Text bold>Run Detail</Text>
+      {!selectedRun && <Text color="gray">No run selected</Text>}
+      {selectedRun && (
+        <>
+          <Box>
+            <Box width="35%" flexDirection="column" marginRight={1} borderStyle="single" borderColor="gray" paddingX={1}>
+              <Text bold color="cyan">Overview</Text>
+              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
+              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
+              <Text>{resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
+              {selectedRun.pr_number !== null && (
+                <Text color="gray">PR #{selectedRun.pr_number}: {resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
+              )}
+              <Text color="gray">phase {selectedRun.current_phase ?? '-'}</Text>
+              <Text color="gray">iter {selectedRun.iteration_count ?? 0}  cost ${(selectedRun.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+              <Text color="gray">updated {formatTime(selectedRun.updated_at)}</Text>
+              {selectedRun.last_error && <Text color="red">error: {truncate(selectedRun.last_error, 90)}</Text>}
+              <Box marginTop={1} flexDirection="column">
+                <Text bold>System</Text>
+                <Text color="gray">active runs {stats.overview.activeRuns}</Text>
+                <Text color="gray">merge queue {mergeBatches.length}</Text>
+              </Box>
+            </Box>
+
+            <Box width="65%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+              <Text bold color="cyan">Agent Stream ({selectedRunEvents.length})</Text>
+              {selectedRunEvents.length === 0 && <Text color="gray">No agent events</Text>}
+              {selectedRunEvents.map((event) => {
+                const color = EVENT_COLORS[event.event_type] ?? 'gray'
+                return (
+                  <Text key={event.id}>
+                    <Text color="gray">[{formatTime(event.created_at)}]</Text>
+                    {' '}
+                    <Text color="gray">{event.role}</Text>
+                    {' '}
+                    <Text color={color}>{event.event_type}</Text>
+                    {' '}
+                    <Text>{formatEventSummary(event)}</Text>
+                  </Text>
+                )
+              })}
+            </Box>
+          </Box>
+          <Text color="gray">Press Esc or o to return to list</Text>
+        </>
+      )}
+    </Box>
+  )
+}
+
+interface StatsViewProps {
+  stats: TuiStatsSnapshot
+  autoRefresh: boolean
+  pollIntervalMs: number
+  lastRefreshAt: string
+}
+
+function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }: StatsViewProps): React.ReactElement {
+  const costSeries = stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd)
+
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>Overview</Text>
-        <Text color="gray">
-          {'  '}total {stats.overview.totalRuns}  active {stats.overview.activeRuns}  running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}
-        </Text>
-        <Text color="gray">
-          {'  '}completed {stats.overview.completedRuns}  review_ready {stats.overview.reviewReadyRuns}  blocked {stats.overview.blockedRuns}  error {stats.overview.errorRuns}
-        </Text>
-        <Text color="gray">{'  '}status mix {formatStatusMix(stats.statusCounts)}</Text>
+      <Box marginBottom={1}>
+        <Text color={autoRefresh ? 'green' : 'yellow'}>{autoRefresh ? '● stats polling active' : '○ stats polling paused'}</Text>
+        <Text color="gray">  interval {pollIntervalMs / 1000}s</Text>
+        <Text color="gray">  last refresh {formatTime(lastRefreshAt)}</Text>
       </Box>
 
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>Throughput</Text>
-        <Text color="gray">
-          {'  '}runs 24h {stats.throughput.runs24h}  7d {stats.throughput.runs7d}  30d {stats.throughput.runs30d}
-        </Text>
-        <Text color="gray">
-          {'  '}terminal 7d completed {stats.throughput.completed7d} blocked {stats.throughput.blocked7d} error {stats.throughput.error7d} success {stats.throughput.successRate7d.toFixed(1)}%
-        </Text>
-        <Text color="gray">
-          {'  '}avg duration 7d {formatMinutes(stats.throughput.avgDurationMinutes7d)}  avg iterations 7d {stats.throughput.avgIterations7d.toFixed(2)}
-        </Text>
-        <Text color="gray">
-          {'  '}active phases {stats.phaseCounts.length === 0 ? '-' : stats.phaseCounts.map((row) => `${row.phase}:${row.count}`).join('  ')}
-        </Text>
+      <Box marginBottom={1}>
+        <StatCard title="Run Health" width="50%" marginRight={1}>
+          <Text>total {stats.overview.totalRuns}  active {stats.overview.activeRuns}</Text>
+          <Text color="gray">running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}</Text>
+          <Text color="gray">review_ready {stats.overview.reviewReadyRuns}  completed {stats.overview.completedRuns}</Text>
+          <Text color="gray">blocked {stats.overview.blockedRuns}  error {stats.overview.errorRuns}</Text>
+          <Text color="gray">mix {formatStatusMix(stats.statusCounts)}</Text>
+        </StatCard>
+
+        <StatCard title="Throughput" width="50%">
+          <Text>runs 24h {stats.throughput.runs24h}  7d {stats.throughput.runs7d}  30d {stats.throughput.runs30d}</Text>
+          <Text color="gray">completed 7d {stats.throughput.completed7d}</Text>
+          <Text color="gray">blocked 7d {stats.throughput.blocked7d}  error 7d {stats.throughput.error7d}</Text>
+          <Text color="gray">success 7d {stats.throughput.successRate7d.toFixed(1)}%</Text>
+          <Text color="gray">avg duration {formatMinutes(stats.throughput.avgDurationMinutes7d)}  avg iter {stats.throughput.avgIterations7d.toFixed(2)}</Text>
+        </StatCard>
       </Box>
 
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>Cost</Text>
-        <Text color="gray">
-          {'  '}today ${stats.cost.todayCostUsd.toFixed(2)} ({stats.cost.todayRunCount} runs)  7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}  avg/day ${stats.cost.avgDailyCost7d.toFixed(2)}
-        </Text>
-        {stats.cost.dailyHistory.length === 0 && <Text color="gray">  No daily cost history</Text>}
-        {stats.cost.dailyHistory.slice().reverse().map((row) => (
-          <Text key={row.date} color="gray">
-            {'  '}
-            <Text>{row.date}</Text>
-            {'  '}
-            <Text>${row.totalCostUsd.toFixed(2)}</Text>
-            {'  '}
-            <Text>{row.runCount} run(s)</Text>
+      <Box marginBottom={1}>
+        <StatCard title="Cost" width="50%" marginRight={1}>
+          <Text>today ${stats.cost.todayCostUsd.toFixed(2)} ({stats.cost.todayRunCount} runs)</Text>
+          <Text color="gray">7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
+          <Text color="gray">avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
+          <Text color="gray">trend {buildSparkline(costSeries)}</Text>
+          {stats.cost.dailyHistory.slice(0, 4).map((row) => (
+            <Text key={row.date} color="gray">{row.date}: ${row.totalCostUsd.toFixed(2)} ({row.runCount})</Text>
+          ))}
+        </StatCard>
+
+        <StatCard title="Agent Activity" width="50%">
+          <Text>events total {stats.agents.eventsTotal}</Text>
+          <Text color="gray">24h {stats.agents.events24h}  7d {stats.agents.events7d}</Text>
+          <Text color="gray">tool calls 24h {stats.agents.toolCalls24h}</Text>
+          <Text color="gray">thinking 24h {stats.agents.thinking24h}  runs 7d {stats.agents.uniqueRuns7d}</Text>
+          <Text color="gray">
+            roles {stats.agents.roleBreakdown7d.length === 0 ? '-' : stats.agents.roleBreakdown7d.map((row) => `${row.role}:${row.events}`).join('  ')}
           </Text>
-        ))}
+        </StatCard>
       </Box>
 
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>Agent Activity</Text>
-        <Text color="gray">
-          {'  '}events total {stats.agents.eventsTotal}  24h {stats.agents.events24h}  7d {stats.agents.events7d}  runs 7d {stats.agents.uniqueRuns7d}
-        </Text>
-        <Text color="gray">
-          {'  '}tool calls 24h {stats.agents.toolCalls24h}  thinking 24h {stats.agents.thinking24h}
-        </Text>
-        <Text color="gray">
-          {'  '}role mix 7d {stats.agents.roleBreakdown7d.length === 0 ? '-' : stats.agents.roleBreakdown7d.map((row) => `${row.role}:${row.events}`).join('  ')}
-        </Text>
-      </Box>
+      <Box>
+        <StatCard title="Merge Queue" width="35%" marginRight={1}>
+          <Text>active batches {stats.queue.activeBatches}</Text>
+          <Text color="gray">
+            statuses {stats.queue.statuses.length === 0 ? '-' : stats.queue.statuses.map((row) => `${row.status}:${row.count}`).join('  ')}
+          </Text>
+          <Text color="gray">
+            active phases {stats.phaseCounts.length === 0 ? '-' : stats.phaseCounts.map((row) => `${row.phase}:${row.count}`).join('  ')}
+          </Text>
+        </StatCard>
 
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>Merge Queue</Text>
-        <Text color="gray">
-          {'  '}active batches {stats.queue.activeBatches}  statuses {stats.queue.statuses.length === 0 ? '-' : stats.queue.statuses.map((row) => `${row.status}:${row.count}`).join('  ')}
-        </Text>
-      </Box>
-
-      <Box flexDirection="column">
-        <Text bold>Top Repos (30d)</Text>
-        {stats.topRepos30d.length === 0 && <Text color="gray">  No run history</Text>}
-        {stats.topRepos30d.map((row) => {
-          const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
-          const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
-          const errorPct = terminalCount > 0 ? (row.errorRuns / terminalCount) * 100 : 0
-          return (
-            <Text key={row.repo}>
-              {'  '}
-              <Text>{truncate(row.repo, 26)}</Text>
-              {'  '}
-              <Text color="gray">runs {row.totalRuns}</Text>
-              {'  '}
-              <Text color="green">ok {successPct.toFixed(0)}%</Text>
-              {'  '}
-              <Text color="red">err {errorPct.toFixed(0)}%</Text>
-              {'  '}
-              <Text color="gray">cost ${row.totalCostUsd.toFixed(2)}</Text>
-              {'  '}
-              <Text color="gray">iter {row.avgIterations.toFixed(1)}</Text>
-            </Text>
-          )
-        })}
+        <StatCard title="Top Repositories (30d)" width="65%">
+          {stats.topRepos30d.length === 0 && <Text color="gray">No run history</Text>}
+          {stats.topRepos30d.map((row) => {
+            const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
+            const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
+            return (
+              <Text key={row.repo}>
+                <Text>{truncate(row.repo, 28)}</Text>
+                {'  '}
+                <Text color="gray">runs {row.totalRuns}</Text>
+                {'  '}
+                <Text color="green">ok {successPct.toFixed(0)}%</Text>
+                {'  '}
+                <Text color="gray">cost ${row.totalCostUsd.toFixed(2)}</Text>
+                {'  '}
+                <Text color="gray">iter {row.avgIterations.toFixed(1)}</Text>
+              </Text>
+            )
+          })}
+        </StatCard>
       </Box>
     </Box>
   )
 }
 
-function loadRuns(db: Database.Database): RunListRow[] {
-  return db
-    .prepare(
-      `SELECT id, repo, issue_number, issue_title, status, current_phase, iteration_count, estimated_cost_usd, last_error, pr_number, pr_title, updated_at
-       FROM runs
-       ORDER BY
-         CASE status
-           WHEN 'running' THEN 0
-           WHEN 'queued' THEN 1
-           WHEN 'review_ready' THEN 2
-           WHEN 'blocked' THEN 3
-           WHEN 'error' THEN 4
-           ELSE 5
-         END,
-         datetime(updated_at) DESC
-       LIMIT 24`,
-    )
-    .all() as RunListRow[]
+interface StatCardProps {
+  title: string
+  width: string
+  marginRight?: number
+  children: React.ReactNode
 }
 
-function loadAgentEvents(db: Database.Database, runId: string, maxLines: number): AgentEventRow[] {
-  const rows = db
-    .prepare(
-      `SELECT id, run_id, role, event_type, data, created_at
-       FROM agent_events
-       WHERE run_id = ?
-       ORDER BY id DESC
-       LIMIT ?`,
-    )
-    .all(runId, maxLines) as AgentEventRow[]
-  return [...rows].reverse()
-}
-
-function loadMergeBatches(db: Database.Database): MergeBatchRow[] {
-  return db
-    .prepare(
-      `SELECT id, repo, status, pr_numbers
-       FROM merge_batches
-       WHERE status NOT IN ('passed', 'failed')
-       ORDER BY created_at DESC
-       LIMIT 5`,
-    )
-    .all() as MergeBatchRow[]
+function StatCard({ title, width, marginRight = 0, children }: StatCardProps): React.ReactElement {
+  return (
+    <Box
+      width={width}
+      marginRight={marginRight}
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="gray"
+      paddingX={1}
+    >
+      <Text bold color="cyan">{title}</Text>
+      {children}
+    </Box>
+  )
 }
 
 function formatStatusMix(statuses: StatusAggregate[]): string {

--- a/src/cli/tui/data.ts
+++ b/src/cli/tui/data.ts
@@ -1,0 +1,114 @@
+import type Database from 'better-sqlite3'
+
+export interface RunListRow {
+  id: string
+  repo: string
+  issue_number: number
+  issue_title: string | null
+  status: string
+  current_phase: string | null
+  iteration_count: number | null
+  estimated_cost_usd: number | null
+  last_error: string | null
+  pr_number: number | null
+  pr_title: string | null
+  updated_at: string
+}
+
+export interface AgentEventRow {
+  id: number
+  run_id: string
+  role: string
+  event_type: string
+  data: string | null
+  created_at: string
+}
+
+export interface MergeBatchRow {
+  id: string
+  repo: string
+  status: string
+  pr_numbers: string
+}
+
+export function loadRuns(db: Database.Database, limit = 24): RunListRow[] {
+  return db
+    .prepare(
+      `SELECT
+         r.id,
+         r.repo,
+         r.issue_number,
+         COALESCE(
+           NULLIF(TRIM(r.issue_title), ''),
+           (
+             SELECT NULLIF(TRIM(r2.issue_title), '')
+             FROM runs r2
+             WHERE r2.repo = r.repo
+               AND r2.issue_number = r.issue_number
+               AND r2.issue_title IS NOT NULL
+               AND TRIM(r2.issue_title) != ''
+             ORDER BY datetime(r2.updated_at) DESC
+             LIMIT 1
+           )
+         ) AS issue_title,
+         r.status,
+         r.current_phase,
+         r.iteration_count,
+         r.estimated_cost_usd,
+         r.last_error,
+         r.pr_number,
+         COALESCE(
+           NULLIF(TRIM(r.pr_title), ''),
+           (
+             SELECT NULLIF(TRIM(rp.pr_title), '')
+             FROM runs rp
+             WHERE rp.repo = r.repo
+               AND r.pr_number IS NOT NULL
+               AND rp.pr_number = r.pr_number
+               AND rp.pr_title IS NOT NULL
+               AND TRIM(rp.pr_title) != ''
+             ORDER BY datetime(rp.updated_at) DESC
+             LIMIT 1
+           )
+         ) AS pr_title,
+         r.updated_at
+       FROM runs r
+       ORDER BY
+         CASE r.status
+           WHEN 'running' THEN 0
+           WHEN 'queued' THEN 1
+           WHEN 'review_ready' THEN 2
+           WHEN 'blocked' THEN 3
+           WHEN 'error' THEN 4
+           ELSE 5
+         END,
+         datetime(r.updated_at) DESC
+       LIMIT ?`,
+    )
+    .all(limit) as RunListRow[]
+}
+
+export function loadAgentEvents(db: Database.Database, runId: string, maxLines: number): AgentEventRow[] {
+  const rows = db
+    .prepare(
+      `SELECT id, run_id, role, event_type, data, created_at
+       FROM agent_events
+       WHERE run_id = ?
+       ORDER BY id DESC
+       LIMIT ?`,
+    )
+    .all(runId, maxLines) as AgentEventRow[]
+  return [...rows].reverse()
+}
+
+export function loadMergeBatches(db: Database.Database, limit = 5): MergeBatchRow[] {
+  return db
+    .prepare(
+      `SELECT id, repo, status, pr_numbers
+       FROM merge_batches
+       WHERE status NOT IN ('passed', 'failed')
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(limit) as MergeBatchRow[]
+}

--- a/src/cli/tui/titles.ts
+++ b/src/cli/tui/titles.ts
@@ -1,0 +1,87 @@
+import type { RunListRow } from './data.js'
+
+export interface TitleLookup {
+  issues: Record<string, string>
+  prs: Record<string, string>
+}
+
+export interface MissingIssueTitleTarget {
+  key: string
+  repo: string
+  issueNumber: number
+}
+
+export interface MissingPrTitleTarget {
+  key: string
+  repo: string
+  prNumber: number
+}
+
+export interface MissingTitleTargets {
+  issues: MissingIssueTitleTarget[]
+  prs: MissingPrTitleTarget[]
+}
+
+export function issueKey(repo: string, issueNumber: number): string {
+  return `${repo}#${issueNumber}`
+}
+
+export function prKey(repo: string, prNumber: number): string {
+  return `${repo}#${prNumber}`
+}
+
+export function hasReadableTitle(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export function resolveIssueTitle(run: RunListRow, lookup: TitleLookup): string | null {
+  if (hasReadableTitle(run.issue_title)) {
+    return run.issue_title.trim()
+  }
+  return lookup.issues[issueKey(run.repo, run.issue_number)] ?? null
+}
+
+export function resolvePrTitle(run: RunListRow, lookup: TitleLookup): string | null {
+  if (run.pr_number === null) return null
+  if (hasReadableTitle(run.pr_title)) {
+    return run.pr_title.trim()
+  }
+  return lookup.prs[prKey(run.repo, run.pr_number)] ?? null
+}
+
+export function collectMissingTitleTargets(
+  runs: RunListRow[],
+  lookup: TitleLookup,
+  attemptedIssueKeys: ReadonlySet<string>,
+  attemptedPrKeys: ReadonlySet<string>,
+  maxItems = 8,
+): MissingTitleTargets {
+  const issueTargets: MissingIssueTitleTarget[] = []
+  const prTargets: MissingPrTitleTarget[] = []
+  const seenIssue = new Set<string>()
+  const seenPr = new Set<string>()
+
+  for (const run of runs) {
+    if (issueTargets.length >= maxItems && prTargets.length >= maxItems) {
+      break
+    }
+
+    if (!hasReadableTitle(run.issue_title) && issueTargets.length < maxItems) {
+      const key = issueKey(run.repo, run.issue_number)
+      if (!lookup.issues[key] && !attemptedIssueKeys.has(key) && !seenIssue.has(key)) {
+        seenIssue.add(key)
+        issueTargets.push({ key, repo: run.repo, issueNumber: run.issue_number })
+      }
+    }
+
+    if (run.pr_number !== null && !hasReadableTitle(run.pr_title) && prTargets.length < maxItems) {
+      const key = prKey(run.repo, run.pr_number)
+      if (!lookup.prs[key] && !attemptedPrKeys.has(key) && !seenPr.has(key)) {
+        seenPr.add(key)
+        prTargets.push({ key, repo: run.repo, prNumber: run.pr_number })
+      }
+    }
+  }
+
+  return { issues: issueTargets, prs: prTargets }
+}

--- a/src/cli/tui/view-model.ts
+++ b/src/cli/tui/view-model.ts
@@ -1,0 +1,31 @@
+export interface WindowedSlice<T> {
+  start: number
+  rows: T[]
+}
+
+export function sliceWindow<T>(rows: T[], selectedIndex: number, windowSize: number): WindowedSlice<T> {
+  if (rows.length === 0) return { start: 0, rows: [] }
+  const safeWindow = Math.max(1, windowSize)
+  const safeIndex = Math.max(0, Math.min(rows.length - 1, selectedIndex))
+  const half = Math.floor(safeWindow / 2)
+  const maxStart = Math.max(0, rows.length - safeWindow)
+  const start = Math.min(maxStart, Math.max(0, safeIndex - half))
+  return {
+    start,
+    rows: rows.slice(start, start + safeWindow),
+  }
+}
+
+export function buildSparkline(values: number[]): string {
+  if (values.length === 0) return '-'
+  const max = Math.max(...values, 0)
+  if (max <= 0) return '▁'.repeat(values.length)
+  const bars = '▁▂▃▄▅▆▇█'
+  return values
+    .map((value) => {
+      const ratio = Math.max(0, Math.min(1, value / max))
+      const index = Math.round(ratio * (bars.length - 1))
+      return bars[index] ?? '▁'
+    })
+    .join('')
+}

--- a/test/cli/tui/actions-bar.test.ts
+++ b/test/cli/tui/actions-bar.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildActionHints } from '../../../src/cli/tui/actions-bar.js'
+
+describe('buildActionHints', () => {
+  it('shows run-specific controls on runs tab', () => {
+    const hints = buildActionHints({
+      activeTab: 'runs',
+      busy: false,
+      runFocused: false,
+      autoRefresh: true,
+    })
+
+    expect(hints.line1).toContain('[j/k]select')
+    expect(hints.line1).toContain('[o/enter]open')
+    expect(hints.line2).toContain('[r]etry')
+    expect(hints.line2).toContain('[b]rebase')
+  })
+
+  it('shows stats polling controls on stats tab without retry/rebase', () => {
+    const hints = buildActionHints({
+      activeTab: 'stats',
+      busy: false,
+      runFocused: false,
+      autoRefresh: false,
+    })
+
+    expect(hints.line1).toContain('[a]toggle auto-refresh')
+    expect(hints.line2).toContain('polling paused')
+    expect(hints.line2).not.toContain('retry')
+    expect(hints.line2).not.toContain('rebase')
+  })
+})

--- a/test/cli/tui/data.test.ts
+++ b/test/cli/tui/data.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type Database from 'better-sqlite3'
+import { initDatabase } from '../../../src/state/db.js'
+import { loadRuns } from '../../../src/cli/tui/data.js'
+
+describe('loadRuns', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'night-orch-tui-data-'))
+    db = initDatabase(join(tmpDir, 'tui.db'))
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('falls back to latest known issue/pr titles for the same issue and PR', () => {
+    const insertRun = db.prepare(
+      `INSERT INTO runs (
+        id, repo, issue_number, issue_title, status, current_phase, iteration_count, estimated_cost_usd,
+        pr_number, pr_title, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+
+    insertRun.run(
+      'run-old',
+      'org/repo',
+      42,
+      'Fix retries in queue handling',
+      'completed',
+      'publish',
+      2,
+      1.2,
+      501,
+      '[night-orch] #42 Fix retries in queue handling',
+      '2026-03-30T10:00:00.000Z',
+      '2026-03-30T10:00:00.000Z',
+    )
+
+    insertRun.run(
+      'run-new',
+      'org/repo',
+      42,
+      null,
+      'running',
+      'code',
+      1,
+      0.6,
+      501,
+      null,
+      '2026-03-31T10:00:00.000Z',
+      '2026-03-31T10:00:00.000Z',
+    )
+
+    insertRun.run(
+      'run-other',
+      'org/repo',
+      77,
+      null,
+      'queued',
+      'plan',
+      0,
+      0,
+      null,
+      null,
+      '2026-03-31T11:00:00.000Z',
+      '2026-03-31T11:00:00.000Z',
+    )
+
+    const rows = loadRuns(db, 10)
+    const newest = rows.find((row) => row.id === 'run-new')
+    const other = rows.find((row) => row.id === 'run-other')
+
+    expect(newest?.issue_title).toBe('Fix retries in queue handling')
+    expect(newest?.pr_title).toBe('[night-orch] #42 Fix retries in queue handling')
+    expect(other?.issue_title).toBeNull()
+    expect(other?.pr_title).toBeNull()
+  })
+})

--- a/test/cli/tui/titles.test.ts
+++ b/test/cli/tui/titles.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectMissingTitleTargets,
+  issueKey,
+  prKey,
+  resolveIssueTitle,
+  resolvePrTitle,
+  type TitleLookup,
+} from '../../../src/cli/tui/titles.js'
+import type { RunListRow } from '../../../src/cli/tui/data.js'
+
+describe('tui title helpers', () => {
+  const lookup: TitleLookup = {
+    issues: {
+      [issueKey('org/repo', 1)]: 'Issue from lookup',
+    },
+    prs: {
+      [prKey('org/repo', 10)]: 'PR from lookup',
+    },
+  }
+
+  it('resolves issue/pr title from row first, then lookup', () => {
+    const rowWithTitles = runRow({
+      issue_title: 'Row issue',
+      pr_number: 5,
+      pr_title: 'Row PR',
+    })
+    const rowWithoutTitles = runRow({
+      issue_number: 1,
+      issue_title: null,
+      pr_number: 10,
+      pr_title: null,
+    })
+
+    expect(resolveIssueTitle(rowWithTitles, lookup)).toBe('Row issue')
+    expect(resolvePrTitle(rowWithTitles, lookup)).toBe('Row PR')
+    expect(resolveIssueTitle(rowWithoutTitles, lookup)).toBe('Issue from lookup')
+    expect(resolvePrTitle(rowWithoutTitles, lookup)).toBe('PR from lookup')
+  })
+
+  it('collects unique missing title targets and skips attempted ones', () => {
+    const rows: RunListRow[] = [
+      runRow({ repo: 'org/repo', issue_number: 11, issue_title: null, pr_number: 101, pr_title: null }),
+      runRow({ repo: 'org/repo', issue_number: 11, issue_title: null, pr_number: 101, pr_title: null }),
+      runRow({ repo: 'org/repo', issue_number: 12, issue_title: null, pr_number: 102, pr_title: null }),
+      runRow({ repo: 'org/repo', issue_number: 13, issue_title: null, pr_number: null, pr_title: null }),
+    ]
+
+    const attemptedIssues = new Set<string>([issueKey('org/repo', 12)])
+    const attemptedPrs = new Set<string>([prKey('org/repo', 102)])
+
+    const targets = collectMissingTitleTargets(rows, { issues: {}, prs: {} }, attemptedIssues, attemptedPrs, 10)
+
+    expect(targets.issues).toEqual([
+      { key: issueKey('org/repo', 11), repo: 'org/repo', issueNumber: 11 },
+      { key: issueKey('org/repo', 13), repo: 'org/repo', issueNumber: 13 },
+    ])
+    expect(targets.prs).toEqual([
+      { key: prKey('org/repo', 101), repo: 'org/repo', prNumber: 101 },
+    ])
+  })
+})
+
+function runRow(partial: Partial<RunListRow>): RunListRow {
+  return {
+    id: partial.id ?? 'run-1',
+    repo: partial.repo ?? 'org/repo',
+    issue_number: partial.issue_number ?? 1,
+    issue_title: partial.issue_title ?? null,
+    status: partial.status ?? 'running',
+    current_phase: partial.current_phase ?? null,
+    iteration_count: partial.iteration_count ?? 0,
+    estimated_cost_usd: partial.estimated_cost_usd ?? 0,
+    last_error: partial.last_error ?? null,
+    pr_number: partial.pr_number ?? null,
+    pr_title: partial.pr_title ?? null,
+    updated_at: partial.updated_at ?? '2026-03-31T00:00:00.000Z',
+  }
+}

--- a/test/cli/tui/view-model.test.ts
+++ b/test/cli/tui/view-model.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { buildSparkline, sliceWindow } from '../../../src/cli/tui/view-model.js'
+
+describe('tui view model helpers', () => {
+  it('centers a selected index in a bounded window', () => {
+    const rows = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const windowed = sliceWindow(rows, 4, 3)
+
+    expect(windowed.start).toBe(3)
+    expect(windowed.rows).toEqual(['d', 'e', 'f'])
+  })
+
+  it('builds a sparkline string with one character per value', () => {
+    const sparkline = buildSparkline([1, 2, 3, 4])
+
+    expect(sparkline).toHaveLength(4)
+    expect(sparkline).not.toBe('----')
+  })
+})


### PR DESCRIPTION
Closes #24

## Plan
**Objective:** Redesign the night-orch TUI with proper layout, fix title loading, add expanded issue view, improve stats dashboard, and context-aware navigation

1. Fix BUG #1 — issue/PR title loading. Investigate why titles show as null. Check if SyncEngine.reconcile() and RetryEngine.retry() populate issue_title when re-processing existing runs. If not, add a backfill step in SyncEngine that fetches and updates missing titles from the forge API for existing runs. Also verify the TUI SQL query correctly aliases the columns.
2. Redesign Header component — Create a proper app title bar with: (a) app name 'night-orch' with bold styling, (b) integrated tab navigation (replacing separate TabBar), (c) key stats indicators (active runs, daily cost, last refresh time), (d) dry-run badge. Use Box with borderStyle for visual separation. Move tab hotkey hints into the header.
3. Redesign RunsView layout — Two-line run entries: Line 1: status icon + status text + repo#issue + issue title (truncated). Line 2: indented metadata — phase, iterations, cost, PR info, run-id short, updated time. Make the left panel narrower (35%) and right panel wider (65%). Use terminal width via useStdout() for responsive truncation lengths.
4. Add expanded/focused issue view — When user presses Enter or 'o' on a selected run, switch to a full-width detail view that shows: (a) full issue title and PR info at top, (b) run metadata (phase, iterations, cost, timing), (c) agent event stream using most of the remaining vertical space with more events (30+ lines). Press Escape/q to return to the split view. Track this with a new 'focused' boolean state.
5. Make right panel (Selected Run detail) narrower in normal mode — Reduce to show a summary + last few agent events. The key info (repo, issue, status, phase, cost) should be compact. Agent stream shows 8-10 lines. The expanded view (step 4) is where users go for full logs.
6. Redesign StatsView layout — Organize into visually distinct sections using Box with borders or separator lines. Use columns (side-by-side boxes) for related metrics: (a) Overview + Throughput side by side, (b) Cost section with the CostBar progress bar integrated (reuse cost-bar.tsx logic), (c) Top Repos as a proper aligned table with fixed-width columns, (d) Agent Activity with visual indicators. Use color meaningfully (green for good rates, yellow for warnings, red for errors).
7. Context-aware ActionsBar — On 'runs' tab: show run-specific actions (retry, rebase, sync, cleanup, poll) + navigation (j/k select, Enter expand). On 'stats' tab: show only refresh-related actions (f refresh, auto-refresh interval indicator with current tick count, last updated timestamp). Remove issue-specific actions from stats tab. Add visual indicator when auto-polling is active.
8. Enhanced stats data — Add to TuiStatsSnapshot: (a) completion rate trend (compare last 7d vs previous 7d), (b) cost trend indicator, (c) average time-to-completion, (d) busiest hours/days summary. Add sparkline-style indicators using unicode block characters for cost history (▁▂▃▄▅▆▇█). This makes stats more actionable compared to raw Grafana numbers.
9. Clean up unused standalone components — Remove active-runs.tsx, recent-runs.tsx, agent-stream.tsx, cost-bar.tsx, merge-queue-panel.tsx since their functionality is now fully integrated into app.tsx. This prevents confusion about which components are actually used.
10. Add tests — Create test/cli/tui/helpers.test.ts for pure functions: truncate(), formatTime(), formatMinutes(), formatEventSummary(), formatStatusMix(), formatPrList(). Create test/state/stats.test.ts for loadTuiStats() using in-memory SQLite with seeded data. Test the new sparkline generation and trend calculations from step 8.

## Implementation
Redesigned the TUI and fixed title loading end-to-end: run rows now use a clearer two-line layout, the runs screen uses a narrower right-side preview pane, and you can open/close an expanded run detail mode (`o`/`Enter`, `Esc`) that gives agent logs much more space. Added a new header with app title + runs/stats navigation, reworked stats into readable card-style sections, and made bottom navigation context-aware so stats no longer shows issue-specific retry/rebase actions and now shows refresh/polling controls with live/paused indicators. Root-cause fix for missing issue/PR titles: `loadRuns` now falls back to latest known titles from related runs, plus the app now does best-effort ForgeAdapter hydration for missing issue/PR titles and persists recovered titles back into `runs`. Added tests for title resolution, missing-title target collection, action-hint context switching, run-window/sparkline helpers, and SQL fallback title behavior. Validation run: `pnpm test` (885 passed), `pnpm typecheck` (pass), `pnpm lint` (pass). TUI research influence used: lazygit keybinding/context model (https://manpages.debian.org/testing/lazygit/lazygit.1.en.html) and bottom’s widget/card dashboard approach (https://github.com/ClementTsang/bottom).

**Changed files:**
- `src/cli/tui/app.tsx`
- `src/cli/tui/actions-bar.tsx`
- `src/cli/tui/data.ts`
- `src/cli/tui/titles.ts`
- `src/cli/tui/view-model.ts`
- `test/cli/tui/actions-bar.test.ts`
- `test/cli/tui/data.test.ts`
- `test/cli/tui/titles.test.ts`
- `test/cli/tui/view-model.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Solid refactoring that addresses all 8 issue requirements: title loading fixed via SQL COALESCE + async forge hydration, two-line run layout, narrower preview panel, focused run view, integrated header with nav, card-based stats layout, context-aware actions bar, and sparkline/auto-refresh for stats. Code is well-structured with clean extraction into data/titles/view-model modules. A few minor concerns around the hydration effect's dependency array and missing test edge cases, but nothing blocking.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude