### PR TITLE
[night-orch] #26 TUI - layout and structural improvements

### DIFF
--- a/.claude/rules/08-react-tui.md
+++ b/.claude/rules/08-react-tui.md
@@ -1,0 +1,21 @@
+# React TUI Rules
+
+These rules apply to React-based terminal UI code.
+
+## MUST
+
+- Keep container/controller logic separate from view components.
+- Scope keybindings by active view or mode to prevent global shortcuts from leaking into nested screens.
+- Keep render functions pure and side-effect free; run polling, I/O, and timers in effects/hooks.
+- Use stable keys for dynamic lists (`id` over array index) unless the list is static.
+- Cap in-memory buffers (logs, events, history) to bounded sizes to prevent unbounded growth.
+- Reset or clamp view-local cursor/scroll state when source data changes.
+- Prefer derived data with `useMemo` for expensive DB-backed calculations during refresh loops.
+- Keep keyboard hint text in sync with actual keybindings.
+
+## NEVER
+
+- Put all TUI state, views, and formatting helpers in one giant component file.
+- Bind `q`/`esc` globally when a focused modal/detail view needs close behavior first.
+- Trigger async work directly during render.
+- Depend on implicit shared mutable module state for UI interaction flow.

--- a/.codex/rules/08-react-tui.md
+++ b/.codex/rules/08-react-tui.md
@@ -1,0 +1,21 @@
+# React TUI Rules
+
+These rules apply to React-based terminal UI code.
+
+## MUST
+
+- Keep container/controller logic separate from view components.
+- Scope keybindings by active view or mode to prevent global shortcuts from leaking into nested screens.
+- Keep render functions pure and side-effect free; run polling, I/O, and timers in effects/hooks.
+- Use stable keys for dynamic lists (`id` over array index) unless the list is static.
+- Cap in-memory buffers (logs, events, history) to bounded sizes to prevent unbounded growth.
+- Reset or clamp view-local cursor/scroll state when source data changes.
+- Prefer derived data with `useMemo` for expensive DB-backed calculations during refresh loops.
+- Keep keyboard hint text in sync with actual keybindings.
+
+## NEVER
+
+- Put all TUI state, views, and formatting helpers in one giant component file.
+- Bind `q`/`esc` globally when a focused modal/detail view needs close behavior first.
+- Trigger async work directly during render.
+- Depend on implicit shared mutable module state for UI interaction flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ src/state/           — SQLite DB, migrations
 
 Detailed implementation specs in `docs/specs-active/`. Consult the relevant phase spec before making changes.
 
