### PR TITLE
[CHORE] TUI - better color coding for runs data (night-orch / #37)

### DIFF
--- a/src/cli/tui/active-runs.tsx
+++ b/src/cli/tui/active-runs.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import { Box, Text } from 'ink'
 import type Database from 'better-sqlite3'
+import {
+  colorForCostUsd,
+  colorForIterationCount,
+  colorForPhase,
+  colorForPrNumber,
+  colorForRunStatus,
+  type TuiColor,
+} from './constants.js'
 
 interface ActiveRunsProps {
   db: Database.Database
@@ -12,12 +20,13 @@ interface ActiveRunRow {
   repo: string
   issue_number: number
   status: string
+  pr_number: number | null
   current_phase: string | null
   iteration_count: number | null
   estimated_cost_usd: number | null
 }
 
-const STATUS_ICONS: Record<string, { icon: string; color: string }> = {
+const STATUS_ICONS: Record<string, { icon: string; color: TuiColor }> = {
   running: { icon: '●', color: 'yellow' },
   queued: { icon: '○', color: 'cyan' },
   review_ready: { icon: '◆', color: 'magenta' },
@@ -27,7 +36,7 @@ const STATUS_ICONS: Record<string, { icon: string; color: string }> = {
 
 export function ActiveRuns({ db, tick: _tick }: ActiveRunsProps): React.ReactElement {
   const rows = db
-    .prepare("SELECT id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd FROM runs WHERE status IN ('queued', 'running', 'review_ready', 'blocked', 'error') ORDER BY created_at DESC LIMIT 10")
+    .prepare("SELECT id, repo, issue_number, status, pr_number, current_phase, iteration_count, estimated_cost_usd FROM runs WHERE status IN ('queued', 'running', 'review_ready', 'blocked', 'error') ORDER BY created_at DESC LIMIT 10")
     .all() as ActiveRunRow[]
 
   if (rows.length === 0) {
@@ -47,17 +56,19 @@ export function ActiveRuns({ db, tick: _tick }: ActiveRunsProps): React.ReactEle
         return (
           <Text key={row.id}>
             {'  '}
-            <Text color={s.color as 'yellow' | 'cyan' | 'magenta' | 'red' | 'white'}>{s.icon}</Text>
+            <Text color={s.color}>{s.icon}</Text>
             {' '}
             <Text>#{row.issue_number} {row.repo}</Text>
             {'  '}
-            <Text color="gray">{row.status}</Text>
+            <Text color={colorForRunStatus(row.status)}>{row.status}</Text>
             {'  '}
-            <Text color="gray">[{row.current_phase ?? '?'}]</Text>
+            <Text color={colorForPhase(row.current_phase)}>[{row.current_phase ?? '?'}]</Text>
             {'  '}
-            <Text color="gray">iter {row.iteration_count ?? 0}</Text>
+            <Text color={colorForIterationCount(row.iteration_count)}>iter {row.iteration_count ?? 0}</Text>
             {'  '}
-            <Text color="green">${(row.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+            <Text color={colorForCostUsd(row.estimated_cost_usd)}>${(row.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+            {'  '}
+            <Text color={colorForPrNumber(row.pr_number)}>{row.pr_number !== null ? `PR #${row.pr_number}` : 'no PR'}</Text>
           </Text>
         )
       })}

--- a/src/cli/tui/constants.ts
+++ b/src/cli/tui/constants.ts
@@ -7,7 +7,9 @@ export const TABS: Array<{ id: TabId; hotkey: string; label: string }> = [
   { id: 'logs', hotkey: '4', label: 'Logs' },
 ]
 
-export const STATUS_COLORS: Record<string, 'white' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'> = {
+export type TuiColor = 'white' | 'gray' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'
+
+export const STATUS_COLORS: Record<string, TuiColor> = {
   running: 'yellow',
   queued: 'cyan',
   review_ready: 'magenta',
@@ -16,7 +18,7 @@ export const STATUS_COLORS: Record<string, 'white' | 'yellow' | 'cyan' | 'magent
   error: 'red',
 }
 
-export const EVENT_COLORS: Record<string, 'gray' | 'cyan' | 'green' | 'yellow' | 'red' | 'magenta'> = {
+export const EVENT_COLORS: Record<string, TuiColor> = {
   session_start: 'green',
   session_end: 'green',
   text: 'gray',
@@ -25,4 +27,81 @@ export const EVENT_COLORS: Record<string, 'gray' | 'cyan' | 'green' | 'yellow' |
   thinking: 'yellow',
   turn_complete: 'yellow',
   error: 'red',
+}
+
+const PHASE_COLORS: Record<string, TuiColor> = {
+  queued: 'cyan',
+  plan: 'cyan',
+  planner: 'cyan',
+  planning: 'cyan',
+  code: 'yellow',
+  coder: 'yellow',
+  review: 'magenta',
+  reviewer: 'magenta',
+  verify: 'green',
+  verification: 'green',
+  publish: 'green',
+  merge: 'green',
+  merged: 'green',
+}
+
+export function colorForRunStatus(status: string): TuiColor {
+  return STATUS_COLORS[status] ?? 'white'
+}
+
+export function colorForPhase(phase: string | null | undefined): TuiColor {
+  const normalized = normalizeLabel(phase)
+  if (!normalized) return 'gray'
+
+  const direct = PHASE_COLORS[normalized]
+  if (direct) return direct
+
+  const tokens = normalized.split(/[\s:_-]+/)
+  for (const token of tokens) {
+    const tokenColor = PHASE_COLORS[token]
+    if (tokenColor) return tokenColor
+  }
+
+  if (tokens.some((token) => token.includes('error') || token.includes('fail') || token.includes('block'))) {
+    return 'red'
+  }
+  if (tokens.some((token) => token.includes('queue') || token.includes('wait') || token.includes('pending'))) {
+    return 'cyan'
+  }
+  if (tokens.some((token) => token.includes('review'))) return 'magenta'
+  if (tokens.some((token) => token.includes('plan'))) return 'cyan'
+  if (tokens.some((token) => token.includes('code') || token.includes('implement') || token.includes('fix'))) {
+    return 'yellow'
+  }
+  if (tokens.some((token) => token.includes('verify') || token.includes('test') || token.includes('check'))) {
+    return 'green'
+  }
+  if (tokens.some((token) => token.includes('publish') || token.includes('merge') || token.includes('release'))) {
+    return 'green'
+  }
+
+  return 'white'
+}
+
+export function colorForPrNumber(prNumber: number | null | undefined): TuiColor {
+  return typeof prNumber === 'number' ? 'cyan' : 'gray'
+}
+
+export function colorForIterationCount(iterationCount: number | null | undefined): TuiColor {
+  const iteration = iterationCount ?? 0
+  if (iteration <= 1) return 'green'
+  if (iteration <= 2) return 'yellow'
+  return 'red'
+}
+
+export function colorForCostUsd(costUsd: number | null | undefined): TuiColor {
+  const cost = costUsd ?? 0
+  if (cost <= 0) return 'gray'
+  if (cost < 0.5) return 'green'
+  if (cost < 2) return 'yellow'
+  return 'red'
+}
+
+function normalizeLabel(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? ''
 }

--- a/src/cli/tui/recent-runs.tsx
+++ b/src/cli/tui/recent-runs.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import { Box, Text } from 'ink'
 import type Database from 'better-sqlite3'
+import {
+  colorForCostUsd,
+  colorForIterationCount,
+  colorForPhase,
+  colorForPrNumber,
+  colorForRunStatus,
+  type TuiColor,
+} from './constants.js'
 
 interface RecentRunsProps {
   db: Database.Database
@@ -12,18 +20,20 @@ interface RecentRunRow {
   repo: string
   issue_number: number
   status: string
+  current_phase: string | null
   iteration_count: number | null
   estimated_cost_usd: number | null
+  pr_number: number | null
   last_error: string | null
 }
 
-const STATUS_DISPLAY: Record<string, { icon: string; color: string }> = {
+const STATUS_DISPLAY: Record<string, { icon: string; color: TuiColor }> = {
   completed: { icon: '✓', color: 'green' },
 }
 
 export function RecentRuns({ db, tick: _tick }: RecentRunsProps): React.ReactElement {
   const rows = db
-    .prepare("SELECT id, repo, issue_number, status, iteration_count, estimated_cost_usd, last_error FROM runs WHERE status = 'completed' ORDER BY updated_at DESC LIMIT 15")
+    .prepare("SELECT id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, pr_number, last_error FROM runs WHERE status = 'completed' ORDER BY updated_at DESC LIMIT 15")
     .all() as RecentRunRow[]
 
   if (rows.length === 0) {
@@ -44,15 +54,19 @@ export function RecentRuns({ db, tick: _tick }: RecentRunsProps): React.ReactEle
         return (
           <Text key={row.id}>
             {'  '}
-            <Text color={s.color as 'green' | 'magenta' | 'red' | 'white'}>{s.icon}</Text>
+            <Text color={s.color}>{s.icon}</Text>
             {' '}
             <Text>#{row.issue_number} {row.repo}</Text>
             {'  '}
-            <Text color="gray">{row.status}</Text>
+            <Text color={colorForRunStatus(row.status)}>{row.status}</Text>
             {'  '}
-            <Text color="gray">{row.iteration_count ?? 0} iter</Text>
+            <Text color={colorForPhase(row.current_phase)}>{row.current_phase ?? '-'}</Text>
             {'  '}
-            <Text color="green">${(row.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+            <Text color={colorForIterationCount(row.iteration_count)}>{row.iteration_count ?? 0} iter</Text>
+            {'  '}
+            <Text color={colorForCostUsd(row.estimated_cost_usd)}>${(row.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+            {'  '}
+            <Text color={colorForPrNumber(row.pr_number)}>{row.pr_number !== null ? `PR #${row.pr_number}` : 'no PR'}</Text>
             {errorInfo && <Text color="red">{errorInfo}</Text>}
           </Text>
         )

--- a/src/cli/tui/runs-view.tsx
+++ b/src/cli/tui/runs-view.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import { Box, Text } from 'ink'
 import type { TuiStatsSnapshot } from '../../state/stats.js'
-import { EVENT_COLORS, STATUS_COLORS } from './constants.js'
+import {
+  EVENT_COLORS,
+  colorForCostUsd,
+  colorForIterationCount,
+  colorForPhase,
+  colorForPrNumber,
+  colorForRunStatus,
+} from './constants.js'
 import type { AgentEventRow, IssueListRow, MergeBatchRow, RunListRow } from './data.js'
 import { formatEventSummary, formatPrList, formatTime, truncate } from './format.js'
 import { resolveIssueTitle, resolvePrTitle, type TitleLookup } from './titles.js'
@@ -68,9 +75,8 @@ export function RunsView({
   const renderIssueRow = (issue: IssueListRow, dimmed: boolean): React.ReactElement => {
     const selected = selectedIssue?.key === issue.key
     const issueTitle = resolveIssueTitle(issue, titleLookup) ?? '(title unavailable)'
-    const statusColor = STATUS_COLORS[issue.status] ?? 'white'
+    const statusColor = colorForRunStatus(issue.status)
     const absoluteIndex = issueIndexByKey.get(issue.key) ?? 0
-    const runStatuses = issue.runs.slice(0, 3).map((run) => run.status).join(' -> ')
 
     return (
       <Box key={issue.key} flexDirection="column">
@@ -87,13 +93,23 @@ export function RunsView({
             <Text>{truncate(issueTitle, 56)}</Text>
           </Text>
         </Text>
-        <Text dimColor color={dimmed ? 'gray' : undefined}>
+        <Text dimColor={dimmed}>
           {'    '}
-          <Text>runs {issue.runs.length}</Text>
+          <Text color="gray">phase </Text>
+          <Text color={colorForPhase(issue.current_phase)}>{truncate(issue.current_phase ?? '-', 12)}</Text>
           {'  '}
-          <Text>history {truncate(runStatuses || '-', 44)}</Text>
+          <Text color="gray">iter </Text>
+          <Text color={colorForIterationCount(issue.iteration_count)}>{issue.iteration_count ?? 0}</Text>
           {'  '}
-          <Text>{formatTime(issue.updated_at)}</Text>
+          <Text color="gray">cost </Text>
+          <Text color={colorForCostUsd(issue.estimated_cost_usd)}>${(issue.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+          {'  '}
+          <Text color={colorForPrNumber(issue.pr_number)}>{issue.pr_number !== null ? `PR #${issue.pr_number}` : 'no PR'}</Text>
+          {'  '}
+          <Text color="gray">runs {issue.runs.length} hist </Text>
+          <RunHistory runs={issue.runs} maxItems={3} maxStatusLength={10} />
+          {'  '}
+          <Text color="gray">{formatTime(issue.updated_at)}</Text>
         </Text>
       </Box>
     )
@@ -130,21 +146,40 @@ export function RunsView({
           {selectedIssue && (
             <>
               <Text>{selectedIssue.repo}#{selectedIssue.issue_number}</Text>
-              <Text color={STATUS_COLORS[selectedIssue.status] ?? 'white'}>{selectedIssue.status}</Text>
+              <Text color={colorForRunStatus(selectedIssue.status)}>{selectedIssue.status}</Text>
               <Text>{truncate(resolveIssueTitle(selectedIssue, titleLookup) ?? '(title unavailable)', 46)}</Text>
+              <Text>
+                <Text color="gray">phase </Text>
+                <Text color={colorForPhase(selectedIssue.current_phase)}>{truncate(selectedIssue.current_phase ?? '-', 10)}</Text>
+                {'  '}
+                <Text color="gray">iter </Text>
+                <Text color={colorForIterationCount(selectedIssue.iteration_count)}>{selectedIssue.iteration_count ?? 0}</Text>
+                {'  '}
+                <Text color="gray">cost </Text>
+                <Text color={colorForCostUsd(selectedIssue.estimated_cost_usd)}>${(selectedIssue.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+              </Text>
               {selectedIssue.pr_number !== null && (
-                <Text dimColor>PR #{selectedIssue.pr_number}: {truncate(resolvePrTitle(selectedIssue, titleLookup) ?? '(title unavailable)', 36)}</Text>
+                <Text dimColor>
+                  <Text color={colorForPrNumber(selectedIssue.pr_number)}>PR #{selectedIssue.pr_number}</Text>
+                  {`: ${truncate(resolvePrTitle(selectedIssue, titleLookup) ?? '(title unavailable)', 36)}`}
+                </Text>
               )}
 
               <Box marginTop={1} flexDirection="column">
                 <Text bold>Runs</Text>
                 {selectedIssue.runs.slice(0, 5).map((run) => (
                   <Text key={run.id}>
-                    <Text color={STATUS_COLORS[run.status] ?? 'white'}>{truncate(run.status, 11)}</Text>
+                    <Text color={colorForRunStatus(run.status)}>{truncate(run.status, 11)}</Text>
+                    {' '}
+                    <Text color={colorForPhase(run.current_phase)}>{truncate(run.current_phase ?? '-', 8)}</Text>
+                    {' '}
+                    <Text color={colorForIterationCount(run.iteration_count)}>i{run.iteration_count ?? 0}</Text>
+                    {' '}
+                    <Text color={colorForCostUsd(run.estimated_cost_usd)}>${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
                     {' '}
                     <Text color="gray">{formatTime(run.updated_at)}</Text>
                     {' '}
-                    <Text>{run.pr_number !== null ? `PR #${run.pr_number}` : 'no PR'}</Text>
+                    <Text color={colorForPrNumber(run.pr_number)}>{run.pr_number !== null ? `PR #${run.pr_number}` : 'no PR'}</Text>
                   </Text>
                 ))}
               </Box>
@@ -227,24 +262,42 @@ function FocusedIssueView({
             <Box width="35%" flexDirection="column" marginRight={1} borderStyle="single" borderColor="gray" paddingX={1}>
               <Text bold color="cyan">Overview</Text>
               <Text>{selectedIssue.repo}#{selectedIssue.issue_number}</Text>
-              <Text color={STATUS_COLORS[selectedIssue.status] ?? 'white'}>{selectedIssue.status}</Text>
+              <Text color={colorForRunStatus(selectedIssue.status)}>{selectedIssue.status}</Text>
               <Text>{resolveIssueTitle(selectedIssue, titleLookup) ?? '(title unavailable)'}</Text>
               {selectedIssue.pr_number !== null && (
-                <Text dimColor>PR #{selectedIssue.pr_number}: {resolvePrTitle(selectedIssue, titleLookup) ?? '(title unavailable)'}</Text>
+                <Text dimColor>
+                  <Text color={colorForPrNumber(selectedIssue.pr_number)}>PR #{selectedIssue.pr_number}</Text>
+                  {`: ${resolvePrTitle(selectedIssue, titleLookup) ?? '(title unavailable)'}`}
+                </Text>
               )}
-              <Text>phase {selectedIssue.current_phase ?? '-'}</Text>
-              <Text>iter {selectedIssue.iteration_count ?? 0}  cost ${(selectedIssue.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+              <Text>
+                <Text color="gray">phase </Text>
+                <Text color={colorForPhase(selectedIssue.current_phase)}>{selectedIssue.current_phase ?? '-'}</Text>
+              </Text>
+              <Text>
+                <Text color="gray">iter </Text>
+                <Text color={colorForIterationCount(selectedIssue.iteration_count)}>{selectedIssue.iteration_count ?? 0}</Text>
+                {'  '}
+                <Text color="gray">cost </Text>
+                <Text color={colorForCostUsd(selectedIssue.estimated_cost_usd)}>${(selectedIssue.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+              </Text>
               <Text dimColor>updated {formatTime(selectedIssue.updated_at)}</Text>
               {selectedIssue.last_error && <Text color="red">error: {truncate(selectedIssue.last_error, 90)}</Text>}
               <Box marginTop={1} flexDirection="column">
                 <Text bold>Runs ({selectedIssue.runs.length})</Text>
                 {selectedIssue.runs.slice(0, 10).map((run) => (
                   <Text key={run.id}>
-                    <Text color={STATUS_COLORS[run.status] ?? 'white'}>{truncate(run.status, 11)}</Text>
+                    <Text color={colorForRunStatus(run.status)}>{truncate(run.status, 10)}</Text>
+                    {' '}
+                    <Text color={colorForPhase(run.current_phase)}>{truncate(run.current_phase ?? '-', 8)}</Text>
+                    {' '}
+                    <Text color={colorForIterationCount(run.iteration_count)}>i{run.iteration_count ?? 0}</Text>
+                    {' '}
+                    <Text color={colorForCostUsd(run.estimated_cost_usd)}>${(run.estimated_cost_usd ?? 0).toFixed(2)}</Text>
+                    {' '}
+                    <Text color={colorForPrNumber(run.pr_number)}>{run.pr_number !== null ? `PR #${run.pr_number}` : 'no PR'}</Text>
                     {' '}
                     <Text color="gray">{formatTime(run.updated_at)}</Text>
-                    {' '}
-                    <Text>{run.id.slice(0, 12)}</Text>
                   </Text>
                 ))}
               </Box>
@@ -260,7 +313,15 @@ function FocusedIssueView({
               {!selectedRun && <Text color="gray">No run available for this issue</Text>}
               {selectedRun && (
                 <Text dimColor>
-                  source run {selectedRun.id} ({selectedRun.status})
+                  source run {selectedRun.id}
+                  {'  '}
+                  <Text color={colorForRunStatus(selectedRun.status)}>{selectedRun.status}</Text>
+                  {'  '}
+                  <Text color={colorForPhase(selectedRun.current_phase)}>{selectedRun.current_phase ?? '-'}</Text>
+                  {'  '}
+                  <Text color={colorForIterationCount(selectedRun.iteration_count)}>i{selectedRun.iteration_count ?? 0}</Text>
+                  {'  '}
+                  <Text color={colorForCostUsd(selectedRun.estimated_cost_usd)}>${(selectedRun.estimated_cost_usd ?? 0).toFixed(2)}</Text>
                 </Text>
               )}
               {selectedRunEvents.length === 0 && <Text color="gray">No agent events</Text>}
@@ -289,5 +350,29 @@ function FocusedIssueView({
         </>
       )}
     </Box>
+  )
+}
+
+interface RunHistoryProps {
+  runs: RunListRow[]
+  maxItems: number
+  maxStatusLength: number
+}
+
+function RunHistory({ runs, maxItems, maxStatusLength }: RunHistoryProps): React.ReactElement {
+  const history = runs.slice(0, maxItems)
+  if (history.length === 0) {
+    return <Text color="gray">-</Text>
+  }
+
+  return (
+    <>
+      {history.map((run, index) => (
+        <React.Fragment key={run.id}>
+          {index > 0 && <Text color="gray">→</Text>}
+          <Text color={colorForRunStatus(run.status)}>{truncate(run.status, maxStatusLength)}</Text>
+        </React.Fragment>
+      ))}
+    </>
   )
 }

--- a/test/cli/tui/constants.test.ts
+++ b/test/cli/tui/constants.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  colorForCostUsd,
+  colorForIterationCount,
+  colorForPhase,
+  colorForPrNumber,
+  colorForRunStatus,
+} from '../../../src/cli/tui/constants.js'
+
+describe('tui semantic color helpers', () => {
+  it('maps run statuses with a safe fallback', () => {
+    expect(colorForRunStatus('running')).toBe('yellow')
+    expect(colorForRunStatus('queued')).toBe('cyan')
+    expect(colorForRunStatus('review_ready')).toBe('magenta')
+    expect(colorForRunStatus('unknown')).toBe('white')
+  })
+
+  it('maps phases by direct match, token match, heuristic, and fallback', () => {
+    expect(colorForPhase(null)).toBe('gray')
+    expect(colorForPhase('  ')).toBe('gray')
+    expect(colorForPhase('review')).toBe('magenta')
+    expect(colorForPhase('phase:verify_checks')).toBe('green')
+    expect(colorForPhase('blocked_by_ci')).toBe('red')
+    expect(colorForPhase('waiting_for_approval')).toBe('cyan')
+    expect(colorForPhase('implement_fix')).toBe('yellow')
+    expect(colorForPhase('release_candidate')).toBe('green')
+    expect(colorForPhase('mystery_phase')).toBe('white')
+  })
+
+  it('maps iteration count thresholds', () => {
+    expect(colorForIterationCount(null)).toBe('green')
+    expect(colorForIterationCount(1)).toBe('green')
+    expect(colorForIterationCount(2)).toBe('yellow')
+    expect(colorForIterationCount(3)).toBe('red')
+  })
+
+  it('maps cost thresholds', () => {
+    expect(colorForCostUsd(null)).toBe('gray')
+    expect(colorForCostUsd(0)).toBe('gray')
+    expect(colorForCostUsd(0.49)).toBe('green')
+    expect(colorForCostUsd(0.5)).toBe('yellow')
+    expect(colorForCostUsd(1.99)).toBe('yellow')
+    expect(colorForCostUsd(2)).toBe('red')
+  })
+
+  it('maps PR number presence', () => {
+    expect(colorForPrNumber(undefined)).toBe('gray')
+    expect(colorForPrNumber(null)).toBe('gray')
+    expect(colorForPrNumber(123)).toBe('cyan')
+  })
+})

--- a/test/cli/tui/runs-view.test.ts
+++ b/test/cli/tui/runs-view.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import type { ReactElement, ReactNode } from 'react'
+import { Text } from 'ink'
+import { RunsView } from '../../../src/cli/tui/runs-view.js'
+import type { AgentEventRow, IssueListRow, RunListRow } from '../../../src/cli/tui/data.js'
+import type { TitleLookup } from '../../../src/cli/tui/titles.js'
+import type { TuiStatsSnapshot } from '../../../src/state/stats.js'
+
+describe('RunsView semantic run data display', () => {
+  it('renders semantic colors for phase/iteration/cost/PR and run-history in list mode', () => {
+    const runs: RunListRow[] = [
+      makeRunRow({
+        id: 'run-1',
+        status: 'running',
+        current_phase: 'verify',
+        iteration_count: 3,
+        estimated_cost_usd: 2.5,
+        pr_number: 42,
+        created_at: '2026-04-01T10:04:00.000Z',
+        updated_at: '2026-04-01T10:04:30.000Z',
+      }),
+      makeRunRow({
+        id: 'run-2',
+        status: 'blocked',
+        current_phase: 'review',
+        iteration_count: 2,
+        estimated_cost_usd: 1.2,
+        pr_number: null,
+        created_at: '2026-04-01T10:03:00.000Z',
+        updated_at: '2026-04-01T10:03:30.000Z',
+      }),
+      makeRunRow({
+        id: 'run-3',
+        status: 'queued',
+        current_phase: 'plan',
+        iteration_count: 1,
+        estimated_cost_usd: 0.1,
+        pr_number: null,
+        created_at: '2026-04-01T10:02:00.000Z',
+        updated_at: '2026-04-01T10:02:30.000Z',
+      }),
+      makeRunRow({
+        id: 'run-4',
+        status: 'error',
+        current_phase: 'failed',
+        iteration_count: 4,
+        estimated_cost_usd: 3,
+        pr_number: null,
+        created_at: '2026-04-01T10:01:00.000Z',
+        updated_at: '2026-04-01T10:01:30.000Z',
+      }),
+    ]
+
+    const issue = makeIssueRow({
+      status: 'running',
+      current_phase: 'verify',
+      iteration_count: 3,
+      estimated_cost_usd: 2.5,
+      pr_number: 42,
+      runs,
+    })
+
+    const tree = RunsView({
+      issues: [issue],
+      selectedIndex: 0,
+      selectedIssue: issue,
+      selectedRun: runs[0]!,
+      selectedRunEvents: [],
+      mergeBatches: [],
+      stats: makeStats(),
+      titleLookup: emptyTitleLookup(),
+      mode: 'list',
+      maxVisibleRuns: 20,
+      eventScrollOffset: 0,
+      eventWindowSize: 20,
+    })
+
+    expect(hasColoredFragment(tree, 'verify', 'green')).toBe(true)
+    expect(hasExactTextWithColor(tree, '3', 'red')).toBe(true)
+    expect(hasExactTextWithColor(tree, '$2.50', 'red')).toBe(true)
+    expect(hasExactTextWithColor(tree, 'PR #42', 'cyan')).toBe(true)
+
+    const historyLine = findTextNode(tree, 'runs 4 hist')
+    expect(historyLine).toBeTruthy()
+
+    const historyText = flattenText(historyLine!.props.children)
+    expect(historyText).toContain('running')
+    expect(historyText).toContain('blocked')
+    expect(historyText).toContain('queued')
+    expect(historyText).not.toContain('error')
+    expect(hasColoredFragment(historyLine, 'running', 'yellow')).toBe(true)
+    expect(hasColoredFragment(historyLine, 'blocked', 'red')).toBe(true)
+    expect(hasColoredFragment(historyLine, 'queued', 'cyan')).toBe(true)
+  })
+
+  it('renders semantic colors for selected run metadata in focus mode', () => {
+    const selectedRun = makeRunRow({
+      id: 'run-focus',
+      status: 'running',
+      current_phase: 'verify',
+      iteration_count: 3,
+      estimated_cost_usd: 2.5,
+      pr_number: 42,
+      created_at: '2026-04-01T10:08:00.000Z',
+      updated_at: '2026-04-01T10:08:30.000Z',
+    })
+    const issue = makeIssueRow({
+      status: 'blocked',
+      current_phase: 'review',
+      iteration_count: 2,
+      estimated_cost_usd: 1.2,
+      pr_number: 42,
+      runs: [selectedRun],
+    })
+
+    const events: AgentEventRow[] = [
+      {
+        id: 1,
+        run_id: selectedRun.id,
+        role: 'coder',
+        event_type: 'text',
+        data: JSON.stringify({ text: 'working' }),
+        created_at: '2026-04-01T10:09:00.000Z',
+      },
+    ]
+
+    const tree = RunsView({
+      issues: [issue],
+      selectedIndex: 0,
+      selectedIssue: issue,
+      selectedRun,
+      selectedRunEvents: events,
+      mergeBatches: [],
+      stats: makeStats(),
+      titleLookup: emptyTitleLookup(),
+      mode: 'focus',
+      maxVisibleRuns: 20,
+      eventScrollOffset: 0,
+      eventWindowSize: 20,
+    })
+
+    expect(hasColoredFragment(tree, 'blocked', 'red')).toBe(true)
+    expect(hasColoredFragment(tree, 'review', 'magenta')).toBe(true)
+    expect(hasExactTextWithColor(tree, 'PR #42', 'cyan')).toBe(true)
+    expect(hasColoredFragment(tree, 'running', 'yellow')).toBe(true)
+    expect(hasExactTextWithColor(tree, 'i3', 'red')).toBe(true)
+    expect(hasExactTextWithColor(tree, '$2.50', 'red')).toBe(true)
+  })
+})
+
+function emptyTitleLookup(): TitleLookup {
+  return {
+    issues: {},
+    prs: {},
+  }
+}
+
+function makeIssueRow(partial: Partial<IssueListRow>): IssueListRow {
+  const repo = partial.repo ?? 'org/repo'
+  const issueNumber = partial.issue_number ?? 7
+  const runs = partial.runs ?? [makeRunRow({})]
+
+  return {
+    key: partial.key ?? `${repo}#${issueNumber}`,
+    repo,
+    issue_number: issueNumber,
+    issue_title: partial.issue_title ?? 'Issue title',
+    status: partial.status ?? 'running',
+    current_phase: partial.current_phase ?? 'plan',
+    iteration_count: partial.iteration_count ?? 1,
+    estimated_cost_usd: partial.estimated_cost_usd ?? 0.1,
+    last_error: partial.last_error ?? null,
+    pr_number: partial.pr_number ?? null,
+    pr_title: partial.pr_title ?? null,
+    created_at: partial.created_at ?? '2026-04-01T10:00:00.000Z',
+    updated_at: partial.updated_at ?? '2026-04-01T10:05:00.000Z',
+    runs,
+  }
+}
+
+function makeRunRow(partial: Partial<RunListRow>): RunListRow {
+  return {
+    id: partial.id ?? 'run-1',
+    repo: partial.repo ?? 'org/repo',
+    issue_number: partial.issue_number ?? 7,
+    issue_title: partial.issue_title ?? 'Issue title',
+    status: partial.status ?? 'running',
+    current_phase: partial.current_phase ?? 'plan',
+    iteration_count: partial.iteration_count ?? 1,
+    estimated_cost_usd: partial.estimated_cost_usd ?? 0.1,
+    last_error: partial.last_error ?? null,
+    pr_number: partial.pr_number ?? null,
+    pr_title: partial.pr_title ?? null,
+    created_at: partial.created_at ?? '2026-04-01T10:00:00.000Z',
+    updated_at: partial.updated_at ?? '2026-04-01T10:00:30.000Z',
+  }
+}
+
+function makeStats(): TuiStatsSnapshot {
+  return {
+    updatedAt: '2026-04-01T10:00:00.000Z',
+    overview: {
+      totalRuns: 1,
+      activeRuns: 1,
+      queuedRuns: 0,
+      runningRuns: 1,
+      reviewReadyRuns: 0,
+      completedRuns: 0,
+      blockedRuns: 0,
+      errorRuns: 0,
+    },
+    statusCounts: [],
+    phaseCounts: [],
+    throughput: {
+      runs24h: 1,
+      runs7d: 1,
+      runs30d: 1,
+      completed7d: 0,
+      blocked7d: 0,
+      error7d: 0,
+      successRate7d: 0,
+      avgDurationMinutes7d: 0,
+      avgIterations7d: 0,
+    },
+    reliability: {
+      failureCount7d: 0,
+      failureRate7d: 0,
+      topErrorPatterns7d: [],
+    },
+    cost: {
+      todayCostUsd: 0,
+      todayRunCount: 0,
+      cost7d: 0,
+      cost30d: 0,
+      avgDailyCost7d: 0,
+      dailyHistory: [],
+    },
+    efficiency: {
+      totalCostUsd7d: 0,
+      avgCostPerRun7d: 0,
+      avgCostPerSuccess7d: 0,
+      avgCostPerIteration7d: 0,
+      completedPerDollar7d: 0,
+    },
+    resources: {
+      activeLeases: 0,
+      expiringLeases: 0,
+      expiredLeases: 0,
+      leasedRepos: 0,
+      activeWorktrees: 0,
+      missingWorktrees: 0,
+      staleWorktrees: 0,
+    },
+    timing: {
+      sampleSize30d: 0,
+      p50Minutes: 0,
+      p90Minutes: 0,
+      p99Minutes: 0,
+    },
+    queue: {
+      activeBatches: 0,
+      statuses: [],
+    },
+    agents: {
+      eventsTotal: 0,
+      events24h: 0,
+      events7d: 0,
+      toolCalls24h: 0,
+      thinking24h: 0,
+      uniqueRuns7d: 0,
+      roleBreakdown7d: [],
+    },
+    topRepos30d: [],
+  }
+}
+
+interface TextProps {
+  children?: ReactNode
+  color?: string
+}
+
+function findTextNode(root: ReactNode, fragment: string): ReactElement<TextProps> | null {
+  for (const node of collectTextNodes(root)) {
+    if (flattenText(node.props.children).includes(fragment)) {
+      return node
+    }
+  }
+  return null
+}
+
+function hasColoredFragment(root: ReactNode, fragment: string, color: string): boolean {
+  return collectTextNodes(root).some((node) => {
+    if (node.props.color !== color) return false
+    return flattenText(node.props.children).includes(fragment)
+  })
+}
+
+function hasExactTextWithColor(root: ReactNode, value: string, color: string): boolean {
+  return collectTextNodes(root).some((node) => {
+    if (node.props.color !== color) return false
+    return flattenText(node.props.children) === value
+  })
+}
+
+function collectTextNodes(node: ReactNode): ReactElement<TextProps>[] {
+  const collected: ReactElement<TextProps>[] = []
+  traverseNode(node, collected)
+  return collected
+}
+
+function traverseNode(node: ReactNode, collected: ReactElement<TextProps>[]): void {
+  if (!React.isValidElement(node)) return
+  if (isLocalRenderableComponent(node.type)) {
+    const rendered = (node.type as (props: Record<string, unknown>) => ReactNode)(node.props as Record<string, unknown>)
+    traverseNode(rendered, collected)
+    return
+  }
+  if (node.type === Text) {
+    collected.push(node as ReactElement<TextProps>)
+  }
+
+  const withChildren = node as ReactElement<{ children?: ReactNode }>
+  for (const child of React.Children.toArray(withChildren.props.children)) {
+    traverseNode(child, collected)
+  }
+}
+
+function flattenText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => flattenText(item)).join('')
+  }
+  if (React.isValidElement(node)) {
+    if (isLocalRenderableComponent(node.type)) {
+      const rendered = (node.type as (props: Record<string, unknown>) => ReactNode)(node.props as Record<string, unknown>)
+      return flattenText(rendered)
+    }
+    const withChildren = node as ReactElement<{ children?: ReactNode }>
+    return flattenText(withChildren.props.children)
+  }
+  return ''
+}
+
+function isLocalRenderableComponent(type: unknown): boolean {
+  if (typeof type !== 'function') return false
+  return type.name === 'FocusedIssueView' || type.name === 'RunHistory'
+}


### PR DESCRIPTION
Closes #37

## Plan
**Objective:** Add semantic color coding for phase, PR number, iteration count, cost, and run history in all TUI runs displays

1. Add PHASE_COLORS map to constants.ts — assign distinct colors per workflow phase: plan=cyan, code=yellow, verify=magenta, review=blue (using 'white' with bold as fallback since ink doesn't have blue on all terminals — or use cyan for review), decide=gray, blocked=red, error=red, completed=green. Also add STATUS_ICONS to constants.ts (consolidate the duplicate STATUS_ICONS from active-runs.tsx and STATUS_DISPLAY from recent-runs.tsx into shared constants).
2. Add colorForIterationCount and colorForRunCost helpers to view-model.ts. colorForIterationCount: 0-1=green, 2-3=yellow, 4+=red. colorForRunCost: <$1=green, <$5=yellow, $5+=red. These follow the existing colorForLowerIsBetter/colorForPresence pattern.
3. Add formatRunHistory helper to format.ts that returns an array of {status, label} objects (or a renderable structure) instead of the current plain text 'status -> status -> status' string. This allows the caller to color each status segment individually.
4. Update runs-view.tsx list mode (renderIssueRow): (a) Color the phase using PHASE_COLORS, (b) Color iteration count using colorForIterationCount, (c) Color cost using colorForRunCost, (d) Replace plain-text run history with per-status colored status icons/dots, (e) Highlight PR number in cyan when present. Update the issue preview sidebar similarly — color phase, iteration, cost, and PR number. Update the focused view (FocusedIssueView) with the same improvements: colored phase, iteration, cost, PR numbers in the overview panel, and colored run statuses in the runs list.
5. Update active-runs.tsx to use shared PHASE_COLORS for the phase display (currently gray), shared STATUS_ICONS from constants (removing local duplicate), colorForIterationCount for iteration, and colorForRunCost for cost.
6. Update recent-runs.tsx to use shared STATUS_ICONS from constants (removing local STATUS_DISPLAY duplicate), colorForIterationCount for iteration, and colorForRunCost for cost.
7. Run pnpm typecheck && pnpm lint && pnpm test to verify no regressions.

## Implementation
Implemented semantic color coding for run status, phase, iteration count, cost, PR presence, and run-history rendering across the TUI runs displays (`ActiveRuns`, `RecentRuns`, and `RunsView`) using new shared `colorFor*` helpers in `constants.ts`. Added focused automated coverage for the new helper behavior and render paths with new tests for helper edge cases and `RunsView` color/history rendering. Verification: targeted new tests pass and full suite passes (`pnpm test`: 995/995).

**Changed files:**
- `src/cli/tui/active-runs.tsx`
- `src/cli/tui/constants.ts`
- `src/cli/tui/recent-runs.tsx`
- `src/cli/tui/runs-view.tsx`
- `test/cli/tui/constants.test.ts`
- `test/cli/tui/runs-view.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all modified files in full (`src/cli/tui/active-runs.tsx`, `constants.ts`, `recent-runs.tsx`, `runs-view.tsx`) plus adjacent TUI modules and the new tests. The previously reported gap is addressed: helper coverage exists in `test/cli/tui/constants.test.ts` and render-path coverage exists in `test/cli/tui/runs-view.test.ts` (including phase/iteration/cost/PR and run history). Verification passed locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, and targeted `pnpm exec vitest run test/cli/tui/constants.test.ts test/cli/tui/runs-view.test.ts`.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex