### PR TITLE
[night-orch] #31 TUI - render old/inactive/done issues differently

### DIFF
--- a/src/cli/tui/runs-view.tsx
+++ b/src/cli/tui/runs-view.tsx
@@ -6,7 +6,7 @@ import type { AgentEventRow, MergeBatchRow, RunListRow } from './data.js'
 import { formatEventSummary, formatPrList, formatTime, truncate } from './format.js'
 import { resolveIssueTitle, resolvePrTitle, type TitleLookup } from './titles.js'
 import type { RunsViewMode } from './types.js'
-import { sliceWindow } from './view-model.js'
+import { partitionRowsByActivity, sliceWindow } from './view-model.js'
 
 interface RunsViewProps {
   runs: RunListRow[]
@@ -49,7 +49,56 @@ export function RunsView({
     )
   }
 
-  const windowed = sliceWindow(runs, selectedIndex, maxVisibleRuns)
+  const allSections = partitionRowsByActivity(runs)
+  const runIndexById = new Map(runs.map((run, index) => [run.id, index]))
+  const selectedRecentIndex = selectedRun
+    ? allSections.recent.findIndex((run) => run.id === selectedRun.id)
+    : -1
+  const fallbackRecentIndex = Math.max(0, selectedIndex - allSections.active.length)
+  const recentWindowSize = Math.max(1, maxVisibleRuns - allSections.active.length)
+  const recentWindow = sliceWindow(
+    allSections.recent,
+    selectedRecentIndex >= 0 ? selectedRecentIndex : fallbackRecentIndex,
+    recentWindowSize,
+  )
+
+  const renderRunRow = (run: RunListRow, dimmed: boolean): React.ReactElement => {
+    const selected = selectedRun?.id === run.id
+    const issueTitle = resolveIssueTitle(run, titleLookup) ?? '(title unavailable)'
+    const prTitle = resolvePrTitle(run, titleLookup)
+    const statusColor = STATUS_COLORS[run.status] ?? 'white'
+    const absoluteIndex = runIndexById.get(run.id) ?? 0
+
+    return (
+      <Box key={run.id} flexDirection="column">
+        <Text>
+          <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
+          {' '}
+          <Text dimColor={dimmed}>
+            <Text color="gray">{String(absoluteIndex + 1).padStart(2, '0')}</Text>
+            {' '}
+            <Text color={statusColor}>{run.status.padEnd(11)}</Text>
+            {' '}
+            <Text>{run.repo}#{run.issue_number}</Text>
+            {'  '}
+            <Text>{truncate(issueTitle, 58)}</Text>
+          </Text>
+        </Text>
+        <Text dimColor color={dimmed ? 'gray' : undefined}>
+          {'    '}
+          <Text>{run.pr_number !== null ? `PR #${run.pr_number} ${truncate(prTitle ?? '(title unavailable)', 40)}` : 'No PR yet'}</Text>
+          {'  '}
+          <Text>phase {run.current_phase ?? '-'}</Text>
+          {'  '}
+          <Text>iter {run.iteration_count ?? 0}</Text>
+          {'  '}
+          <Text>cost ${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+          {'  '}
+          <Text>{formatTime(run.updated_at)}</Text>
+        </Text>
+      </Box>
+    )
+  }
 
   return (
     <>
@@ -57,43 +106,22 @@ export function RunsView({
         <Box width="72%" flexDirection="column" marginRight={1}>
           <Text bold>Runs ({runs.length})</Text>
           {runs.length === 0 && <Text color="gray">  No runs found</Text>}
-          {windowed.rows.map((run, idx) => {
-            const absoluteIndex = windowed.start + idx
-            const selected = selectedRun?.id === run.id
-            const issueTitle = resolveIssueTitle(run, titleLookup) ?? '(title unavailable)'
-            const prTitle = resolvePrTitle(run, titleLookup)
-            const statusColor = STATUS_COLORS[run.status] ?? 'white'
+          {runs.length > 0 && (
+            <>
+              <Text bold color="cyan">Active ({allSections.active.length})</Text>
+              {allSections.active.length === 0 && <Text color="gray">  No active runs</Text>}
+              {allSections.active.map((run) => renderRunRow(run, false))}
 
-            return (
-              <Box key={run.id} flexDirection="column">
-                <Text>
-                  <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
-                  {' '}
-                  <Text color="gray">{String(absoluteIndex + 1).padStart(2, '0')}</Text>
-                  {' '}
-                  <Text color={statusColor}>{run.status.padEnd(11)}</Text>
-                  {' '}
-                  <Text>{run.repo}#{run.issue_number}</Text>
-                  {'  '}
-                  <Text>{truncate(issueTitle, 58)}</Text>
-                </Text>
-                <Text dimColor>
-                  {'    '}
-                  <Text>{run.pr_number !== null ? `PR #${run.pr_number} ${truncate(prTitle ?? '(title unavailable)', 40)}` : 'No PR yet'}</Text>
-                  {'  '}
-                  <Text>phase {run.current_phase ?? '-'}</Text>
-                  {'  '}
-                  <Text>iter {run.iteration_count ?? 0}</Text>
-                  {'  '}
-                  <Text>cost ${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
-                  {'  '}
-                  <Text>{formatTime(run.updated_at)}</Text>
-                </Text>
-              </Box>
-            )
-          })}
-          {runs.length > windowed.rows.length && (
-            <Text color="gray">  showing {windowed.start + 1}-{windowed.start + windowed.rows.length} of {runs.length}</Text>
+              <Text bold color="gray">Recent ({allSections.recent.length})</Text>
+              {allSections.recent.length === 0 && <Text color="gray">  No recent runs</Text>}
+              {recentWindow.rows.map((run) => renderRunRow(run, true))}
+            </>
+          )}
+          {allSections.recent.length > recentWindow.rows.length && (
+            <Text color="gray">
+              {'  '}
+              showing recent {recentWindow.start + 1}-{recentWindow.start + recentWindow.rows.length} of {allSections.recent.length}
+            </Text>
           )}
         </Box>
 

--- a/src/cli/tui/view-model.ts
+++ b/src/cli/tui/view-model.ts
@@ -3,6 +3,11 @@ export interface WindowedSlice<T> {
   rows: T[]
 }
 
+export interface PartitionedRows<T> {
+  active: T[]
+  recent: T[]
+}
+
 export function sliceWindow<T>(rows: T[], selectedIndex: number, windowSize: number): WindowedSlice<T> {
   if (rows.length === 0) return { start: 0, rows: [] }
   const safeWindow = Math.max(1, windowSize)
@@ -14,6 +19,25 @@ export function sliceWindow<T>(rows: T[], selectedIndex: number, windowSize: num
     start,
     rows: rows.slice(start, start + safeWindow),
   }
+}
+
+export function isActiveRunStatus(status: string): boolean {
+  return status === 'queued' || status === 'running'
+}
+
+export function partitionRowsByActivity<T extends { status: string }>(rows: T[]): PartitionedRows<T> {
+  const active: T[] = []
+  const recent: T[] = []
+
+  for (const row of rows) {
+    if (isActiveRunStatus(row.status)) {
+      active.push(row)
+      continue
+    }
+    recent.push(row)
+  }
+
+  return { active, recent }
 }
 
 export function buildSparkline(values: number[]): string {

--- a/test/cli/tui/view-model.test.ts
+++ b/test/cli/tui/view-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildSparkline, sliceWindow } from '../../../src/cli/tui/view-model.js'
+import { buildSparkline, isActiveRunStatus, partitionRowsByActivity, sliceWindow } from '../../../src/cli/tui/view-model.js'
 
 describe('tui view model helpers', () => {
   it('centers a selected index in a bounded window', () => {
@@ -15,5 +15,66 @@ describe('tui view model helpers', () => {
 
     expect(sparkline).toHaveLength(4)
     expect(sparkline).not.toBe('----')
+  })
+
+  it('treats only queued and running statuses as active', () => {
+    expect(isActiveRunStatus('queued')).toBe(true)
+    expect(isActiveRunStatus('running')).toBe(true)
+    expect(isActiveRunStatus('review_ready')).toBe(false)
+    expect(isActiveRunStatus('completed')).toBe(false)
+  })
+
+  it('partitions rows into active and recent sections', () => {
+    const rows = [
+      { id: 'a', status: 'running' },
+      { id: 'b', status: 'queued' },
+      { id: 'c', status: 'review_ready' },
+      { id: 'd', status: 'error' },
+    ]
+
+    const partitioned = partitionRowsByActivity(rows)
+
+    expect(partitioned.active).toEqual([
+      { id: 'a', status: 'running' },
+      { id: 'b', status: 'queued' },
+    ])
+    expect(partitioned.recent).toEqual([
+      { id: 'c', status: 'review_ready' },
+      { id: 'd', status: 'error' },
+    ])
+  })
+
+  it('returns empty active and recent arrays for empty input', () => {
+    const partitioned = partitionRowsByActivity([])
+    expect(partitioned.active).toEqual([])
+    expect(partitioned.recent).toEqual([])
+  })
+
+  it('returns empty recent when all rows are active', () => {
+    const partitioned = partitionRowsByActivity([
+      { id: 'a', status: 'running' },
+      { id: 'b', status: 'queued' },
+    ])
+
+    expect(partitioned.active).toEqual([
+      { id: 'a', status: 'running' },
+      { id: 'b', status: 'queued' },
+    ])
+    expect(partitioned.recent).toEqual([])
+  })
+
+  it('returns empty active when all rows are recent', () => {
+    const partitioned = partitionRowsByActivity([
+      { id: 'a', status: 'review_ready' },
+      { id: 'b', status: 'completed' },
+      { id: 'c', status: 'error' },
+    ])
+
+    expect(partitioned.active).toEqual([])
+    expect(partitioned.recent).toEqual([
+      { id: 'a', status: 'review_ready' },
+      { id: 'b', status: 'completed' },
+      { id: 'c', status: 'error' },
+    ])
   })
 })


### PR DESCRIPTION
Closes #31

## Plan
**Objective:** Split the TUI runs list into Active and Recent sections, dimming inactive/done runs

1. Add ACTIVE_STATUSES set to constants.ts — defines which statuses are considered active (running, queued, review_ready). This is the single source of truth for the active/inactive split.
2. Refactor the list-mode rendering in runs-view.tsx to split runs into two sections. After sliceWindow produces the visible rows, partition them into active and inactive groups. Render an 'Active' header followed by active runs (bright), then a 'Recent' header followed by inactive runs (dimmed — both lines get dimColor). Section headers only appear if that section has rows in the visible window. The key insight: we do NOT change the flat list or selectedIndex — we just visually group the windowed rows and dim the inactive ones.
3. In the run row rendering, apply dimColor to the entire row (both lines) for inactive runs. Active runs keep the current bright styling. The selection marker (▶) and status color remain visible even on dimmed rows to maintain scannability.

## Implementation
Addressed both review findings. In `runs-view.tsx`, active runs are now always rendered unwindowed, while only the recent section is windowed with an adjusted index/size. This removes the header/row mismatch where `Active (N)` could show no rows. Also updated the truncated indicator to apply to recent rows only. In `view-model` tests, added edge-case coverage for `partitionRowsByActivity` with empty input, all-active input, and all-recent input.

**Changed files:**
- `src/cli/tui/runs-view.tsx`
- `src/cli/tui/view-model.ts`
- `test/cli/tui/view-model.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Both previous findings have been addressed. Active runs render without windowing, recent runs are windowed. Edge-case tests added for empty input, all-active, and all-recent. The partition logic is consistent with the DB's definition of active (queued + running). Code is clean and well-structured.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=claude