### PR TITLE
[CHORE] TUI - Extended stats and color coding (night-orch / #39)

### DIFF
--- a/src/cli/tui/stats-view.tsx
+++ b/src/cli/tui/stats-view.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import { Box, Text } from 'ink'
 import type { TuiStatsSnapshot } from '../../state/stats.js'
-import { buildSparkline } from './view-model.js'
+import {
+  buildSparkline,
+  colorForHigherIsBetter,
+  colorForLowerIsBetter,
+  colorForPresence,
+  colorForRatioToBaseline,
+} from './view-model.js'
 import { formatMinutes, formatStatusMix, formatTime, truncate } from './format.js'
 
 interface StatsViewProps {
@@ -13,6 +19,21 @@ interface StatsViewProps {
 
 export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }: StatsViewProps): React.ReactElement {
   const costSeries = stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd)
+  const successColor = colorForHigherIsBetter(stats.throughput.successRate7d, 80, 60)
+  const failureRateColor = colorForLowerIsBetter(stats.reliability.failureRate7d, 10, 25)
+  const overviewBlockedColor = colorForPresence(stats.overview.blockedRuns, 1, 2)
+  const overviewErrorColor = colorForPresence(stats.overview.errorRuns, 1, 2)
+  const throughputBlockedColor = colorForPresence(stats.throughput.blocked7d, 1, 2)
+  const throughputErrorColor = colorForPresence(stats.throughput.error7d, 1, 2)
+  const todayCostColor = colorForRatioToBaseline(stats.cost.todayCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)
+  const costPerRunColor = colorForLowerIsBetter(stats.efficiency.avgCostPerRun7d, 1.5, 3)
+  const costPerSuccessColor = colorForLowerIsBetter(stats.efficiency.avgCostPerSuccess7d, 3, 6)
+  const expiredLeaseColor = colorForPresence(stats.resources.expiredLeases, 1, 2)
+  const expiringLeaseColor = colorForPresence(stats.resources.expiringLeases, 1, 3)
+  const missingWorktreeColor = colorForPresence(stats.resources.missingWorktrees, 1, 2)
+  const staleWorktreeColor = colorForPresence(stats.resources.staleWorktrees, 1, 2)
+  const tailLatencyRatio = stats.timing.p50Minutes > 0 ? stats.timing.p90Minutes / stats.timing.p50Minutes : 1
+  const tailLatencyColor = colorForLowerIsBetter(tailLatencyRatio, 2.5, 4.5)
 
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -27,27 +48,66 @@ export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }:
           <Text>total {stats.overview.totalRuns}  active {stats.overview.activeRuns}</Text>
           <Text>running {stats.overview.runningRuns}  queued {stats.overview.queuedRuns}</Text>
           <Text>review_ready {stats.overview.reviewReadyRuns}  completed {stats.overview.completedRuns}</Text>
-          <Text>blocked {stats.overview.blockedRuns}  error {stats.overview.errorRuns}</Text>
+          <Text>
+            blocked <Text color={overviewBlockedColor}>{stats.overview.blockedRuns}</Text>
+            {'  '}
+            error <Text color={overviewErrorColor}>{stats.overview.errorRuns}</Text>
+          </Text>
           <Text dimColor>mix {formatStatusMix(stats.statusCounts)}</Text>
         </StatCard>
 
         <StatCard title="Throughput" width="50%">
           <Text>runs 24h {stats.throughput.runs24h}  7d {stats.throughput.runs7d}  30d {stats.throughput.runs30d}</Text>
           <Text>completed 7d {stats.throughput.completed7d}</Text>
-          <Text>blocked 7d {stats.throughput.blocked7d}  error 7d {stats.throughput.error7d}</Text>
-          <Text>success 7d {stats.throughput.successRate7d.toFixed(1)}%</Text>
+          <Text>
+            blocked 7d <Text color={throughputBlockedColor}>{stats.throughput.blocked7d}</Text>
+            {'  '}
+            error 7d <Text color={throughputErrorColor}>{stats.throughput.error7d}</Text>
+          </Text>
+          <Text>
+            success 7d <Text color={successColor}>{stats.throughput.successRate7d.toFixed(1)}%</Text>
+            {'  '}
+            failure rate <Text color={failureRateColor}>{stats.reliability.failureRate7d.toFixed(1)}%</Text>
+          </Text>
           <Text dimColor>avg duration {formatMinutes(stats.throughput.avgDurationMinutes7d)}  avg iter {stats.throughput.avgIterations7d.toFixed(2)}</Text>
+          <Text dimColor>
+            p50 {formatMinutes(stats.timing.p50Minutes)}
+            {'  '}
+            p90 <Text color={tailLatencyColor}>{formatMinutes(stats.timing.p90Minutes)}</Text>
+            {'  '}
+            p99 <Text color={tailLatencyColor}>{formatMinutes(stats.timing.p99Minutes)}</Text>
+            {'  '}
+            n {stats.timing.sampleSize30d}
+          </Text>
         </StatCard>
       </Box>
 
       <Box marginBottom={1}>
         <StatCard title="Cost" width="50%" marginRight={1}>
-          <Text>today ${stats.cost.todayCostUsd.toFixed(2)} ({stats.cost.todayRunCount} runs)</Text>
+          <Text>
+            today <Text color={todayCostColor}>${stats.cost.todayCostUsd.toFixed(2)}</Text> ({stats.cost.todayRunCount} runs)
+          </Text>
           <Text>7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
           <Text>avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
+          <Text>
+            cost/run 7d <Text color={costPerRunColor}>${stats.efficiency.avgCostPerRun7d.toFixed(2)}</Text>
+            {'  '}
+            cost/success <Text color={costPerSuccessColor}>${stats.efficiency.avgCostPerSuccess7d.toFixed(2)}</Text>
+          </Text>
+          <Text>
+            cost/iter <Text color={costPerRunColor}>${stats.efficiency.avgCostPerIteration7d.toFixed(2)}</Text>
+            {'  '}
+            completed/$ <Text color={successColor}>{stats.efficiency.completedPerDollar7d.toFixed(2)}</Text>
+          </Text>
           <Text>trend {buildSparkline(costSeries)}</Text>
           {stats.cost.dailyHistory.slice(0, 4).map((row) => (
-            <Text key={row.date} dimColor>{row.date}: ${row.totalCostUsd.toFixed(2)} ({row.runCount})</Text>
+            <Text key={row.date} dimColor>
+              <Text color={colorForRatioToBaseline(row.totalCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)}>
+                {row.date}: ${row.totalCostUsd.toFixed(2)}
+              </Text>
+              {'  '}
+              ({row.runCount})
+            </Text>
           ))}
         </StatCard>
 
@@ -59,6 +119,52 @@ export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }:
           <Text dimColor>
             roles {stats.agents.roleBreakdown7d.length === 0 ? '-' : stats.agents.roleBreakdown7d.map((row) => `${row.role}:${row.events}`).join('  ')}
           </Text>
+        </StatCard>
+      </Box>
+
+      <Box marginBottom={1}>
+        <StatCard title="Reliability" width="50%" marginRight={1}>
+          <Text>
+            failures 7d <Text color={failureRateColor}>{stats.reliability.failureCount7d}</Text>
+            {'  '}
+            rate <Text color={failureRateColor}>{stats.reliability.failureRate7d.toFixed(1)}%</Text>
+          </Text>
+          <Text>
+            tail p90/p50 <Text color={tailLatencyColor}>{tailLatencyRatio.toFixed(2)}x</Text>
+            {'  '}
+            median {formatMinutes(stats.timing.p50Minutes)}
+          </Text>
+          <Text dimColor>patterns (7d)</Text>
+          {stats.reliability.topErrorPatterns7d.length === 0 && <Text color="gray">none in the last 7 days</Text>}
+          {stats.reliability.topErrorPatterns7d.map((row) => (
+            <Text key={`${row.pattern}-${row.count}`}>
+              <Text color={colorForPresence(row.count, 2, 4)}>{String(row.count).padStart(2, ' ')}x</Text>
+              {'  '}
+              <Text>{truncate(row.pattern, 64)}</Text>
+            </Text>
+          ))}
+        </StatCard>
+
+        <StatCard title="Resources" width="50%">
+          <Text>
+            leases active <Text color="green">{stats.resources.activeLeases}</Text>
+            {'  '}
+            repos {stats.resources.leasedRepos}
+          </Text>
+          <Text>
+            expiring <Text color={expiringLeaseColor}>{stats.resources.expiringLeases}</Text>
+            {'  '}
+            expired <Text color={expiredLeaseColor}>{stats.resources.expiredLeases}</Text>
+          </Text>
+          <Text>
+            worktrees active <Text color="cyan">{stats.resources.activeWorktrees}</Text>
+            {'  '}
+            missing <Text color={missingWorktreeColor}>{stats.resources.missingWorktrees}</Text>
+          </Text>
+          <Text>
+            stale completed worktrees <Text color={staleWorktreeColor}>{stats.resources.staleWorktrees}</Text>
+          </Text>
+          <Text dimColor>lease horizon marks leases expiring in ≤30m</Text>
         </StatCard>
       </Box>
 