+## React TUI Rules
+
+- Follow `.claude/rules/08-react-tui.md` and `.codex/rules/08-react-tui.md` for React TUI structure, keybinding scoping, and state management.
+
 ## Config Documentation
 
 Configuration authoring reference lives in `docs/CONFIGURATION.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,5 @@ When changing config schema, config loading behavior, or config-dependent runtim
 ## Extended Rules
 
 Domain-specific rules are in `.claude/rules/` — architecture, security, TypeScript, loop engine, testing, specs, and operational patterns. These are loaded automatically when relevant.
+
+React TUI-specific rules live in `.claude/rules/08-react-tui.md` and should be applied for terminal UI components and keybinding logic.

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -28,16 +28,34 @@ export async function runWatch(globalOpts?: GlobalOpts): Promise<void> {
   }
 
   const db = initDatabase(config.storage.dbPath)
+  const pollIntervalMs = config.github.pollIntervalSeconds * 1000
+  const useAltScreen = Boolean(process.stdout.isTTY)
 
-  const { waitUntilExit } = render(
-    React.createElement(App, {
-      db,
-      config,
-      pollIntervalMs: 2000,
-      dryRun: globalOpts?.dryRun ?? false,
-    }),
-  )
+  if (useAltScreen) {
+    process.stdout.write('\u001B[?1049h\u001B[H')
+    process.stdout.write('\u001B[?25l')
+  }
 
-  await waitUntilExit()
-  db.close()
+  try {
+    const { waitUntilExit } = render(
+      React.createElement(App, {
+        db,
+        config,
+        pollIntervalMs,
+        dryRun: globalOpts?.dryRun ?? false,
+        enableBackgroundPoller: true,
+      }),
+      {
+        exitOnCtrlC: false,
+      },
+    )
+
+    await waitUntilExit()
+  } finally {
+    if (useAltScreen) {
+      process.stdout.write('\u001B[?25h')
+      process.stdout.write('\u001B[?1049l')
+    }
+    db.close()
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,10 +23,13 @@ program
   .option('--trust-workspace', 'Allow loading .night-orch.yaml/.yml from the current directory')
   .option('--dry-run', 'Show what would happen without making changes')
   .option('--log-level <level>', 'Log level (debug, info, warn, error)', 'info')
+  .action(async (_opts, cmd) => {
+    await runWatch(cmd.opts())
+  })
 
 program
   .command('run')
-  .description('Long-running poller — poll GitHub on interval and process eligible issues')
+  .description('Headless long-running poller — poll GitHub on interval and process eligible issues')
   .action((_opts, cmd) => runCommand(cmd.parent?.opts()))
 
 program
@@ -98,7 +101,7 @@ program
 
 program
   .command('tui')
-  .description('Interactive monitoring and control TUI')
+  .description('Interactive monitoring and control TUI with integrated poller and logs')
   .action((_opts, cmd) => runWatch(cmd.parent?.opts()))
 
 program.parse()

--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box, Text } from 'ink'
 
 interface ActionsBarProps {
-  activeTab: 'runs' | 'stats'
+  activeTab: 'runs' | 'stats' | 'logs'
   busy: boolean
   runFocused: boolean
   autoRefresh: boolean
@@ -14,22 +14,29 @@ interface ActionHints {
 }
 
 export function buildActionHints(props: ActionsBarProps): ActionHints {
-  const tabHints = '[1]runs  [2]stats  [h/l]tabs'
+  const tabHints = '[1]runs  [2]stats  [3]logs  [h/l]tabs'
   if (props.activeTab === 'runs') {
-    const focusHint = props.runFocused ? '[esc]close' : '[o/enter]open'
+    const navHint = props.runFocused ? '[j/k]scroll  [esc/q]close' : '[j/k]select  [o/enter]open'
     const actionHints = props.busy
       ? 'actions locked while task is running'
       : '[r]etry  [b]rebase  [p]oll  [s]ync  [c]leanup'
     return {
-      line1: `${tabHints}  [j/k]select  ${focusHint}`,
+      line1: `${tabHints}  ${navHint}`,
       line2: `${actionHints}  [f]refresh  [q]quit`,
     }
   }
 
-  const polling = props.autoRefresh ? 'polling live' : 'polling paused'
+  if (props.activeTab === 'stats') {
+    const polling = props.autoRefresh ? 'polling live' : 'polling paused'
+    return {
+      line1: `${tabHints}  [f]refresh now  [a]toggle auto-refresh`,
+      line2: `${polling}  [q]quit`,
+    }
+  }
+
   return {
-    line1: `${tabHints}  [f]refresh now  [a]toggle auto-refresh`,
-    line2: `${polling}  [q]quit`,
+    line1: `${tabHints}  [j/k]scroll logs  [f]refresh`,
+    line2: '[q]quit',
   }
 }
 

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -8,17 +8,23 @@ import { pollOnce } from '../../runner/poller.js'
 import { queueRebase } from '../../ops/rebase-and-check.js'
 import { createForgeAdapter } from '../../forge/factory.js'
 import type Database from 'better-sqlite3'
-import { loadTuiStats, type StatusAggregate, type TuiStatsSnapshot } from '../../state/stats.js'
+import { loadTuiStats } from '../../state/stats.js'
 import { ActionsBar } from './actions-bar.js'
-import { loadRuns, loadAgentEvents, loadMergeBatches, type AgentEventRow, type MergeBatchRow, type RunListRow } from './data.js'
-import { collectMissingTitleTargets, hasReadableTitle, resolveIssueTitle, resolvePrTitle, type TitleLookup } from './titles.js'
-import { buildSparkline, sliceWindow } from './view-model.js'
+import { loadRuns, loadAgentEvents, loadMergeBatches, type RunListRow } from './data.js'
+import { Header } from './header.js'
+import { LogsView } from './logs-view.js'
+import { RunsView } from './runs-view.js'
+import { StatsView } from './stats-view.js'
+import { collectMissingTitleTargets, hasReadableTitle, type TitleLookup } from './titles.js'
+import { TABS } from './constants.js'
+import type { RunsViewMode, TabId, TuiLogLine } from './types.js'
 
 interface AppProps {
   db: Database.Database
   config: Config
   pollIntervalMs?: number
   dryRun?: boolean
+  enableBackgroundPoller?: boolean
 }
 
 interface ActionState {
@@ -26,35 +32,17 @@ interface ActionState {
   action: string | null
 }
 
-type TabId = 'runs' | 'stats'
-type RunsViewMode = 'list' | 'focus'
+const MAX_LOG_LINES = 500
+const FOCUSED_EVENT_WINDOW_SIZE = 18
+const LOG_WINDOW_SIZE = 18
 
-const TABS: Array<{ id: TabId; hotkey: string; label: string }> = [
-  { id: 'runs', hotkey: '1', label: 'Runs' },
-  { id: 'stats', hotkey: '2', label: 'Stats' },
-]
-
-const STATUS_COLORS: Record<string, 'white' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'> = {
-  running: 'yellow',
-  queued: 'cyan',
-  review_ready: 'magenta',
-  completed: 'green',
-  blocked: 'red',
-  error: 'red',
-}
-
-const EVENT_COLORS: Record<string, 'gray' | 'cyan' | 'green' | 'yellow' | 'red' | 'magenta'> = {
-  session_start: 'green',
-  session_end: 'green',
-  text: 'gray',
-  tool_call: 'cyan',
-  tool_result: 'magenta',
-  thinking: 'yellow',
-  turn_complete: 'yellow',
-  error: 'red',
-}
-
-export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppProps): React.ReactElement {
+export function App({
+  db,
+  config,
+  pollIntervalMs = 2000,
+  dryRun = false,
+  enableBackgroundPoller = true,
+}: AppProps): React.ReactElement {
   const { exit } = useApp()
 
   const [tick, setTick] = useState(0)
@@ -66,10 +54,37 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [lastRefreshAt, setLastRefreshAt] = useState(new Date().toISOString())
   const [titleLookup, setTitleLookup] = useState<TitleLookup>({ issues: {}, prs: {} })
+  const [runEventScrollOffset, setRunEventScrollOffset] = useState(0)
+  const [logScrollOffset, setLogScrollOffset] = useState(0)
+  const [logLines, setLogLines] = useState<TuiLogLine[]>([])
+  const [startupReady, setStartupReady] = useState(!enableBackgroundPoller)
 
   const attemptedIssueKeys = useRef<Set<string>>(new Set())
   const attemptedPrKeys = useRef<Set<string>>(new Set())
   const lastHydrationAt = useRef(0)
+  const logSequence = useRef(1)
+  const pollInFlight = useRef(false)
+
+  const appendLog = useCallback((level: TuiLogLine['level'], message: string) => {
+    setLogLines((current) => {
+      const next = [
+        ...current,
+        {
+          id: logSequence.current++,
+          createdAt: new Date().toISOString(),
+          level,
+          message,
+        },
+      ]
+      if (next.length <= MAX_LOG_LINES) return next
+      return next.slice(next.length - MAX_LOG_LINES)
+    })
+  }, [])
+
+  useEffect(() => {
+    const maxOffset = Math.max(0, logLines.length - LOG_WINDOW_SIZE)
+    setLogScrollOffset((current) => Math.min(current, maxOffset))
+  }, [logLines.length])
 
   const forgeByRepo = useMemo(() => {
     const map = new Map<string, ReturnType<typeof createForgeAdapter>>()
@@ -91,15 +106,58 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
     setLastRefreshAt(new Date().toISOString())
   }, [tick])
 
+  useEffect(() => {
+    if (!enableBackgroundPoller) return
+    let alive = true
+
+    void (async () => {
+      appendLog('info', 'startup recovery: begin')
+      try {
+        const { LeaseManager } = await import('../../state/leases.js')
+        const leaseManager = new LeaseManager(db)
+        const releasedLeases = leaseManager.releaseAll()
+        if (releasedLeases > 0) {
+          appendLog('info', `startup recovery: released ${releasedLeases} orphaned lease(s)`)
+        }
+      } catch (err) {
+        appendLog('warn', `startup recovery: lease cleanup failed: ${(err as Error).message}`)
+      }
+
+      try {
+        const syncEngine = new SyncEngine(db, config)
+        const syncResult = await syncEngine.reconcile(dryRun)
+        appendLog(
+          'info',
+          `startup recovery: ${syncResult.reconciledRuns.length} reconciled, ${syncResult.expiredLeases} expired lease(s)`,
+        )
+      } catch (err) {
+        appendLog('warn', `startup recovery: sync failed: ${(err as Error).message}`)
+      }
+
+      if (!alive) return
+      setStartupReady(true)
+      setTick((t) => t + 1)
+    })()
+
+    return () => {
+      alive = false
+    }
+  }, [appendLog, config, db, dryRun, enableBackgroundPoller])
+
   const runs = useMemo(() => loadRuns(db), [db, tick])
   const selectedIndex = runs.findIndex((run) => run.id === selectedRunId)
   const selectedRun = selectedIndex >= 0 ? (runs[selectedIndex] ?? null) : (runs[0] ?? null)
   const selectedRunEvents = useMemo(
-    () => (selectedRun ? loadAgentEvents(db, selectedRun.id, runsViewMode === 'focus' ? 40 : 10) : []),
+    () => (selectedRun ? loadAgentEvents(db, selectedRun.id, runsViewMode === 'focus' ? 240 : 12) : []),
     [db, tick, selectedRun?.id, runsViewMode],
   )
   const mergeBatches = useMemo(() => loadMergeBatches(db), [db, tick])
   const stats = useMemo(() => loadTuiStats(db), [db, tick])
+
+  useEffect(() => {
+    const maxOffset = Math.max(0, selectedRunEvents.length - FOCUSED_EVENT_WINDOW_SIZE)
+    setRunEventScrollOffset((current) => Math.min(current, maxOffset))
+  }, [selectedRunEvents.length])
 
   useEffect(() => {
     if (runs.length === 0) {
@@ -199,6 +257,57 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
     })()
   }, [db, forgeByRepo, runs, titleLookup])
 
+  const runPollCycle = useCallback(async (
+    trigger: 'auto' | 'manual',
+    targetRun?: RunListRow | null,
+  ): Promise<string> => {
+    if (pollInFlight.current) {
+      return 'poll already in progress'
+    }
+    pollInFlight.current = true
+    try {
+      const targetIssue = trigger === 'manual' && targetRun
+        ? { repo: targetRun.repo, issueNumber: targetRun.issue_number }
+        : undefined
+      const result = await pollOnce(config, db, dryRun, undefined, targetIssue)
+      const targetSuffix = targetIssue ? ` for ${targetIssue.repo}#${targetIssue.issueNumber}` : ''
+      const summary = `${result.processed} processed, ${result.errors} error(s)${targetSuffix}${dryRun ? ' (dry-run)' : ''}`
+      appendLog('info', `${trigger} poll: ${summary}`)
+      return summary
+    } catch (err) {
+      appendLog('error', `${trigger} poll failed: ${(err as Error).message}`)
+      throw err
+    } finally {
+      pollInFlight.current = false
+      setTick((t) => t + 1)
+    }
+  }, [appendLog, config, db, dryRun])
+
+  useEffect(() => {
+    if (!enableBackgroundPoller || !startupReady || !autoRefresh) return
+    let stopped = false
+
+    const cycle = async () => {
+      if (stopped) return
+      try {
+        const summary = await runPollCycle('auto')
+        setStatusLine(`poll: ${summary}`)
+      } catch (err) {
+        setStatusLine(`poll failed: ${(err as Error).message}`)
+      }
+    }
+
+    void cycle()
+    const timer = setInterval(() => {
+      void cycle()
+    }, pollIntervalMs)
+
+    return () => {
+      stopped = true
+      clearInterval(timer)
+    }
+  }, [autoRefresh, enableBackgroundPoller, pollIntervalMs, runPollCycle, startupReady])
+
   const moveSelection = useCallback((direction: -1 | 1) => {
     if (runs.length === 0) return
 
@@ -231,16 +340,20 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
     if (actionState.busy) return
     setActionState({ busy: true, action: actionName })
     setStatusLine(`Running ${actionName}...`)
+    appendLog('info', `action ${actionName}: start`)
     try {
       const result = await actionFn()
       setStatusLine(`${actionName}: ${result}`)
+      appendLog('info', `action ${actionName}: ${result}`)
     } catch (err) {
-      setStatusLine(`${actionName} failed: ${(err as Error).message}`)
+      const message = (err as Error).message
+      setStatusLine(`${actionName} failed: ${message}`)
+      appendLog('error', `action ${actionName} failed: ${message}`)
     } finally {
       setActionState({ busy: false, action: null })
       setTick((t) => t + 1)
     }
-  }, [actionState.busy])
+  }, [actionState.busy, appendLog])
 
   const runRetry = useCallback(async () => {
     await runAction('retry', async () => {
@@ -279,15 +392,8 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
   }, [config, db, dryRun, runAction])
 
   const runPoll = useCallback(async () => {
-    await runAction('poll', async () => {
-      const targetIssue = selectedRun
-        ? { repo: selectedRun.repo, issueNumber: selectedRun.issue_number }
-        : undefined
-      const result = await pollOnce(config, db, dryRun, undefined, targetIssue)
-      const targetSuffix = targetIssue ? ` for ${targetIssue.repo}#${targetIssue.issueNumber}` : ''
-      return `${result.processed} processed, ${result.errors} error(s)${targetSuffix}${dryRun ? ' (dry-run)' : ''}`
-    })
-  }, [config, db, dryRun, runAction, selectedRun])
+    await runAction('poll', async () => runPollCycle('manual', selectedRun))
+  }, [runAction, runPollCycle, selectedRun])
 
   const runRebase = useCallback(async () => {
     await runAction('rebase', async () => {
@@ -300,7 +406,9 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       try {
         const auth = await forge.validateAuth()
         botUser = auth.user
-      } catch { /* best effort */ }
+      } catch {
+        // Best effort only.
+      }
       const result = await queueRebase(db, forge, repoConfig, target.issue_number, botUser)
       return `${target.repo}#${target.issue_number}: ${result.reason}`
     })
@@ -311,6 +419,23 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       exit()
       return
     }
+
+    if (activeTab === 'runs' && runsViewMode === 'focus') {
+      if (key.escape || input === 'q') {
+        setRunsViewMode('list')
+        setStatusLine('Closed run detail')
+        return
+      }
+      if (key.downArrow || input === 'j') {
+        setRunEventScrollOffset((current) => current + 1)
+        return
+      }
+      if (key.upArrow || input === 'k') {
+        setRunEventScrollOffset((current) => Math.max(0, current - 1))
+        return
+      }
+    }
+
     if (input === 'q') {
       exit()
       return
@@ -324,6 +449,10 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       setActiveTab('stats')
       return
     }
+    if (input === '3') {
+      setActiveTab('logs')
+      return
+    }
     if (key.rightArrow || input === 'l') {
       switchTab(1)
       return
@@ -333,7 +462,7 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       return
     }
 
-    if (activeTab === 'runs') {
+    if (activeTab === 'runs' && runsViewMode === 'list') {
       if (key.downArrow || input === 'j') {
         moveSelection(1)
         return
@@ -344,12 +473,20 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       }
       if (input === 'o' || key.return) {
         if (selectedRun) {
-          setRunsViewMode((mode) => (mode === 'list' ? 'focus' : 'list'))
+          setRunsViewMode('focus')
+          setRunEventScrollOffset(0)
         }
         return
       }
-      if (key.escape && runsViewMode === 'focus') {
-        setRunsViewMode('list')
+    }
+
+    if (activeTab === 'logs') {
+      if (key.downArrow || input === 'j') {
+        setLogScrollOffset((current) => current + 1)
+        return
+      }
+      if (key.upArrow || input === 'k') {
+        setLogScrollOffset((current) => Math.max(0, current - 1))
         return
       }
     }
@@ -363,6 +500,7 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       setAutoRefresh((current) => {
         const next = !current
         setStatusLine(next ? 'Auto-refresh enabled' : 'Auto-refresh paused')
+        appendLog('info', next ? 'auto-refresh enabled' : 'auto-refresh paused')
         return next
       })
       return
@@ -372,7 +510,7 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       return
     }
 
-    if (activeTab !== 'runs') {
+    if (activeTab !== 'runs' || runsViewMode === 'focus') {
       return
     }
 
@@ -400,7 +538,7 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
   const runsVisible = runsViewMode === 'focus' ? 8 : 10
 
   return (
-    <Box flexDirection="column" padding={1}>
+    <Box flexDirection="column" height="100%">
       <Header
         activeTab={activeTab}
         pollIntervalMs={pollIntervalMs}
@@ -416,28 +554,36 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
         </Text>
       </Box>
 
-      {activeTab === 'runs'
-        ? (
-            <RunsView
-              runs={runs}
-              selectedIndex={selectedIndex < 0 ? 0 : selectedIndex}
-              selectedRun={selectedRun}
-              selectedRunEvents={selectedRunEvents}
-              mergeBatches={mergeBatches}
-              stats={stats}
-              titleLookup={titleLookup}
-              mode={runsViewMode}
-              maxVisibleRuns={runsVisible}
-            />
-          )
-        : (
-            <StatsView
-              stats={stats}
-              autoRefresh={autoRefresh}
-              pollIntervalMs={pollIntervalMs}
-              lastRefreshAt={lastRefreshAt}
-            />
-          )}
+      {activeTab === 'runs' && (
+        <RunsView
+          runs={runs}
+          selectedIndex={selectedIndex < 0 ? 0 : selectedIndex}
+          selectedRun={selectedRun}
+          selectedRunEvents={selectedRunEvents}
+          mergeBatches={mergeBatches}
+          stats={stats}
+          titleLookup={titleLookup}
+          mode={runsViewMode}
+          maxVisibleRuns={runsVisible}
+          eventScrollOffset={runEventScrollOffset}
+          eventWindowSize={FOCUSED_EVENT_WINDOW_SIZE}
+        />
+      )}
+      {activeTab === 'stats' && (
+        <StatsView
+          stats={stats}
+          autoRefresh={autoRefresh}
+          pollIntervalMs={pollIntervalMs}
+          lastRefreshAt={lastRefreshAt}
+        />
+      )}
+      {activeTab === 'logs' && (
+        <LogsView
+          logs={logLines}
+          scrollOffset={logScrollOffset}
+          windowSize={LOG_WINDOW_SIZE}
+        />
+      )}
 
       <ActionsBar
         activeTab={activeTab}
@@ -447,434 +593,4 @@ export function App({ db, config, pollIntervalMs = 2000, dryRun = false }: AppPr
       />
     </Box>
   )
-}
-
-interface HeaderProps {
-  activeTab: TabId
-  pollIntervalMs: number
-  dryRun: boolean
-  status: TuiStatsSnapshot
-  autoRefresh: boolean
-  lastRefreshAt: string
-}
-
-function Header({ activeTab, pollIntervalMs, dryRun, status, autoRefresh, lastRefreshAt }: HeaderProps): React.ReactElement {
-  return (
-    <Box flexDirection="column" marginBottom={1} borderStyle="round" borderColor="cyan" paddingX={1}>
-      <Box>
-        <Text bold color="cyan">NIGHT-ORCH CONTROL ROOM</Text>
-        <Text color="gray">  refresh {pollIntervalMs / 1000}s</Text>
-        {dryRun && <Text color="yellow">  [dry-run]</Text>}
-        <Text color={autoRefresh ? 'green' : 'yellow'}>  {autoRefresh ? '● live' : '○ paused'}</Text>
-        <Text color="gray">  updated {formatTime(lastRefreshAt)}</Text>
-      </Box>
-      <Box>
-        {TABS.map((tab) => (
-          <Box key={tab.id} marginRight={2}>
-            <Text color={activeTab === tab.id ? 'cyan' : 'gray'}>
-              {activeTab === tab.id ? '▸' : ' '}[{tab.hotkey}] {tab.label}
-            </Text>
-          </Box>
-        ))}
-      </Box>
-      <Text color="gray">
-        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  running {status.overview.runningRuns}  cost today ${status.cost.todayCostUsd.toFixed(2)}
-      </Text>
-    </Box>
-  )
-}
-
-interface RunsViewProps {
-  runs: RunListRow[]
-  selectedIndex: number
-  selectedRun: RunListRow | null
-  selectedRunEvents: AgentEventRow[]
-  mergeBatches: MergeBatchRow[]
-  stats: TuiStatsSnapshot
-  titleLookup: TitleLookup
-  mode: RunsViewMode
-  maxVisibleRuns: number
-}
-
-function RunsView({
-  runs,
-  selectedIndex,
-  selectedRun,
-  selectedRunEvents,
-  mergeBatches,
-  stats,
-  titleLookup,
-  mode,
-  maxVisibleRuns,
-}: RunsViewProps): React.ReactElement {
-  if (mode === 'focus') {
-    return (
-      <FocusedRunView
-        selectedRun={selectedRun}
-        selectedRunEvents={selectedRunEvents}
-        titleLookup={titleLookup}
-        stats={stats}
-        mergeBatches={mergeBatches}
-      />
-    )
-  }
-
-  const windowed = sliceWindow(runs, selectedIndex, maxVisibleRuns)
-
-  return (
-    <>
-      <Box marginBottom={1}>
-        <Box width="72%" flexDirection="column" marginRight={1}>
-          <Text bold>Runs ({runs.length})</Text>
-          {runs.length === 0 && <Text color="gray">  No runs found</Text>}
-          {windowed.rows.map((run, idx) => {
-            const absoluteIndex = windowed.start + idx
-            const selected = selectedRun?.id === run.id
-            const issueTitle = resolveIssueTitle(run, titleLookup) ?? '(title unavailable)'
-            const prTitle = resolvePrTitle(run, titleLookup)
-            const statusColor = STATUS_COLORS[run.status] ?? 'white'
-
-            return (
-              <Box key={run.id} flexDirection="column">
-                <Text>
-                  <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
-                  {' '}
-                  <Text color="gray">{String(absoluteIndex + 1).padStart(2, '0')}</Text>
-                  {' '}
-                  <Text color={statusColor}>{run.status.padEnd(11)}</Text>
-                  {' '}
-                  <Text>{run.repo}#{run.issue_number}</Text>
-                  {'  '}
-                  <Text>{truncate(issueTitle, 58)}</Text>
-                </Text>
-                <Text color="gray">
-                  {'    '}
-                  <Text>{run.pr_number !== null ? `PR #${run.pr_number} ${truncate(prTitle ?? '(title unavailable)', 40)}` : 'No PR yet'}</Text>
-                  {'  '}
-                  <Text>phase {run.current_phase ?? '-'}</Text>
-                  {'  '}
-                  <Text>iter {run.iteration_count ?? 0}</Text>
-                  {'  '}
-                  <Text>cost ${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
-                  {'  '}
-                  <Text>{formatTime(run.updated_at)}</Text>
-                </Text>
-              </Box>
-            )
-          })}
-          {runs.length > windowed.rows.length && (
-            <Text color="gray">  showing {windowed.start + 1}-{windowed.start + windowed.rows.length} of {runs.length}</Text>
-          )}
-        </Box>
-
-        <Box width="28%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
-          <Text bold color="cyan">Issue Preview</Text>
-          {!selectedRun && <Text color="gray">Select a run to inspect</Text>}
-          {selectedRun && (
-            <>
-              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
-              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
-              <Text>{truncate(resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)', 46)}</Text>
-              {selectedRun.pr_number !== null && (
-                <Text color="gray">PR #{selectedRun.pr_number}: {truncate(resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)', 36)}</Text>
-              )}
-
-              <Box marginTop={1} flexDirection="column">
-                <Text bold>Log Glimpse</Text>
-                {selectedRunEvents.length === 0 && <Text color="gray">No agent events yet</Text>}
-                {selectedRunEvents.slice(-5).map((event) => {
-                  const color = EVENT_COLORS[event.event_type] ?? 'gray'
-                  return (
-                    <Text key={event.id}>
-                      <Text color="gray">{formatTime(event.created_at)}</Text>
-                      {' '}
-                      <Text color={color}>{truncate(event.event_type, 10)}</Text>
-                      {' '}
-                      <Text>{truncate(formatEventSummary(event), 22)}</Text>
-                    </Text>
-                  )
-                })}
-              </Box>
-
-              <Text color="gray">Press o or Enter for expanded view</Text>
-            </>
-          )}
-        </Box>
-      </Box>
-
-      <Box marginBottom={1} flexDirection="column">
-        <Text bold>System Snapshot</Text>
-        <Text color="gray">
-          {'  '}active {stats.overview.activeRuns}  running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}  merge queue {mergeBatches.length}
-        </Text>
-        {mergeBatches.slice(0, 3).map((batch) => (
-          <Text key={batch.id}>
-            {'  '}
-            <Text color="cyan">{batch.status}</Text>
-            {' '}
-            <Text>{batch.repo}</Text>
-            {' PRs '}
-            <Text>{formatPrList(batch.pr_numbers)}</Text>
-          </Text>
-        ))}
-      </Box>
-    </>
-  )
-}
-
-interface FocusedRunViewProps {
-  selectedRun: RunListRow | null
-  selectedRunEvents: AgentEventRow[]
-  titleLookup: TitleLookup
-  stats: TuiStatsSnapshot
-  mergeBatches: MergeBatchRow[]
-}
-
-function FocusedRunView({ selectedRun, selectedRunEvents, titleLookup, stats, mergeBatches }: FocusedRunViewProps): React.ReactElement {
-  return (
-    <Box marginBottom={1} flexDirection="column">
-      <Text bold>Run Detail</Text>
-      {!selectedRun && <Text color="gray">No run selected</Text>}
-      {selectedRun && (
-        <>
-          <Box>
-            <Box width="35%" flexDirection="column" marginRight={1} borderStyle="single" borderColor="gray" paddingX={1}>
-              <Text bold color="cyan">Overview</Text>
-              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
-              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
-              <Text>{resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
-              {selectedRun.pr_number !== null && (
-                <Text color="gray">PR #{selectedRun.pr_number}: {resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
-              )}
-              <Text color="gray">phase {selectedRun.current_phase ?? '-'}</Text>
-              <Text color="gray">iter {selectedRun.iteration_count ?? 0}  cost ${(selectedRun.estimated_cost_usd ?? 0).toFixed(2)}</Text>
-              <Text color="gray">updated {formatTime(selectedRun.updated_at)}</Text>
-              {selectedRun.last_error && <Text color="red">error: {truncate(selectedRun.last_error, 90)}</Text>}
-              <Box marginTop={1} flexDirection="column">
-                <Text bold>System</Text>
-                <Text color="gray">active runs {stats.overview.activeRuns}</Text>
-                <Text color="gray">merge queue {mergeBatches.length}</Text>
-              </Box>
-            </Box>
-
-            <Box width="65%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
-              <Text bold color="cyan">Agent Stream ({selectedRunEvents.length})</Text>
-              {selectedRunEvents.length === 0 && <Text color="gray">No agent events</Text>}
-              {selectedRunEvents.map((event) => {
-                const color = EVENT_COLORS[event.event_type] ?? 'gray'
-                return (
-                  <Text key={event.id}>
-                    <Text color="gray">[{formatTime(event.created_at)}]</Text>
-                    {' '}
-                    <Text color="gray">{event.role}</Text>
-                    {' '}
-                    <Text color={color}>{event.event_type}</Text>
-                    {' '}
-                    <Text>{formatEventSummary(event)}</Text>
-                  </Text>
-                )
-              })}
-            </Box>
-          </Box>
-          <Text color="gray">Press Esc or o to return to list</Text>
-        </>
-      )}
-    </Box>
-  )
-}
-
-interface StatsViewProps {
-  stats: TuiStatsSnapshot
-  autoRefresh: boolean
-  pollIntervalMs: number
-  lastRefreshAt: string
-}
-
-function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }: StatsViewProps): React.ReactElement {
-  const costSeries = stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd)
-
-  return (
-    <Box flexDirection="column" marginBottom={1}>
-      <Box marginBottom={1}>
-        <Text color={autoRefresh ? 'green' : 'yellow'}>{autoRefresh ? '● stats polling active' : '○ stats polling paused'}</Text>
-        <Text color="gray">  interval {pollIntervalMs / 1000}s</Text>
-        <Text color="gray">  last refresh {formatTime(lastRefreshAt)}</Text>
-      </Box>
-
-      <Box marginBottom={1}>
-        <StatCard title="Run Health" width="50%" marginRight={1}>
-          <Text>total {stats.overview.totalRuns}  active {stats.overview.activeRuns}</Text>
-          <Text color="gray">running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}</Text>
-          <Text color="gray">review_ready {stats.overview.reviewReadyRuns}  completed {stats.overview.completedRuns}</Text>
-          <Text color="gray">blocked {stats.overview.blockedRuns}  error {stats.overview.errorRuns}</Text>
-          <Text color="gray">mix {formatStatusMix(stats.statusCounts)}</Text>
-        </StatCard>
-
-        <StatCard title="Throughput" width="50%">
-          <Text>runs 24h {stats.throughput.runs24h}  7d {stats.throughput.runs7d}  30d {stats.throughput.runs30d}</Text>
-          <Text color="gray">completed 7d {stats.throughput.completed7d}</Text>
-          <Text color="gray">blocked 7d {stats.throughput.blocked7d}  error 7d {stats.throughput.error7d}</Text>
-          <Text color="gray">success 7d {stats.throughput.successRate7d.toFixed(1)}%</Text>
-          <Text color="gray">avg duration {formatMinutes(stats.throughput.avgDurationMinutes7d)}  avg iter {stats.throughput.avgIterations7d.toFixed(2)}</Text>
-        </StatCard>
-      </Box>
-
-      <Box marginBottom={1}>
-        <StatCard title="Cost" width="50%" marginRight={1}>
-          <Text>today ${stats.cost.todayCostUsd.toFixed(2)} ({stats.cost.todayRunCount} runs)</Text>
-          <Text color="gray">7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
-          <Text color="gray">avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
-          <Text color="gray">trend {buildSparkline(costSeries)}</Text>
-          {stats.cost.dailyHistory.slice(0, 4).map((row) => (
-            <Text key={row.date} color="gray">{row.date}: ${row.totalCostUsd.toFixed(2)} ({row.runCount})</Text>
-          ))}
-        </StatCard>
-
-        <StatCard title="Agent Activity" width="50%">
-          <Text>events total {stats.agents.eventsTotal}</Text>
-          <Text color="gray">24h {stats.agents.events24h}  7d {stats.agents.events7d}</Text>
-          <Text color="gray">tool calls 24h {stats.agents.toolCalls24h}</Text>
-          <Text color="gray">thinking 24h {stats.agents.thinking24h}  runs 7d {stats.agents.uniqueRuns7d}</Text>
-          <Text color="gray">
-            roles {stats.agents.roleBreakdown7d.length === 0 ? '-' : stats.agents.roleBreakdown7d.map((row) => `${row.role}:${row.events}`).join('  ')}
-          </Text>
-        </StatCard>
-      </Box>
-
-      <Box>
-        <StatCard title="Merge Queue" width="35%" marginRight={1}>
-          <Text>active batches {stats.queue.activeBatches}</Text>
-          <Text color="gray">
-            statuses {stats.queue.statuses.length === 0 ? '-' : stats.queue.statuses.map((row) => `${row.status}:${row.count}`).join('  ')}
-          </Text>
-          <Text color="gray">
-            active phases {stats.phaseCounts.length === 0 ? '-' : stats.phaseCounts.map((row) => `${row.phase}:${row.count}`).join('  ')}
-          </Text>
-        </StatCard>
-
-        <StatCard title="Top Repositories (30d)" width="65%">
-          {stats.topRepos30d.length === 0 && <Text color="gray">No run history</Text>}
-          {stats.topRepos30d.map((row) => {
-            const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
-            const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
-            return (
-              <Text key={row.repo}>
-                <Text>{truncate(row.repo, 28)}</Text>
-                {'  '}
-                <Text color="gray">runs {row.totalRuns}</Text>
-                {'  '}
-                <Text color="green">ok {successPct.toFixed(0)}%</Text>
-                {'  '}
-                <Text color="gray">cost ${row.totalCostUsd.toFixed(2)}</Text>
-                {'  '}
-                <Text color="gray">iter {row.avgIterations.toFixed(1)}</Text>
-              </Text>
-            )
-          })}
-        </StatCard>
-      </Box>
-    </Box>
-  )
-}
-
-interface StatCardProps {
-  title: string
-  width: string
-  marginRight?: number
-  children: React.ReactNode
-}
-
-function StatCard({ title, width, marginRight = 0, children }: StatCardProps): React.ReactElement {
-  return (
-    <Box
-      width={width}
-      marginRight={marginRight}
-      flexDirection="column"
-      borderStyle="single"
-      borderColor="gray"
-      paddingX={1}
-    >
-      <Text bold color="cyan">{title}</Text>
-      {children}
-    </Box>
-  )
-}
-
-function formatStatusMix(statuses: StatusAggregate[]): string {
-  if (statuses.length === 0) return '-'
-  return statuses.map((row) => `${row.status}:${row.count}`).join('  ')
-}
-
-function formatEventSummary(event: AgentEventRow): string {
-  const data = parseEventData(event.data)
-  if (!data) return ''
-
-  if (event.event_type === 'tool_call') {
-    const toolName = asString(data['toolName']) ?? 'tool'
-    const args = asString(data['toolArgs'])
-    return truncate(args ? `${toolName} ${args}` : toolName)
-  }
-  if (event.event_type === 'text' || event.event_type === 'thinking') {
-    return truncate(asString(data['text']) ?? '')
-  }
-  if (event.event_type === 'error') {
-    return truncate(asString(data['error']) ?? '')
-  }
-  if (event.event_type === 'turn_complete' && typeof data['tokenCount'] === 'number') {
-    return `${data['tokenCount']} tokens`
-  }
-  if (event.event_type === 'session_start' || event.event_type === 'session_end') {
-    const sessionId = asString(data['sessionId'])
-    return sessionId ? `session ${sessionId}` : ''
-  }
-  return truncate(JSON.stringify(data))
-}
-
-function parseEventData(value: string | null): Record<string, unknown> | null {
-  if (!value) return null
-  try {
-    const parsed: unknown = JSON.parse(value)
-    if (typeof parsed === 'object' && parsed !== null) {
-      return parsed as Record<string, unknown>
-    }
-    return null
-  } catch {
-    return { raw: value }
-  }
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === 'string' ? value : null
-}
-
-function truncate(value: string, maxLen = 72): string {
-  if (value.length <= maxLen) return value
-  return `${value.slice(0, maxLen - 3)}...`
-}
-
-function formatTime(timestamp: string): string {
-  const date = new Date(timestamp)
-  if (Number.isNaN(date.getTime())) return '--:--:--'
-  return date.toISOString().slice(11, 19)
-}
-
-function formatMinutes(minutes: number): string {
-  if (minutes <= 0) return '-'
-  if (minutes < 1) return `${Math.round(minutes * 60)}s`
-  if (minutes < 60) return `${minutes.toFixed(1)}m`
-  const hours = Math.floor(minutes / 60)
-  const mins = Math.round(minutes % 60)
-  return `${hours}h${String(mins).padStart(2, '0')}m`
-}
-
-function formatPrList(prNumbersRaw: string): string {
-  try {
-    const parsed: unknown = JSON.parse(prNumbersRaw)
-    if (Array.isArray(parsed)) {
-      return parsed.map((value) => String(value)).join(', ')
-    }
-    return '-'
-  } catch {
-    return '-'
-  }
 }

--- a/src/cli/tui/constants.ts
+++ b/src/cli/tui/constants.ts
@@ -1,0 +1,27 @@
+import type { TabId } from './types.js'
+
+export const TABS: Array<{ id: TabId; hotkey: string; label: string }> = [
+  { id: 'runs', hotkey: '1', label: 'Runs' },
+  { id: 'stats', hotkey: '2', label: 'Stats' },
+  { id: 'logs', hotkey: '3', label: 'Logs' },
+]
+
+export const STATUS_COLORS: Record<string, 'white' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'> = {
+  running: 'yellow',
+  queued: 'cyan',
+  review_ready: 'magenta',
+  completed: 'green',
+  blocked: 'red',
+  error: 'red',
+}
+
+export const EVENT_COLORS: Record<string, 'gray' | 'cyan' | 'green' | 'yellow' | 'red' | 'magenta'> = {
+  session_start: 'green',
+  session_end: 'green',
+  text: 'gray',
+  tool_call: 'cyan',
+  tool_result: 'magenta',
+  thinking: 'yellow',
+  turn_complete: 'yellow',
+  error: 'red',
+}

--- a/src/cli/tui/format.ts
+++ b/src/cli/tui/format.ts
@@ -1,0 +1,87 @@
+import type { StatusAggregate } from '../../state/stats.js'
+import type { AgentEventRow } from './data.js'
+import type { TuiLogLine } from './types.js'
+
+export function formatStatusMix(statuses: StatusAggregate[]): string {
+  if (statuses.length === 0) return '-'
+  return statuses.map((row) => `${row.status}:${row.count}`).join('  ')
+}
+
+export function formatEventSummary(event: AgentEventRow): string {
+  const data = parseEventData(event.data)
+  if (!data) return ''
+
+  if (event.event_type === 'tool_call') {
+    const toolName = asString(data['toolName']) ?? 'tool'
+    const args = asString(data['toolArgs'])
+    return truncate(args ? `${toolName} ${args}` : toolName)
+  }
+  if (event.event_type === 'text' || event.event_type === 'thinking') {
+    return truncate(asString(data['text']) ?? '')
+  }
+  if (event.event_type === 'error') {
+    return truncate(asString(data['error']) ?? '')
+  }
+  if (event.event_type === 'turn_complete' && typeof data['tokenCount'] === 'number') {
+    return `${data['tokenCount']} tokens`
+  }
+  if (event.event_type === 'session_start' || event.event_type === 'session_end') {
+    const sessionId = asString(data['sessionId'])
+    return sessionId ? `session ${sessionId}` : ''
+  }
+  return truncate(JSON.stringify(data))
+}
+
+export function truncate(value: string, maxLen = 72): string {
+  if (value.length <= maxLen) return value
+  return `${value.slice(0, maxLen - 3)}...`
+}
+
+export function formatTime(timestamp: string): string {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return '--:--:--'
+  return date.toISOString().slice(11, 19)
+}
+
+export function formatMinutes(minutes: number): string {
+  if (minutes <= 0) return '-'
+  if (minutes < 1) return `${Math.round(minutes * 60)}s`
+  if (minutes < 60) return `${minutes.toFixed(1)}m`
+  const hours = Math.floor(minutes / 60)
+  const mins = Math.round(minutes % 60)
+  return `${hours}h${String(mins).padStart(2, '0')}m`
+}
+
+export function formatPrList(prNumbersRaw: string): string {
+  try {
+    const parsed: unknown = JSON.parse(prNumbersRaw)
+    if (Array.isArray(parsed)) {
+      return parsed.map((value) => String(value)).join(', ')
+    }
+    return '-'
+  } catch {
+    return '-'
+  }
+}
+
+export function formatLogLine(line: TuiLogLine, maxLen = 180): string {
+  const prefix = `${formatTime(line.createdAt)} ${line.level.toUpperCase().padEnd(5)}`
+  return `${prefix} ${truncate(line.message, maxLen)}`
+}
+
+function parseEventData(value: string | null): Record<string, unknown> | null {
+  if (!value) return null
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (typeof parsed === 'object' && parsed !== null) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch {
+    return { raw: value }
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}

--- a/src/cli/tui/header.tsx
+++ b/src/cli/tui/header.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { TuiStatsSnapshot } from '../../state/stats.js'
+import { TABS } from './constants.js'
+import type { TabId } from './types.js'
+import { formatTime } from './format.js'
+
+interface HeaderProps {
+  activeTab: TabId
+  pollIntervalMs: number
+  dryRun: boolean
+  status: TuiStatsSnapshot
+  autoRefresh: boolean
+  lastRefreshAt: string
+}
+
+export function Header({
+  activeTab,
+  pollIntervalMs,
+  dryRun,
+  status,
+  autoRefresh,
+  lastRefreshAt,
+}: HeaderProps): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginBottom={1} borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Box>
+        <Text bold color="cyan">NIGHT-ORCH CONTROL ROOM</Text>
+        <Text color="gray">  refresh {pollIntervalMs / 1000}s</Text>
+        {dryRun && <Text color="yellow">  [dry-run]</Text>}
+        <Text color={autoRefresh ? 'green' : 'yellow'}>  {autoRefresh ? '● live' : '○ paused'}</Text>
+        <Text color="gray">  updated {formatTime(lastRefreshAt)}</Text>
+      </Box>
+      <Box>
+        {TABS.map((tab) => (
+          <Box key={tab.id} marginRight={2}>
+            <Text color={activeTab === tab.id ? 'cyan' : 'gray'}>
+              {activeTab === tab.id ? '▸' : ' '}[{tab.hotkey}] {tab.label}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+      <Text color="gray">
+        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  running {status.overview.runningRuns}  cost today ${status.cost.todayCostUsd.toFixed(2)}
+      </Text>
+    </Box>
+  )
+}

--- a/src/cli/tui/logs-view.tsx
+++ b/src/cli/tui/logs-view.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import { formatLogLine } from './format.js'
+import type { TuiLogLine } from './types.js'
+
+interface LogsViewProps {
+  logs: TuiLogLine[]
+  scrollOffset: number
+  windowSize: number
+}
+
+export function LogsView({ logs, scrollOffset, windowSize }: LogsViewProps): React.ReactElement {
+  const maxOffset = Math.max(0, logs.length - windowSize)
+  const clampedOffset = Math.max(0, Math.min(maxOffset, scrollOffset))
+  const rows = logs.slice(clampedOffset, clampedOffset + windowSize)
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text bold>Logs</Text>
+      <Text color="gray">Integrated poller output and control actions</Text>
+      <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+        {rows.length === 0 && <Text color="gray">No logs yet</Text>}
+        {rows.map((line) => (
+          <Text
+            key={line.id}
+            color={line.level === 'error' ? 'red' : line.level === 'warn' ? 'yellow' : 'gray'}
+          >
+            {formatLogLine(line, 200)}
+          </Text>
+        ))}
+      </Box>
+      {logs.length > windowSize && (
+        <Text color="gray">showing {clampedOffset + 1}-{clampedOffset + rows.length} of {logs.length}</Text>
+      )}
+      <Text color="gray">Press j/k to scroll logs</Text>
+    </Box>
+  )
+}

--- a/src/cli/tui/runs-view.tsx
+++ b/src/cli/tui/runs-view.tsx
@@ -1,0 +1,233 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { TuiStatsSnapshot } from '../../state/stats.js'
+import { EVENT_COLORS, STATUS_COLORS } from './constants.js'
+import type { AgentEventRow, MergeBatchRow, RunListRow } from './data.js'
+import { formatEventSummary, formatPrList, formatTime, truncate } from './format.js'
+import { resolveIssueTitle, resolvePrTitle, type TitleLookup } from './titles.js'
+import type { RunsViewMode } from './types.js'
+import { sliceWindow } from './view-model.js'
+
+interface RunsViewProps {
+  runs: RunListRow[]
+  selectedIndex: number
+  selectedRun: RunListRow | null
+  selectedRunEvents: AgentEventRow[]
+  mergeBatches: MergeBatchRow[]
+  stats: TuiStatsSnapshot
+  titleLookup: TitleLookup
+  mode: RunsViewMode
+  maxVisibleRuns: number
+  eventScrollOffset: number
+  eventWindowSize: number
+}
+
+export function RunsView({
+  runs,
+  selectedIndex,
+  selectedRun,
+  selectedRunEvents,
+  mergeBatches,
+  stats,
+  titleLookup,
+  mode,
+  maxVisibleRuns,
+  eventScrollOffset,
+  eventWindowSize,
+}: RunsViewProps): React.ReactElement {
+  if (mode === 'focus') {
+    return (
+      <FocusedRunView
+        selectedRun={selectedRun}
+        selectedRunEvents={selectedRunEvents}
+        titleLookup={titleLookup}
+        stats={stats}
+        mergeBatches={mergeBatches}
+        eventScrollOffset={eventScrollOffset}
+        eventWindowSize={eventWindowSize}
+      />
+    )
+  }
+
+  const windowed = sliceWindow(runs, selectedIndex, maxVisibleRuns)
+
+  return (
+    <>
+      <Box marginBottom={1}>
+        <Box width="72%" flexDirection="column" marginRight={1}>
+          <Text bold>Runs ({runs.length})</Text>
+          {runs.length === 0 && <Text color="gray">  No runs found</Text>}
+          {windowed.rows.map((run, idx) => {
+            const absoluteIndex = windowed.start + idx
+            const selected = selectedRun?.id === run.id
+            const issueTitle = resolveIssueTitle(run, titleLookup) ?? '(title unavailable)'
+            const prTitle = resolvePrTitle(run, titleLookup)
+            const statusColor = STATUS_COLORS[run.status] ?? 'white'
+
+            return (
+              <Box key={run.id} flexDirection="column">
+                <Text>
+                  <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
+                  {' '}
+                  <Text color="gray">{String(absoluteIndex + 1).padStart(2, '0')}</Text>
+                  {' '}
+                  <Text color={statusColor}>{run.status.padEnd(11)}</Text>
+                  {' '}
+                  <Text>{run.repo}#{run.issue_number}</Text>
+                  {'  '}
+                  <Text>{truncate(issueTitle, 58)}</Text>
+                </Text>
+                <Text color="gray">
+                  {'    '}
+                  <Text>{run.pr_number !== null ? `PR #${run.pr_number} ${truncate(prTitle ?? '(title unavailable)', 40)}` : 'No PR yet'}</Text>
+                  {'  '}
+                  <Text>phase {run.current_phase ?? '-'}</Text>
+                  {'  '}
+                  <Text>iter {run.iteration_count ?? 0}</Text>
+                  {'  '}
+                  <Text>cost ${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+                  {'  '}
+                  <Text>{formatTime(run.updated_at)}</Text>
+                </Text>
+              </Box>
+            )
+          })}
+          {runs.length > windowed.rows.length && (
+            <Text color="gray">  showing {windowed.start + 1}-{windowed.start + windowed.rows.length} of {runs.length}</Text>
+          )}
+        </Box>
+
+        <Box width="28%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+          <Text bold color="cyan">Issue Preview</Text>
+          {!selectedRun && <Text color="gray">Select a run to inspect</Text>}
+          {selectedRun && (
+            <>
+              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
+              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
+              <Text>{truncate(resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)', 46)}</Text>
+              {selectedRun.pr_number !== null && (
+                <Text color="gray">PR #{selectedRun.pr_number}: {truncate(resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)', 36)}</Text>
+              )}
+
+              <Box marginTop={1} flexDirection="column">
+                <Text bold>Log Glimpse</Text>
+                {selectedRunEvents.length === 0 && <Text color="gray">No agent events yet</Text>}
+                {selectedRunEvents.slice(-5).map((event) => {
+                  const color = EVENT_COLORS[event.event_type] ?? 'gray'
+                  return (
+                    <Text key={event.id}>
+                      <Text color="gray">{formatTime(event.created_at)}</Text>
+                      {' '}
+                      <Text color={color}>{truncate(event.event_type, 10)}</Text>
+                      {' '}
+                      <Text>{truncate(formatEventSummary(event), 22)}</Text>
+                    </Text>
+                  )
+                })}
+              </Box>
+
+              <Text color="gray">Press o or Enter for expanded view</Text>
+            </>
+          )}
+        </Box>
+      </Box>
+
+      <Box marginBottom={1} flexDirection="column">
+        <Text bold>System Snapshot</Text>
+        <Text color="gray">
+          {'  '}active {stats.overview.activeRuns}  running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}  merge queue {mergeBatches.length}
+        </Text>
+        {mergeBatches.slice(0, 3).map((batch) => (
+          <Text key={batch.id}>
+            {'  '}
+            <Text color="cyan">{batch.status}</Text>
+            {' '}
+            <Text>{batch.repo}</Text>
+            {' PRs '}
+            <Text>{formatPrList(batch.pr_numbers)}</Text>
+          </Text>
+        ))}
+      </Box>
+    </>
+  )
+}
+
+interface FocusedRunViewProps {
+  selectedRun: RunListRow | null
+  selectedRunEvents: AgentEventRow[]
+  titleLookup: TitleLookup
+  stats: TuiStatsSnapshot
+  mergeBatches: MergeBatchRow[]
+  eventScrollOffset: number
+  eventWindowSize: number
+}
+
+function FocusedRunView({
+  selectedRun,
+  selectedRunEvents,
+  titleLookup,
+  stats,
+  mergeBatches,
+  eventScrollOffset,
+  eventWindowSize,
+}: FocusedRunViewProps): React.ReactElement {
+  const maxEventOffset = Math.max(0, selectedRunEvents.length - eventWindowSize)
+  const clampedOffset = Math.max(0, Math.min(maxEventOffset, eventScrollOffset))
+  const visibleEvents = selectedRunEvents.slice(clampedOffset, clampedOffset + eventWindowSize)
+
+  return (
+    <Box marginBottom={1} flexDirection="column">
+      <Text bold>Run Detail</Text>
+      {!selectedRun && <Text color="gray">No run selected</Text>}
+      {selectedRun && (
+        <>
+          <Box>
+            <Box width="35%" flexDirection="column" marginRight={1} borderStyle="single" borderColor="gray" paddingX={1}>
+              <Text bold color="cyan">Overview</Text>
+              <Text>{selectedRun.repo}#{selectedRun.issue_number}</Text>
+              <Text color={STATUS_COLORS[selectedRun.status] ?? 'white'}>{selectedRun.status}</Text>
+              <Text>{resolveIssueTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
+              {selectedRun.pr_number !== null && (
+                <Text color="gray">PR #{selectedRun.pr_number}: {resolvePrTitle(selectedRun, titleLookup) ?? '(title unavailable)'}</Text>
+              )}
+              <Text color="gray">phase {selectedRun.current_phase ?? '-'}</Text>
+              <Text color="gray">iter {selectedRun.iteration_count ?? 0}  cost ${(selectedRun.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+              <Text color="gray">updated {formatTime(selectedRun.updated_at)}</Text>
+              {selectedRun.last_error && <Text color="red">error: {truncate(selectedRun.last_error, 90)}</Text>}
+              <Box marginTop={1} flexDirection="column">
+                <Text bold>System</Text>
+                <Text color="gray">active runs {stats.overview.activeRuns}</Text>
+                <Text color="gray">merge queue {mergeBatches.length}</Text>
+              </Box>
+            </Box>
+
+            <Box width="65%" flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
+              <Text bold color="cyan">Agent Stream ({selectedRunEvents.length})</Text>
+              {selectedRunEvents.length === 0 && <Text color="gray">No agent events</Text>}
+              {visibleEvents.map((event) => {
+                const color = EVENT_COLORS[event.event_type] ?? 'gray'
+                return (
+                  <Text key={event.id}>
+                    <Text color="gray">[{formatTime(event.created_at)}]</Text>
+                    {' '}
+                    <Text color="gray">{event.role}</Text>
+                    {' '}
+                    <Text color={color}>{event.event_type}</Text>
+                    {' '}
+                    <Text>{formatEventSummary(event)}</Text>
+                  </Text>
+                )
+              })}
+              {selectedRunEvents.length > eventWindowSize && (
+                <Text color="gray">
+                  showing {clampedOffset + 1}-{clampedOffset + visibleEvents.length} of {selectedRunEvents.length}
+                </Text>
+              )}
+            </Box>
+          </Box>
+          <Text color="gray">Press j/k to scroll stream, esc or q to close detail</Text>
+        </>
+      )}
+    </Box>
+  )
+}

--- a/src/cli/tui/stats-view.tsx
+++ b/src/cli/tui/stats-view.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { TuiStatsSnapshot } from '../../state/stats.js'
+import { buildSparkline } from './view-model.js'
+import { formatMinutes, formatStatusMix, formatTime, truncate } from './format.js'
+
+interface StatsViewProps {
+  stats: TuiStatsSnapshot
+  autoRefresh: boolean
+  pollIntervalMs: number
+  lastRefreshAt: string
+}
+
+export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }: StatsViewProps): React.ReactElement {
+  const costSeries = stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd)
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box marginBottom={1}>
+        <Text color={autoRefresh ? 'green' : 'yellow'}>{autoRefresh ? '● stats polling active' : '○ stats polling paused'}</Text>
+        <Text color="gray">  interval {pollIntervalMs / 1000}s</Text>
+        <Text color="gray">  last refresh {formatTime(lastRefreshAt)}</Text>
+      </Box>
+
+      <Box marginBottom={1}>
+        <StatCard title="Run Health" width="50%" marginRight={1}>
+          <Text>total {stats.overview.totalRuns}  active {stats.overview.activeRuns}</Text>
+          <Text color="gray">running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}</Text>
+          <Text color="gray">review_ready {stats.overview.reviewReadyRuns}  completed {stats.overview.completedRuns}</Text>
+          <Text color="gray">blocked {stats.overview.blockedRuns}  error {stats.overview.errorRuns}</Text>
+          <Text color="gray">mix {formatStatusMix(stats.statusCounts)}</Text>
+        </StatCard>
+
+        <StatCard title="Throughput" width="50%">
+          <Text>runs 24h {stats.throughput.runs24h}  7d {stats.throughput.runs7d}  30d {stats.throughput.runs30d}</Text>
+          <Text color="gray">completed 7d {stats.throughput.completed7d}</Text>
+          <Text color="gray">blocked 7d {stats.throughput.blocked7d}  error 7d {stats.throughput.error7d}</Text>
+          <Text color="gray">success 7d {stats.throughput.successRate7d.toFixed(1)}%</Text>
+          <Text color="gray">avg duration {formatMinutes(stats.throughput.avgDurationMinutes7d)}  avg iter {stats.throughput.avgIterations7d.toFixed(2)}</Text>
+        </StatCard>
+      </Box>
+
+      <Box marginBottom={1}>
+        <StatCard title="Cost" width="50%" marginRight={1}>
+          <Text>today ${stats.cost.todayCostUsd.toFixed(2)} ({stats.cost.todayRunCount} runs)</Text>
+          <Text color="gray">7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
+          <Text color="gray">avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
+          <Text color="gray">trend {buildSparkline(costSeries)}</Text>
+          {stats.cost.dailyHistory.slice(0, 4).map((row) => (
+            <Text key={row.date} color="gray">{row.date}: ${row.totalCostUsd.toFixed(2)} ({row.runCount})</Text>
+          ))}
+        </StatCard>
+
+        <StatCard title="Agent Activity" width="50%">
+          <Text>events total {stats.agents.eventsTotal}</Text>
+          <Text color="gray">24h {stats.agents.events24h}  7d {stats.agents.events7d}</Text>
+          <Text color="gray">tool calls 24h {stats.agents.toolCalls24h}</Text>
+          <Text color="gray">thinking 24h {stats.agents.thinking24h}  runs 7d {stats.agents.uniqueRuns7d}</Text>
+          <Text color="gray">
+            roles {stats.agents.roleBreakdown7d.length === 0 ? '-' : stats.agents.roleBreakdown7d.map((row) => `${row.role}:${row.events}`).join('  ')}
+          </Text>
+        </StatCard>
+      </Box>
+
+      <Box>
+        <StatCard title="Merge Queue" width="35%" marginRight={1}>
+          <Text>active batches {stats.queue.activeBatches}</Text>
+          <Text color="gray">
+            statuses {stats.queue.statuses.length === 0 ? '-' : stats.queue.statuses.map((row) => `${row.status}:${row.count}`).join('  ')}
+          </Text>
+          <Text color="gray">
+            active phases {stats.phaseCounts.length === 0 ? '-' : stats.phaseCounts.map((row) => `${row.phase}:${row.count}`).join('  ')}
+          </Text>
+        </StatCard>
+
+        <StatCard title="Top Repositories (30d)" width="65%">
+          {stats.topRepos30d.length === 0 && <Text color="gray">No run history</Text>}
+          {stats.topRepos30d.map((row) => {
+            const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
+            const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
+            return (
+              <Text key={row.repo}>
+                <Text>{truncate(row.repo, 28)}</Text>
+                {'  '}
+                <Text color="gray">runs {row.totalRuns}</Text>
+                {'  '}
+                <Text color="green">ok {successPct.toFixed(0)}%</Text>
+                {'  '}
+                <Text color="gray">cost ${row.totalCostUsd.toFixed(2)}</Text>
+                {'  '}
+                <Text color="gray">iter {row.avgIterations.toFixed(1)}</Text>
+              </Text>
+            )
+          })}
+        </StatCard>
+      </Box>
+    </Box>
+  )
+}
+
+interface StatCardProps {
+  title: string
+  width: string
+  marginRight?: number
+  children: React.ReactNode
+}
+
+function StatCard({ title, width, marginRight = 0, children }: StatCardProps): React.ReactElement {
+  return (
+    <Box
+      width={width}
+      marginRight={marginRight}
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="gray"
+      paddingX={1}
+    >
+      <Text bold color="cyan">{title}</Text>
+      {children}
+    </Box>
+  )
+}

--- a/src/cli/tui/types.ts
+++ b/src/cli/tui/types.ts
@@ -1,0 +1,10 @@
+export type TabId = 'runs' | 'stats' | 'logs'
+
+export type RunsViewMode = 'list' | 'focus'
+
+export interface TuiLogLine {
+  id: number
+  createdAt: string
+  level: 'info' | 'warn' | 'error'
+  message: string
+}

--- a/test/cli/tui/actions-bar.test.ts
+++ b/test/cli/tui/actions-bar.test.ts
@@ -12,8 +12,21 @@ describe('buildActionHints', () => {
 
     expect(hints.line1).toContain('[j/k]select')
     expect(hints.line1).toContain('[o/enter]open')
+    expect(hints.line1).toContain('[3]logs')
     expect(hints.line2).toContain('[r]etry')
     expect(hints.line2).toContain('[b]rebase')
+  })
+
+  it('shows focused run controls when detail view is open', () => {
+    const hints = buildActionHints({
+      activeTab: 'runs',
+      busy: false,
+      runFocused: true,
+      autoRefresh: true,
+    })
+
+    expect(hints.line1).toContain('[j/k]scroll')
+    expect(hints.line1).toContain('[esc/q]close')
   })
 
   it('shows stats polling controls on stats tab without retry/rebase', () => {
@@ -28,5 +41,17 @@ describe('buildActionHints', () => {
     expect(hints.line2).toContain('polling paused')
     expect(hints.line2).not.toContain('retry')
     expect(hints.line2).not.toContain('rebase')
+  })
+
+  it('shows log navigation controls on logs tab', () => {
+    const hints = buildActionHints({
+      activeTab: 'logs',
+      busy: false,
+      runFocused: false,
+      autoRefresh: false,
+    })
+
+    expect(hints.line1).toContain('[j/k]scroll logs')
+    expect(hints.line2).toContain('[q]quit')
   })
 })


### PR DESCRIPTION
Closes #26

## Plan
**Objective:** Restructure the TUI into modular components, fix keybinding/layout issues, integrate server+TUI into a unified command, and add React coding rules

1. Add React/TUI coding rules for Claude and Codex — create .claude/rules/08-react-tui.md with conventions: component file structure (one component per file, max ~150 lines), hooks extraction patterns, keybinding scoping (view-level not global), naming conventions, Ink-specific patterns (Box/Text usage, useInput scoping), and no-flicker guidelines (memoization, stable keys, avoid unnecessary re-renders)
2. Extract shared types, constants, and utility functions from app.tsx into dedicated files: types.ts (TabId, RunsViewMode, ActionState, AppProps, all component prop interfaces), constants.ts (TABS, STATUS_COLORS, EVENT_COLORS), format.ts (formatTime, formatMinutes, formatPrList, formatEventSummary, parseEventData, asString, truncate). This prepares the foundation for component extraction without changing behavior.
3. Extract custom hooks from the App component: (a) use-data-polling.ts — timer tick, auto-refresh toggle, data loading (runs, events, batches, stats), selected run tracking; (b) use-actions.ts — action state management, runRetry/runSync/runCleanup/runPoll/runRebase callbacks; (c) use-title-hydration.ts — forge-based title lookup with debounce and attempt tracking; (d) use-keyboard.ts — centralized keyboard handler that dispatches based on active view context, with proper scoping so focus-view keys don't leak to list view
4. Extract UI components from app.tsx into individual files: header.tsx (Header), runs-list.tsx (windowed run list with selection indicator), run-detail.tsx (FocusedRunView with overview + agent stream panels), stats-view.tsx (StatsView with all stat cards), stat-card.tsx (StatCard), status-bar.tsx (status line display), log-panel.tsx (agent event stream), merge-queue.tsx (merge batch display). Each file exports one component, imports from types/constants/format.
5. Create view-level containers that compose components and own their keybinding scope: runs-tab.tsx (RunsTab — owns j/k/o/Enter/Esc/r/b/s/c/p bindings, manages list vs focus sub-view), stats-tab.tsx (StatsTab — owns 'a' toggle), logs-tab.tsx (LogsTab — new tab for embedded server logs, owns scroll bindings). Views consume hooks and pass data down to presentational components.
6. Rewrite app.tsx as a thin shell (~80 lines): fullscreen mode activation (Ink's render with alternateScreen option or manual ANSI alternate screen buffer \x1b[?1049h on mount, \x1b[?1049l on unmount), tab router dispatching to view containers, global-only keybindings (q/Ctrl+C to exit, 1/2/3 and h/l for tab switching, f for force refresh). Remove all inline component definitions and move to imports. The 'q' key should only exit from the top-level app — views handle their own Esc behavior.
7. Fix keybinding scoping in the focus/detail view: (a) In run-detail view, j/k should scroll through agent events, not switch runs — run switching only in list view; (b) 'q' in any sub-view (focus, stats) returns to parent view, only 'q' at top-level list exits the TUI; (c) Esc in focus view closes it (already works but ensure it's in the view's own useInput, not global); (d) Implement proper input focus chain: App (global keys) → active Tab view (tab-specific keys) → sub-view (sub-view-specific keys)
8. Implement fullscreen terminal usage: Use Ink's render() with the built-in fullscreen support or manually enter alternate screen buffer on TUI start. This ensures the TUI takes over the entire terminal and shell history is not visible. On exit (q/Ctrl+C), restore the original screen buffer. Test with process.stdout.rows/columns to adapt layout.
9. Reduce flickering: (a) Memoize all data-derived computations with useMemo and stable dependency arrays; (b) Use React.memo() on all presentational components (Header, RunsList, RunDetail, StatsView, StatCard, etc.); (c) Ensure stable keys on all .map() renders (already using run.id/event.id/batch.id — verify); (d) Batch state updates where possible (React 19 auto-batches in most cases); (e) Avoid re-creating callbacks on every render — ensure useCallback deps are minimal; (f) Consider reducing default poll interval from 2s to 3-5s if flicker persists
10. Implement unified server+TUI command: Modify 'night-orch run' to accept a --tui flag (or make it the default when stdout is a TTY). When --tui is active: (a) start the polling orchestrator in the background (same poll loop as current run.ts), (b) capture pino log output into a ring buffer instead of stdout, (c) render the TUI with a new [3]Logs tab that displays the captured log buffer, (d) graceful shutdown handles both poller and TUI. This gives a single 'night-orch run' command that shows the TUI with embedded server. The standalone 'night-orch tui' command remains for connecting to an already-running instance (read-only monitoring).
11. Clean up unused component files from prior extraction attempts: Remove or repurpose agent-stream.tsx, active-runs.tsx, recent-runs.tsx, cost-bar.tsx, merge-queue-panel.tsx — their functionality is now covered by the new modular components. Update actions-bar.tsx to import from the new types/constants modules.
12. Verify command parity: Ensure the new Logs tab and unified run+TUI mode are reflected in MCP tools (src/mcp/tools/) if applicable. The TUI itself doesn't need MCP parity (it IS the UI surface), but any new operational commands exposed through the TUI must also be available via CLI and MCP.
13. Run typecheck (pnpm typecheck), lint (pnpm lint), and tests (pnpm test) to verify everything compiles and passes. Fix any issues. Test the TUI manually with 'mise run dev-solo' to verify: fullscreen mode works, keybindings are properly scoped, no flickering, logs tab shows server output, q/esc behavior is correct per view context.

## Implementation
Refactored the TUI into a modular file-based structure (separate header/runs/stats/logs views, constants/types/format helpers), integrated poller + logs into the TUI flow, and made `night-orch` (no subcommand) launch the interactive TUI directly. Fixed focus-view keybindings so `j/k` scroll inside issue detail, and `q`/`esc` close detail instead of exiting. Updated terminal layout behavior to use alternate-screen full-terminal rendering, added React TUI rule files for both Claude and Codex, and updated TUI action-hint tests. Validation passed: `pnpm typecheck`, `pnpm lint`, `pnpm test`.

**Changed files:**
- `AGENTS.md`
- `CLAUDE.md`
- `.claude/rules/08-react-tui.md`
- `.codex/rules/08-react-tui.md`
- `src/cli/index.ts`
- `src/cli/commands/watch.ts`
- `src/cli/tui/app.tsx`
- `src/cli/tui/actions-bar.tsx`
- `src/cli/tui/constants.ts`
- `src/cli/tui/format.ts`
- `src/cli/tui/header.tsx`
- `src/cli/tui/logs-view.tsx`
- `src/cli/tui/runs-view.tsx`
- `src/cli/tui/stats-view.tsx`
- `src/cli/tui/types.ts`
- `test/cli/tui/actions-bar.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Clean modular extraction of TUI components with proper keybinding scoping, alt-screen support, and integrated background poller. Two minor scroll edge cases and a missing SIGINT fallback, but nothing blocking.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude