### PR TITLE
[night-orch] #30 TUI - dim navigation options at bottom

### DIFF
--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -45,8 +45,8 @@ export function ActionsBar(props: ActionsBarProps): React.ReactElement {
 
   return (
     <Box marginTop={1} flexDirection="column">
-      <Text dimColor>{hints.line1}</Text>
-      <Text dimColor>{hints.line2}</Text>
+      <Text color="gray">{hints.line1}</Text>
+      <Text color="gray">{hints.line2}</Text>
     </Box>
   )
 }


### PR DESCRIPTION
Closes #30

## Plan
**Objective:** Change TUI bottom navigation hints from dimColor to color="gray" to match the header's gray styling

1. In ActionsBar component, change <Text dimColor> to <Text color="gray"> on both hint lines (lines 48-49) to match the header's gray styling pattern

## Implementation
Updated the TUI bottom navigation hints in `ActionsBar` to use explicit gray styling (`color="gray"`) instead of `dimColor`, matching the header’s gray appearance. Ran `pnpm -s typecheck` successfully.

**Changed files:**
- `src/cli/tui/actions-bar.tsx`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Straightforward styling change: switches bottom navigation hints from `dimColor` to `color="gray"` to match the header and the rest of the TUI's hint styling convention.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=claude