@@ -78,13 +184,14 @@ export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }:
           {stats.topRepos30d.map((row) => {
             const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
             const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
+            const repoSuccessColor = colorForHigherIsBetter(successPct, 80, 60)
             return (
               <Text key={row.repo}>
                 <Text>{truncate(row.repo, 28)}</Text>
                 {'  '}
                 <Text>runs {row.totalRuns}</Text>
                 {'  '}
-                <Text color="green">ok {successPct.toFixed(0)}%</Text>
+                <Text color={repoSuccessColor}>ok {successPct.toFixed(0)}%</Text>
                 {'  '}
                 <Text>cost ${row.totalCostUsd.toFixed(2)}</Text>
                 {'  '}

--- a/src/cli/tui/view-model.ts
+++ b/src/cli/tui/view-model.ts
@@ -8,6 +8,8 @@ export interface PartitionedRows<T> {
   recent: T[]
 }
 
+export type MetricColor = 'white' | 'gray' | 'green' | 'yellow' | 'red' | 'cyan' | 'magenta'
+
 export function sliceWindow<T>(rows: T[], selectedIndex: number, windowSize: number): WindowedSlice<T> {
   if (rows.length === 0) return { start: 0, rows: [] }
   const safeWindow = Math.max(1, windowSize)
@@ -58,4 +60,37 @@ export function buildSparkline(values: number[]): string {
       return bars[index] ?? '▁'
     })
     .join('')
+}
+
+export function colorForHigherIsBetter(value: number, greenAt: number, yellowAt: number): MetricColor {
+  if (value >= greenAt) return 'green'
+  if (value >= yellowAt) return 'yellow'
+  return 'red'
+}
+
+export function colorForLowerIsBetter(value: number, greenAt: number, yellowAt: number): MetricColor {
+  if (value <= greenAt) return 'green'
+  if (value <= yellowAt) return 'yellow'
+  return 'red'
+}
+
+export function colorForPresence(value: number, yellowAt = 1, redAt = 3): MetricColor {
+  if (value < yellowAt) return 'green'
+  if (value < redAt) return 'yellow'
+  return 'red'
+}
+
+export function colorForRatioToBaseline(
+  value: number,
+  baseline: number,
+  greenAtRatio: number,
+  yellowAtRatio: number,
+): MetricColor {
+  if (baseline <= 0) {
+    return value <= 0 ? 'green' : 'yellow'
+  }
+  const ratio = value / baseline
+  if (ratio <= greenAtRatio) return 'green'
+  if (ratio <= yellowAtRatio) return 'yellow'
+  return 'red'
 }

--- a/src/state/stats.ts
+++ b/src/state/stats.ts
@@ -32,6 +32,11 @@ export interface DailyCostAggregate {
   runCount: number
 }
 
+export interface ErrorPatternAggregate {
+  pattern: string
+  count: number
+}
+
 export interface TuiStatsSnapshot {
   readonly updatedAt: string
   readonly overview: {
@@ -57,6 +62,11 @@ export interface TuiStatsSnapshot {
     avgDurationMinutes7d: number
     avgIterations7d: number
   }
+  readonly reliability: {
+    failureCount7d: number
+    failureRate7d: number
+    topErrorPatterns7d: ErrorPatternAggregate[]
+  }
   readonly cost: {
     todayCostUsd: number
     todayRunCount: number
@@ -64,6 +74,28 @@ export interface TuiStatsSnapshot {
     cost30d: number
     avgDailyCost7d: number
     dailyHistory: DailyCostAggregate[]
+  }
+  readonly efficiency: {
+    totalCostUsd7d: number
+    avgCostPerRun7d: number
+    avgCostPerSuccess7d: number
+    avgCostPerIteration7d: number
+    completedPerDollar7d: number
+  }
+  readonly resources: {
+    activeLeases: number
+    expiringLeases: number
+    expiredLeases: number
+    leasedRepos: number
+    activeWorktrees: number
+    missingWorktrees: number
+    staleWorktrees: number
+  }
+  readonly timing: {
+    sampleSize30d: number
+    p50Minutes: number
+    p90Minutes: number
+    p99Minutes: number
   }
   readonly queue: {
     activeBatches: number
@@ -147,6 +179,18 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
     )
     .get() as ThroughputRow | undefined
 
+  const efficiencyRow = db
+    .prepare(
+      `SELECT
+         COUNT(*) AS runs_7d,
+         SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_7d,
+         SUM(COALESCE(estimated_cost_usd, 0)) AS total_cost_usd_7d,
+         SUM(COALESCE(iteration_count, 0)) AS total_iterations_7d
+       FROM runs
+       WHERE datetime(created_at) >= datetime('now', '-7 days')`,
+    )
+    .get() as EfficiencyRow | undefined
+
   const costRow = db
     .prepare(
       `SELECT
@@ -167,6 +211,82 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
        ORDER BY date DESC`,
     )
     .all() as DailyCostRow[]
+
+  const errorMessages = db
+    .prepare(
+      `SELECT COALESCE(NULLIF(TRIM(block_reason), ''), NULLIF(TRIM(last_error), '')) AS message
+       FROM runs
+       WHERE datetime(created_at) >= datetime('now', '-7 days')
+         AND status IN ('blocked', 'error')
+         AND COALESCE(NULLIF(TRIM(block_reason), ''), NULLIF(TRIM(last_error), '')) IS NOT NULL
+       ORDER BY datetime(updated_at) DESC
+       LIMIT 200`,
+    )
+    .all() as ErrorMessageRow[]
+
+  const leaseHealthRow = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN datetime(leased_until) >= datetime('now') THEN 1 ELSE 0 END) AS active_leases,
+         SUM(
+           CASE
+             WHEN datetime(leased_until) >= datetime('now')
+               AND datetime(leased_until) <= datetime('now', '+30 minutes')
+             THEN 1
+             ELSE 0
+           END
+         ) AS expiring_leases,
+         SUM(CASE WHEN datetime(leased_until) < datetime('now') THEN 1 ELSE 0 END) AS expired_leases,
+         COUNT(DISTINCT CASE WHEN datetime(leased_until) >= datetime('now') THEN repo ELSE NULL END) AS leased_repos
+       FROM leases`,
+    )
+    .get() as LeaseHealthRow | undefined
+
+  const worktreeHealthRow = db
+    .prepare(
+      `SELECT
+         COUNT(
+           DISTINCT CASE
+             WHEN status IN ('queued', 'running', 'blocked', 'review_ready', 'error')
+               AND worktree_path IS NOT NULL
+               AND TRIM(worktree_path) != ''
+             THEN worktree_path
+             ELSE NULL
+           END
+         ) AS active_worktrees,
+         SUM(
+           CASE
+             WHEN status IN ('queued', 'running', 'blocked', 'review_ready', 'error')
+               AND (worktree_path IS NULL OR TRIM(worktree_path) = '')
+             THEN 1
+             ELSE 0
+           END
+         ) AS missing_worktrees,
+         COUNT(
+           DISTINCT CASE
+             WHEN status = 'completed'
+               AND worktree_path IS NOT NULL
+               AND TRIM(worktree_path) != ''
+               AND datetime(COALESCE(ended_at, updated_at, created_at)) < datetime('now', '-24 hours')
+             THEN worktree_path
+             ELSE NULL
+           END
+         ) AS stale_worktrees
+       FROM runs`,
+    )
+    .get() as WorktreeHealthRow | undefined
+
+  const durationRows = db
+    .prepare(
+      `SELECT (julianday(ended_at) - julianday(started_at)) * 24 * 60 AS duration_minutes
+       FROM runs
+       WHERE datetime(created_at) >= datetime('now', '-30 days')
+         AND status IN ('completed', 'blocked', 'error')
+         AND started_at IS NOT NULL
+         AND ended_at IS NOT NULL
+       ORDER BY duration_minutes ASC`,
+    )
+    .all() as DurationRow[]
 
   const queueStatuses = db
     .prepare(
@@ -234,8 +354,27 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
   const completed7d = toNumber(throughputRow?.completed_7d)
   const blocked7d = toNumber(throughputRow?.blocked_7d)
   const error7d = toNumber(throughputRow?.error_7d)
+  const runs7d = toNumber(throughputRow?.runs_7d)
   const terminal7d = completed7d + blocked7d + error7d
   const successRate7d = terminal7d > 0 ? (completed7d / terminal7d) * 100 : 0
+  const failureCount7d = blocked7d + error7d
+  const failureRate7d = terminal7d > 0 ? (failureCount7d / terminal7d) * 100 : 0
+  const topErrorPatterns7d = summarizeErrorPatterns(errorMessages.map((row) => row.message))
+
+  const totalCostUsd7d = toNumber(efficiencyRow?.total_cost_usd_7d)
+  const completedRunsForEfficiency = toNumber(efficiencyRow?.completed_7d)
+  const totalIterations7d = toNumber(efficiencyRow?.total_iterations_7d)
+  const runsForEfficiency = toNumber(efficiencyRow?.runs_7d)
+
+  const avgCostPerRun7d = runsForEfficiency > 0 ? totalCostUsd7d / runsForEfficiency : 0
+  const avgCostPerSuccess7d = completedRunsForEfficiency > 0 ? totalCostUsd7d / completedRunsForEfficiency : 0
+  const avgCostPerIteration7d = totalIterations7d > 0 ? totalCostUsd7d / totalIterations7d : 0
+  const completedPerDollar7d = totalCostUsd7d > 0 ? completedRunsForEfficiency / totalCostUsd7d : 0
+
+  const durations = durationRows
+    .map((row) => toNumber(row.duration_minutes))
+    .filter((duration) => duration > 0)
+    .sort((a, b) => a - b)
 
   return {
     updatedAt: new Date().toISOString(),
@@ -259,7 +398,7 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
     })),
     throughput: {
       runs24h: toNumber(throughputRow?.runs_24h),
-      runs7d: toNumber(throughputRow?.runs_7d),
+      runs7d,
       runs30d: toNumber(throughputRow?.runs_30d),
       completed7d,
       blocked7d,
@@ -267,6 +406,11 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
       successRate7d,
       avgDurationMinutes7d: toNumber(throughputRow?.avg_duration_min_7d),
       avgIterations7d: toNumber(throughputRow?.avg_iterations_7d),
+    },
+    reliability: {
+      failureCount7d,
+      failureRate7d,
+      topErrorPatterns7d,
     },
     cost: {
       todayCostUsd: toNumber(costRow?.today_cost_usd),
@@ -279,6 +423,28 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
         totalCostUsd: toNumber(row.total_cost_usd),
         runCount: toNumber(row.run_count),
       })),
+    },
+    efficiency: {
+      totalCostUsd7d,
+      avgCostPerRun7d,
+      avgCostPerSuccess7d,
+      avgCostPerIteration7d,
+      completedPerDollar7d,
+    },
+    resources: {
+      activeLeases: toNumber(leaseHealthRow?.active_leases),
+      expiringLeases: toNumber(leaseHealthRow?.expiring_leases),
+      expiredLeases: toNumber(leaseHealthRow?.expired_leases),
+      leasedRepos: toNumber(leaseHealthRow?.leased_repos),
+      activeWorktrees: toNumber(worktreeHealthRow?.active_worktrees),
+      missingWorktrees: toNumber(worktreeHealthRow?.missing_worktrees),
+      staleWorktrees: toNumber(worktreeHealthRow?.stale_worktrees),
+    },
+    timing: {
+      sampleSize30d: durations.length,
+      p50Minutes: calculatePercentile(durations, 0.5),
+      p90Minutes: calculatePercentile(durations, 0.9),
+      p99Minutes: calculatePercentile(durations, 0.99),
     },
     queue: {
       activeBatches: toNumber(queueActive?.count),
@@ -322,6 +488,67 @@ function toNumber(value: number | bigint | string | null | undefined): number {
   return 0
 }
 
+function calculatePercentile(sortedValues: number[], percentile: number): number {
+  if (sortedValues.length === 0) return 0
+  const clamped = Math.min(1, Math.max(0, percentile))
+  const position = clamped * (sortedValues.length - 1)
+  const lowerIndex = Math.floor(position)
+  const upperIndex = Math.ceil(position)
+
+  const lowerValue = sortedValues[lowerIndex] ?? 0
+  const upperValue = sortedValues[upperIndex] ?? lowerValue
+  if (lowerIndex === upperIndex) return lowerValue
+
+  const weight = position - lowerIndex
+  return lowerValue + ((upperValue - lowerValue) * weight)
+}
+
+function summarizeErrorPatterns(messages: Array<string | null | undefined>): ErrorPatternAggregate[] {
+  const patterns = new Map<string, { count: number; pattern: string }>()
+
+  for (const message of messages) {
+    if (typeof message !== 'string') continue
+    const normalizedWhitespace = message.replace(/\s+/g, ' ').trim()
+    if (!normalizedWhitespace) continue
+
+    const key = normalizeErrorPattern(normalizedWhitespace)
+    const existing = patterns.get(key)
+    if (existing) {
+      existing.count += 1
+      continue
+    }
+    patterns.set(key, {
+      count: 1,
+      pattern: truncateErrorPattern(normalizedWhitespace, 80),
+    })
+  }
+
+  return [...patterns.values()]
+    .sort((a, b) => b.count - a.count || a.pattern.localeCompare(b.pattern))
+    .slice(0, 4)
+    .map((entry) => ({
+      pattern: entry.pattern,
+      count: entry.count,
+    }))
+}
+
+function normalizeErrorPattern(message: string): string {
+  return message
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, '<url>')
+    .replace(/0x[0-9a-f]+/gi, '<hex>')
+    .replace(/\b[0-9a-f]{7,40}\b/gi, '<id>')
+    .replace(/#[0-9]+\b/g, '#<n>')
+    .replace(/\b\d+(\.\d+)?\b/g, '<n>')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function truncateErrorPattern(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength - 3)}...`
+}
+
 interface OverviewRow {
   total_runs: number | null
   active_runs: number | null
@@ -342,6 +569,13 @@ interface ThroughputRow {
   error_7d: number | null
   avg_duration_min_7d: number | null
   avg_iterations_7d: number | null
+}
+
+interface EfficiencyRow {
+  runs_7d: number | null
+  completed_7d: number | null
+  total_cost_usd_7d: number | null
+  total_iterations_7d: number | null
 }
 
 interface CostRow {
@@ -365,6 +599,10 @@ interface DailyCostRow {
   date: string
   total_cost_usd: number | null
   run_count: number | null
+}
+
+interface ErrorMessageRow {
+  message: string | null
 }
 
 interface StatusCountRow {
@@ -395,4 +633,21 @@ interface RepoRow {
 
 interface CountRow {
   count: number | null
+}
+
+interface LeaseHealthRow {
+  active_leases: number | null
+  expiring_leases: number | null
+  expired_leases: number | null
+  leased_repos: number | null
+}
+
+interface WorktreeHealthRow {
+  active_worktrees: number | null
+  missing_worktrees: number | null
+  stale_worktrees: number | null
+}
+
+interface DurationRow {
+  duration_minutes: number | null
 }

--- a/test/cli/tui/stats-view.test.ts
+++ b/test/cli/tui/stats-view.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import type { ReactElement, ReactNode } from 'react'
+import { Text } from 'ink'
+import type { TuiStatsSnapshot } from '../../../src/state/stats.js'
+import { StatsView } from '../../../src/cli/tui/stats-view.js'
+
+describe('StatsView', () => {
+  it('uses throughput counters for throughput blocked/error colors', () => {
+    const stats: TuiStatsSnapshot = {
+      updatedAt: '2026-04-01T10:00:00.000Z',
+      overview: {
+        totalRuns: 12,
+        activeRuns: 7,
+        queuedRuns: 1,
+        runningRuns: 2,
+        reviewReadyRuns: 1,
+        completedRuns: 5,
+        blockedRuns: 4,
+        errorRuns: 3,
+      },
+      statusCounts: [
+        { status: 'completed', count: 5 },
+        { status: 'blocked', count: 4 },
+        { status: 'error', count: 3 },
+      ],
+      phaseCounts: [{ phase: 'plan', count: 2 }],
+      throughput: {
+        runs24h: 2,
+        runs7d: 5,
+        runs30d: 9,
+        completed7d: 2,
+        blocked7d: 0,
+        error7d: 0,
+        successRate7d: 100,
+        avgDurationMinutes7d: 20,
+        avgIterations7d: 1.2,
+      },
+      reliability: {
+        failureCount7d: 0,
+        failureRate7d: 0,
+        topErrorPatterns7d: [],
+      },
+      cost: {
+        todayCostUsd: 3.5,
+        todayRunCount: 2,
+        cost7d: 12.2,
+        cost30d: 44.2,
+        avgDailyCost7d: 2.5,
+        dailyHistory: [{ date: '2026-04-01', totalCostUsd: 3.5, runCount: 2 }],
+      },
+      efficiency: {
+        totalCostUsd7d: 12.2,
+        avgCostPerRun7d: 2.4,
+        avgCostPerSuccess7d: 6.1,
+        avgCostPerIteration7d: 1.2,
+        completedPerDollar7d: 0.16,
+      },
+      resources: {
+        activeLeases: 1,
+        expiringLeases: 0,
+        expiredLeases: 0,
+        leasedRepos: 1,
+        activeWorktrees: 2,
+        missingWorktrees: 0,
+        staleWorktrees: 0,
+      },
+      timing: {
+        sampleSize30d: 3,
+        p50Minutes: 10,
+        p90Minutes: 25,
+        p99Minutes: 30,
+      },
+      queue: {
+        activeBatches: 0,
+        statuses: [],
+      },
+      agents: {
+        eventsTotal: 0,
+        events24h: 0,
+        events7d: 0,
+        toolCalls24h: 0,
+        thinking24h: 0,
+        uniqueRuns7d: 0,
+        roleBreakdown7d: [],
+      },
+      topRepos30d: [],
+    }
+
+    const tree = StatsView({
+      stats,
+      autoRefresh: true,
+      pollIntervalMs: 2000,
+      lastRefreshAt: '2026-04-01T10:00:00.000Z',
+    })
+
+    const runHealthLine = findTextNode(tree, 'blocked 4')
+    const throughputLine = findTextNode(tree, 'blocked 7d')
+
+    expect(runHealthLine).toBeTruthy()
+    expect(throughputLine).toBeTruthy()
+    expect(extractInlineColorValues(runHealthLine!)).toEqual(['red', 'red'])
+    expect(extractInlineColorValues(throughputLine!)).toEqual(['green', 'green'])
+  })
+})
+
+function findTextNode(root: ReactNode, fragment: string): ReactElement | null {
+  for (const node of collectTextNodes(root)) {
+    if (flattenText(node.props.children).includes(fragment)) {
+      return node
+    }
+  }
+  return null
+}
+
+function collectTextNodes(node: ReactNode): ReactElement[] {
+  const collected: ReactElement[] = []
+  traverseNode(node, collected)
+  return collected
+}
+
+function traverseNode(node: ReactNode, collected: ReactElement[]): void {
+  if (!React.isValidElement(node)) return
+  if (node.type === Text) {
+    collected.push(node)
+  }
+  for (const child of React.Children.toArray(node.props.children)) {
+    traverseNode(child, collected)
+  }
+}
+
+function flattenText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => flattenText(item)).join('')
+  }
+  if (React.isValidElement(node)) {
+    return flattenText(node.props.children)
+  }
+  return ''
+}
+
+function extractInlineColorValues(line: ReactElement): string[] {
+  return React.Children
+    .toArray(line.props.children)
+    .filter(React.isValidElement)
+    .filter((child): child is ReactElement<{ color?: string }> => child.type === Text)
+    .map((child) => child.props.color)
+    .filter((color): color is string => typeof color === 'string')
+}

--- a/test/cli/tui/view-model.test.ts
+++ b/test/cli/tui/view-model.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest'
-import { buildSparkline, isActiveRunStatus, partitionRowsByActivity, sliceWindow } from '../../../src/cli/tui/view-model.js'
+import {
+  buildSparkline,
+  colorForHigherIsBetter,
+  colorForLowerIsBetter,
+  colorForPresence,
+  colorForRatioToBaseline,
+  isActiveRunStatus,
+  partitionRowsByActivity,
+  sliceWindow,
+} from '../../../src/cli/tui/view-model.js'
 
 describe('tui view model helpers', () => {
   it('centers a selected index in a bounded window', () => {
@@ -78,5 +87,31 @@ describe('tui view model helpers', () => {
     expect(partitioned.recent).toEqual([
       { id: 'b', status: 'completed' },
     ])
+  })
+
+  it('selects colors for higher-is-better metrics', () => {
+    expect(colorForHigherIsBetter(90, 80, 60)).toBe('green')
+    expect(colorForHigherIsBetter(70, 80, 60)).toBe('yellow')
+    expect(colorForHigherIsBetter(40, 80, 60)).toBe('red')
+  })
+
+  it('selects colors for lower-is-better metrics', () => {
+    expect(colorForLowerIsBetter(8, 10, 25)).toBe('green')
+    expect(colorForLowerIsBetter(15, 10, 25)).toBe('yellow')
+    expect(colorForLowerIsBetter(30, 10, 25)).toBe('red')
+  })
+
+  it('selects colors for presence counts', () => {
+    expect(colorForPresence(0)).toBe('green')
+    expect(colorForPresence(1)).toBe('yellow')
+    expect(colorForPresence(3)).toBe('red')
+  })
+
+  it('selects colors for values relative to a baseline', () => {
+    expect(colorForRatioToBaseline(100, 100, 1.05, 1.35)).toBe('green')
+    expect(colorForRatioToBaseline(120, 100, 1.05, 1.35)).toBe('yellow')
+    expect(colorForRatioToBaseline(150, 100, 1.05, 1.35)).toBe('red')
+    expect(colorForRatioToBaseline(0, 0, 1.05, 1.35)).toBe('green')
+    expect(colorForRatioToBaseline(10, 0, 1.05, 1.35)).toBe('yellow')
   })
 })

--- a/test/state/stats.test.ts
+++ b/test/state/stats.test.ts
@@ -26,7 +26,11 @@ describe('loadTuiStats', () => {
     expect(stats.overview.totalRuns).toBe(0)
     expect(stats.overview.activeRuns).toBe(0)
     expect(stats.throughput.runs7d).toBe(0)
+    expect(stats.reliability.failureCount7d).toBe(0)
     expect(stats.cost.todayCostUsd).toBe(0)
+    expect(stats.efficiency.avgCostPerRun7d).toBe(0)
+    expect(stats.resources.activeLeases).toBe(0)
+    expect(stats.timing.sampleSize30d).toBe(0)
     expect(stats.queue.activeBatches).toBe(0)
     expect(stats.agents.eventsTotal).toBe(0)
     expect(stats.topRepos30d).toEqual([])
@@ -35,27 +39,114 @@ describe('loadTuiStats', () => {
   it('aggregates run, cost, queue, and agent stats from the database', () => {
     const now = Date.now()
     const oneHourAgo = iso(now - (1 * 60 * 60 * 1000))
-    const twoHoursAgo = iso(now - (2 * 60 * 60 * 1000))
+    const tenMinutesAgo = iso(now - (10 * 60 * 1000))
+    const tenMinutesFromNow = iso(now + (10 * 60 * 1000))
+    const oneHourFromNow = iso(now + (1 * 60 * 60 * 1000))
     const oneDayAgo = iso(now - (24 * 60 * 60 * 1000))
+    const oneDayAgoPlusThirtyMinutes = iso(now - (24 * 60 * 60 * 1000) + (30 * 60 * 1000))
     const twoDaysAgo = iso(now - (2 * 24 * 60 * 60 * 1000))
+    const twoDaysAgoPlusFortyFiveMinutes = iso(now - (2 * 24 * 60 * 60 * 1000) + (45 * 60 * 1000))
     const thirtyFiveDaysAgo = iso(now - (35 * 24 * 60 * 60 * 1000))
 
     const insertRun = db.prepare(
       `INSERT INTO runs (
-        id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, started_at, ended_at, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, started_at, ended_at,
+        last_error, block_reason, worktree_path, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
 
-    insertRun.run('run-1', 'org/repo-a', 1, 'completed', 'publish', 2, 4.2, twoHoursAgo, oneHourAgo, twoDaysAgo, oneHourAgo)
-    insertRun.run('run-2', 'org/repo-a', 2, 'error', 'code', 1, 1.5, oneDayAgo, oneHourAgo, oneDayAgo, oneHourAgo)
-    insertRun.run('run-3', 'org/repo-b', 3, 'running', 'plan', 0, 0.4, oneHourAgo, null, oneHourAgo, oneHourAgo)
-    insertRun.run('run-4', 'org/repo-b', 4, 'queued', 'plan', 0, 0, oneHourAgo, null, oneHourAgo, oneHourAgo)
-    insertRun.run('run-5', 'org/repo-c', 5, 'blocked', 'review', 3, 2, thirtyFiveDaysAgo, oneDayAgo, thirtyFiveDaysAgo, oneDayAgo)
+    insertRun.run(
+      'run-1',
+      'org/repo-a',
+      1,
+      'completed',
+      'publish',
+      2,
+      4.2,
+      twoDaysAgo,
+      twoDaysAgoPlusFortyFiveMinutes,
+      null,
+      null,
+      '/tmp/wt-repo-a-1',
+      twoDaysAgo,
+      oneHourAgo,
+    )
+    insertRun.run(
+      'run-2',
+      'org/repo-a',
+      2,
+      'error',
+      'code',
+      1,
+      1.5,
+      oneDayAgo,
+      oneDayAgoPlusThirtyMinutes,
+      'API timeout after 30s while calling provider',
+      null,
+      '/tmp/wt-repo-a-2',
+      oneDayAgo,
+      oneHourAgo,
+    )
+    insertRun.run(
+      'run-3',
+      'org/repo-b',
+      3,
+      'running',
+      'plan',
+      0,
+      0.4,
+      oneHourAgo,
+      null,
+      null,
+      null,
+      '/tmp/wt-repo-b-3',
+      oneHourAgo,
+      oneHourAgo,
+    )
+    insertRun.run(
+      'run-4',
+      'org/repo-b',
+      4,
+      'queued',
+      'plan',
+      0,
+      0,
+      oneHourAgo,
+      null,
+      null,
+      null,
+      null,
+      oneHourAgo,
+      oneHourAgo,
+    )
+    insertRun.run(
+      'run-5',
+      'org/repo-c',
+      5,
+      'blocked',
+      'review',
+      3,
+      2,
+      thirtyFiveDaysAgo,
+      oneDayAgo,
+      null,
+      'Lease expired for issue 5',
+      '/tmp/wt-repo-c-5',
+      thirtyFiveDaysAgo,
+      oneDayAgo,
+    )
 
     const today = dateOnly(now)
     const yesterday = dateOnly(now - (24 * 60 * 60 * 1000))
     db.prepare('INSERT INTO daily_costs (date, total_cost_usd, run_count) VALUES (?, ?, ?)').run(today, 12.5, 2)
     db.prepare('INSERT INTO daily_costs (date, total_cost_usd, run_count) VALUES (?, ?, ?)').run(yesterday, 3.5, 1)
+
+    const insertLease = db.prepare(
+      'INSERT INTO leases (repo, issue_number, lease_owner, leased_until) VALUES (?, ?, ?, ?)',
+    )
+    insertLease.run('org/repo-a', 1, 'worker-a', oneHourFromNow)
+    insertLease.run('org/repo-b', 3, 'worker-b', tenMinutesFromNow)
+    insertLease.run('org/repo-c', 5, 'worker-c', tenMinutesAgo)
 
     db.prepare(
       `INSERT INTO merge_batches (id, repo, base_branch, base_sha, status, pr_numbers, approved_shas, created_at, updated_at)
@@ -86,11 +177,39 @@ describe('loadTuiStats', () => {
     expect(stats.throughput.completed7d).toBe(1)
     expect(stats.throughput.error7d).toBe(1)
     expect(stats.throughput.successRate7d).toBeCloseTo(50, 5)
+    expect(stats.reliability.failureCount7d).toBe(1)
+    expect(stats.reliability.failureRate7d).toBeCloseTo(50, 5)
+    expect(stats.reliability.topErrorPatterns7d).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          count: 1,
+          pattern: expect.stringContaining('API timeout after 30s'),
+        }),
+      ]),
+    )
 
     expect(stats.cost.todayCostUsd).toBeCloseTo(12.5, 5)
     expect(stats.cost.cost7d).toBeCloseTo(16, 5)
     expect(stats.cost.todayRunCount).toBe(2)
     expect(stats.cost.dailyHistory.length).toBe(2)
+    expect(stats.efficiency.totalCostUsd7d).toBeCloseTo(6.1, 5)
+    expect(stats.efficiency.avgCostPerRun7d).toBeCloseTo(1.525, 5)
+    expect(stats.efficiency.avgCostPerSuccess7d).toBeCloseTo(6.1, 5)
+    expect(stats.efficiency.avgCostPerIteration7d).toBeCloseTo(6.1 / 3, 5)
+    expect(stats.efficiency.completedPerDollar7d).toBeCloseTo(1 / 6.1, 5)
+
+    expect(stats.resources.activeLeases).toBe(2)
+    expect(stats.resources.expiringLeases).toBe(1)
+    expect(stats.resources.expiredLeases).toBe(1)
+    expect(stats.resources.leasedRepos).toBe(2)
+    expect(stats.resources.activeWorktrees).toBe(3)
+    expect(stats.resources.missingWorktrees).toBe(1)
+    expect(stats.resources.staleWorktrees).toBe(1)
+
+    expect(stats.timing.sampleSize30d).toBe(2)
+    expect(stats.timing.p50Minutes).toBeCloseTo(37.5, 5)
+    expect(stats.timing.p90Minutes).toBeCloseTo(43.5, 5)
+    expect(stats.timing.p99Minutes).toBeCloseTo(44.85, 5)
 
     expect(stats.queue.activeBatches).toBe(1)
     expect(stats.queue.statuses).toEqual([{ status: 'pending', count: 1 }])


### PR DESCRIPTION
Closes #39

## Plan
**Objective:** Add smart color coding to stats metrics and extend stats with additional useful data (error patterns, cost efficiency, lease/worktree info, timing percentiles)

1. Add color helper functions to format.ts — threshold-based color selectors for percentages (successRateColor), costs (costColor), counts (countColor for error/warning levels), and a generic threshold color function. These return Ink-compatible color strings based on value ranges.
2. Extend TuiStatsSnapshot interface and loadTuiStats() in stats.ts with new metrics: (a) medianDurationMinutes7d for timing, (b) costPerCompletedRun7d for cost efficiency, (c) errorRate7d (complement of successRate), (d) activeLeases count from leases table, (e) blockedReasons7d — top 3 block_reason values from runs, (f) topErrors7d — top 3 last_error patterns from errored runs. Add the corresponding SQL queries.
3. Apply color coding throughout stats-view.tsx: (a) Run Health card — color status counts using STATUS_COLORS (green for completed, red for error/blocked, yellow for running, cyan for queued, magenta for review_ready), (b) Throughput card — color success rate green/yellow/red based on threshold (>80% green, 50-80% yellow, <50% red), color error/blocked counts red when >0, (c) Cost card — color today's cost green/yellow/red based on comparison with 7d average, (d) Agent Activity — color event counts with cyan, (e) Top Repos — color success percentage with threshold colors. Add new extended stat rows to relevant cards (median duration in Throughput, cost/completed in Cost, blocked reasons and top errors in Run Health, active leases in Merge Queue).

## Implementation
Addressed all review findings for extended stats/color coding. Fixed the throughput color bug by separating overview-based and throughput-based blocked/error colors in `StatsView` (Throughput card now derives colors from `stats.throughput.*7d`). Aligned `failureRate7d` with `successRate7d` by using the same terminal-run denominator (`completed+blocked+error`) in `loadTuiStats`, so the two rates are directly comparable. Added a new `StatsView` regression test that uses divergent overview vs throughput values and asserts the Throughput line colors come from throughput counters while Run Health uses overview counters. Updated existing stats aggregation assertions accordingly. Verification: targeted tests, typecheck, and lint all pass.

**Changed files:**
- `src/cli/tui/stats-view.tsx`
- `src/state/stats.ts`
- `test/state/stats.test.ts`
- `test/cli/tui/stats-view.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all modified files in full and related adjacent code/tests. The previously reported issues are resolved: throughput blocked/error colors now derive from throughput counters (`src/cli/tui/stats-view.tsx:26-27`, `src/cli/tui/stats-view.tsx:63-65`), success/failure rates now use the same terminal-run denominator (`src/state/stats.ts:358-361`), and a view-level regression test was added to lock this wiring (`test/cli/tui/stats-view.test.ts:9-104`). Validation in this workspace: `pnpm typecheck` passed, `pnpm lint` passed, and `pnpm test` passed on rerun.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex