### PR TITLE
[CHORE] TUI - logs (night-orch / #40)

### DIFF
--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -79,10 +79,10 @@ export function buildActionHints(props: ActionsBarProps): ActionHints {
   return {
     line1: joinHintGroups(
       globalNavGroup({ includePoll: false }),
-      '[j/k]scroll logs [f]refresh',
+      '[j/k]select log [J/K]scroll raw [f]refresh',
       EXTRA_TAB_NAV_GROUP,
     ),
-    line2: '',
+    line2: 'inspect full payload in the raw log pane',
   }
 }
 

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -35,7 +35,8 @@ interface ActionState {
 
 const MAX_LOG_LINES = 500
 const FOCUSED_EVENT_WINDOW_SIZE = 18
-const LOG_WINDOW_SIZE = 18
+const MIN_LOG_WINDOW_SIZE = 4
+const LOG_WINDOW_RESERVED_ROWS = 17
 
 export function resolveTabHotkey(input: string): TabId | null {
   if (input === '1') return 'runs'
@@ -48,6 +49,71 @@ export function resolveTabHotkey(input: string): TabId | null {
 export function moveProjectSelection(current: number, direction: -1 | 1, projectCount: number): number {
   const maxProjectIndex = Math.max(0, projectCount - 1)
   return Math.max(0, Math.min(maxProjectIndex, current + direction))
+}
+
+export function resolveSelectedLogIndex(logs: TuiLogLine[], selectedLogId: number | null): number {
+  if (logs.length === 0) return -1
+  if (selectedLogId === null) return -1
+  return logs.findIndex((line) => line.id === selectedLogId)
+}
+
+interface LogSelectionSnapshot {
+  selectedLogId: number | null
+  selectedLogIndex: number
+  logCount: number
+}
+
+export function reconcileSelectedLogId(
+  logs: TuiLogLine[],
+  selectedLogId: number | null,
+  previousSelectedIndex: number,
+  previousLogCount: number,
+): number | null {
+  if (logs.length === 0) return null
+
+  const previousTailIndex = previousLogCount > 0 ? previousLogCount - 1 : -1
+  const wasAtTail = previousSelectedIndex >= 0 && previousSelectedIndex >= previousTailIndex
+  const selectedIndex = resolveSelectedLogIndex(logs, selectedLogId)
+
+  if (selectedIndex >= 0) {
+    if (wasAtTail && selectedIndex !== logs.length - 1) {
+      return logs[logs.length - 1]!.id
+    }
+    return selectedLogId
+  }
+
+  if (wasAtTail || selectedLogId === null) {
+    return logs[logs.length - 1]!.id
+  }
+
+  const fallbackIndex = Math.max(0, Math.min(logs.length - 1, previousSelectedIndex))
+  return logs[fallbackIndex]!.id
+}
+
+export function moveLogSelection(logs: TuiLogLine[], selectedLogId: number | null, direction: -1 | 1): number | null {
+  if (logs.length === 0) return null
+  const currentIndex = resolveSelectedLogIndex(logs, selectedLogId)
+  const safeIndex = currentIndex >= 0 ? currentIndex : logs.length - 1
+  const nextIndex = Math.max(0, Math.min(logs.length - 1, safeIndex + direction))
+  return logs[nextIndex]!.id
+}
+
+export function reconcileLogSelectionSnapshot(
+  logs: TuiLogLine[],
+  selectedLogId: number | null,
+  previousSelectedIndex: number,
+  previousLogCount: number,
+): LogSelectionSnapshot {
+  const nextSelectedLogId = reconcileSelectedLogId(logs, selectedLogId, previousSelectedIndex, previousLogCount)
+  return {
+    selectedLogId: nextSelectedLogId,
+    selectedLogIndex: resolveSelectedLogIndex(logs, nextSelectedLogId),
+    logCount: logs.length,
+  }
+}
+
+export function resolveLogWindowSize(termRows: number): number {
+  return Math.max(MIN_LOG_WINDOW_SIZE, termRows - LOG_WINDOW_RESERVED_ROWS)
 }
 
 export function App({
@@ -72,13 +138,16 @@ export function App({
   const [lastRefreshAt, setLastRefreshAt] = useState(new Date().toISOString())
   const [titleLookup, setTitleLookup] = useState<TitleLookup>({ issues: {}, prs: {} })
   const [runEventScrollOffset, setRunEventScrollOffset] = useState(0)
-  const [logScrollOffset, setLogScrollOffset] = useState(0)
+  const [selectedLogId, setSelectedLogId] = useState<number | null>(null)
+  const [logDetailScrollOffset, setLogDetailScrollOffset] = useState(0)
   const [logLines, setLogLines] = useState<TuiLogLine[]>([])
   const [startupReady, setStartupReady] = useState(!enableBackgroundPoller)
 
   const attemptedIssueKeys = useRef<Set<string>>(new Set())
   const attemptedPrKeys = useRef<Set<string>>(new Set())
   const lastHydrationAt = useRef(0)
+  const lastLogCount = useRef(0)
+  const selectedLogIndexRef = useRef(-1)
   const logSequence = useRef(1)
   const pollInFlight = useRef(false)
   const pollPromise = useRef<Promise<unknown> | null>(null)
@@ -105,11 +174,6 @@ export function App({
       return next.slice(next.length - MAX_LOG_LINES)
     })
   }, [])
-
-  useEffect(() => {
-    const maxOffset = Math.max(0, logLines.length - LOG_WINDOW_SIZE)
-    setLogScrollOffset((current) => Math.min(current, maxOffset))
-  }, [logLines.length])
 
   const forgeByRepo = useMemo(() => {
     const map = new Map<string, ReturnType<typeof createForgeAdapter>>()
@@ -180,6 +244,24 @@ export function App({
   )
   const mergeBatches = useMemo(() => loadMergeBatches(db), [db, tick])
   const stats = useMemo(() => loadTuiStats(db), [db, tick])
+  const logWindowSize = useMemo(() => resolveLogWindowSize(termRows), [termRows])
+  const selectedLogIndex = useMemo(() => resolveSelectedLogIndex(logLines, selectedLogId), [logLines, selectedLogId])
+
+  useEffect(() => {
+    const snapshot = reconcileLogSelectionSnapshot(
+      logLines,
+      selectedLogId,
+      selectedLogIndexRef.current,
+      lastLogCount.current,
+    )
+    setSelectedLogId(snapshot.selectedLogId)
+    selectedLogIndexRef.current = snapshot.selectedLogIndex
+    lastLogCount.current = snapshot.logCount
+  }, [logLines, selectedLogId])
+
+  useEffect(() => {
+    setLogDetailScrollOffset(0)
+  }, [selectedLogId])
 
   useEffect(() => {
     const maxOffset = Math.max(0, selectedRunEvents.length - FOCUSED_EVENT_WINDOW_SIZE)
@@ -561,11 +643,23 @@ export function App({
 
     if (activeTab === 'logs') {
       if (key.downArrow || input === 'j') {
-        setLogScrollOffset((current) => current + 1)
+        const nextId = moveLogSelection(logLines, selectedLogId, 1)
+        setSelectedLogId(nextId)
+        selectedLogIndexRef.current = resolveSelectedLogIndex(logLines, nextId)
         return
       }
       if (key.upArrow || input === 'k') {
-        setLogScrollOffset((current) => Math.max(0, current - 1))
+        const nextId = moveLogSelection(logLines, selectedLogId, -1)
+        setSelectedLogId(nextId)
+        selectedLogIndexRef.current = resolveSelectedLogIndex(logLines, nextId)
+        return
+      }
+      if (input === 'J') {
+        setLogDetailScrollOffset((current) => current + 1)
+        return
+      }
+      if (input === 'K') {
+        setLogDetailScrollOffset((current) => Math.max(0, current - 1))
         return
       }
     }
@@ -671,11 +765,14 @@ export function App({
         />
       )}
       {activeTab === 'logs' && (
-        <LogsView
-          logs={logLines}
-          scrollOffset={logScrollOffset}
-          windowSize={LOG_WINDOW_SIZE}
-        />
+        <Box flexGrow={1} minHeight={0}>
+          <LogsView
+            logs={logLines}
+            selectedIndex={selectedLogIndex}
+            windowSize={logWindowSize}
+            detailScrollOffset={logDetailScrollOffset}
+          />
+        </Box>
       )}
 
       <ActionsBar

--- a/src/cli/tui/logs-view.tsx
+++ b/src/cli/tui/logs-view.tsx
@@ -1,38 +1,127 @@
 import React from 'react'
 import { Box, Text } from 'ink'
-import { formatLogLine } from './format.js'
+import { formatTime, truncate } from './format.js'
 import type { TuiLogLine } from './types.js'
+import { sliceWindow } from './view-model.js'
 
 interface LogsViewProps {
   logs: TuiLogLine[]
-  scrollOffset: number
+  selectedIndex: number
   windowSize: number
+  detailScrollOffset: number
 }
 
-export function LogsView({ logs, scrollOffset, windowSize }: LogsViewProps): React.ReactElement {
-  const maxOffset = Math.max(0, logs.length - windowSize)
-  const clampedOffset = Math.max(0, Math.min(maxOffset, scrollOffset))
-  const rows = logs.slice(clampedOffset, clampedOffset + windowSize)
+export function LogsView({ logs, selectedIndex, windowSize, detailScrollOffset }: LogsViewProps): React.ReactElement {
+  const safeWindowSize = Math.max(1, windowSize)
+  const hasRows = logs.length > 0
+  const safeSelectedIndex = hasRows ? Math.max(0, Math.min(logs.length - 1, selectedIndex)) : -1
+  const windowedRows = sliceWindow(logs, safeSelectedIndex >= 0 ? safeSelectedIndex : 0, safeWindowSize)
+  const selectedRow = safeSelectedIndex >= 0 ? (logs[safeSelectedIndex] ?? null) : null
+  const detailLines = buildLogDetailLines(selectedRow)
+  const detailWindow = sliceRowsByOffset(detailLines, detailScrollOffset, Math.max(1, safeWindowSize - 1))
+  const visibleRange = windowedRows.rows.length === 0
+    ? `showing 0 of ${logs.length}`
+    : `showing ${windowedRows.start + 1}-${windowedRows.start + windowedRows.rows.length} of ${logs.length}`
+  const detailRange = detailWindow.rows.length === 0
+    ? `detail 0 of ${detailLines.length}`
+    : `detail ${detailWindow.offset + 1}-${detailWindow.offset + detailWindow.rows.length} of ${detailLines.length}`
 
   return (
-    <Box flexDirection="column" marginBottom={1}>
-      <Text bold>Logs</Text>
+    <Box flexDirection="column" flexGrow={1} minHeight={0}>
+      <Text bold>Logs ({logs.length})</Text>
       <Text dimColor>Integrated poller output and control actions</Text>
-      <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1}>
-        {rows.length === 0 && <Text color="gray">No logs yet</Text>}
-        {rows.map((line) => (
-          <Text
-            key={line.id}
-            color={line.level === 'error' ? 'red' : line.level === 'warn' ? 'yellow' : 'white'}
-          >
-            {formatLogLine(line, 200)}
-          </Text>
-        ))}
+
+      <Box marginTop={1} flexGrow={1} minHeight={0}>
+        <Box
+          width="64%"
+          marginRight={1}
+          flexDirection="column"
+          borderStyle="single"
+          borderColor="gray"
+          paddingX={1}
+          flexGrow={1}
+        >
+          {windowedRows.rows.length === 0 && <Text color="gray">No logs yet</Text>}
+          {windowedRows.rows.map((line, index) => {
+            const absoluteIndex = windowedRows.start + index
+            const selected = absoluteIndex === safeSelectedIndex
+            return (
+              <Text key={line.id} dimColor={!selected}>
+                <Text color={selected ? 'cyan' : 'gray'}>{selected ? '▶' : ' '}</Text>
+                {' '}
+                <Text color="gray">{String(absoluteIndex + 1).padStart(3, '0')}</Text>
+                {' '}
+                <Text color="gray">{formatTime(line.createdAt)}</Text>
+                {' '}
+                <Text color={resolveLogLevelColor(line.level)}>{line.level.toUpperCase().padEnd(5)}</Text>
+                {' '}
+                <Text>{truncate(line.message, 80)}</Text>
+              </Text>
+            )
+          })}
+        </Box>
+
+        <Box
+          width="36%"
+          flexDirection="column"
+          borderStyle="single"
+          borderColor="gray"
+          paddingX={1}
+          flexGrow={1}
+        >
+          <Text bold color="cyan">Raw Log</Text>
+          {!selectedRow && <Text color="gray">Select a log row to inspect</Text>}
+          {selectedRow && detailWindow.rows.map((line, index) => (
+            <Text key={`${detailWindow.offset}-${index}`}>{line.length > 0 ? line : ' '}</Text>
+          ))}
+        </Box>
       </Box>
-      {logs.length > windowSize && (
-        <Text color="gray">showing {clampedOffset + 1}-{clampedOffset + rows.length} of {logs.length}</Text>
-      )}
-      <Text color="gray">Press j/k to scroll logs</Text>
+
+      <Text color="gray">{visibleRange}  {detailRange}</Text>
+      <Text color="gray">Press j/k to select log row, J/K to scroll raw detail</Text>
     </Box>
   )
+}
+
+export function resolveLogLevelColor(level: TuiLogLine['level']): 'cyan' | 'yellow' | 'red' {
+  if (level === 'error') return 'red'
+  if (level === 'warn') return 'yellow'
+  return 'cyan'
+}
+
+export function buildLogDetailLines(row: TuiLogLine | null): string[] {
+  if (!row) return []
+  const messageLines = row.message.split('\n')
+  const rawLines = JSON.stringify(row, null, 2).split('\n')
+  return [
+    `time ${row.createdAt}`,
+    `level ${row.level.toUpperCase()}`,
+    `id ${row.id}`,
+    '',
+    'message',
+    ...messageLines,
+    '',
+    'raw',
+    ...rawLines,
+  ]
+}
+
+interface OffsetSlice<T> {
+  offset: number
+  rows: T[]
+  maxOffset: number
+}
+
+export function sliceRowsByOffset<T>(rows: T[], offset: number, windowSize: number): OffsetSlice<T> {
+  if (rows.length === 0) {
+    return { offset: 0, rows: [], maxOffset: 0 }
+  }
+  const safeWindow = Math.max(1, windowSize)
+  const maxOffset = Math.max(0, rows.length - safeWindow)
+  const clampedOffset = Math.max(0, Math.min(maxOffset, offset))
+  return {
+    offset: clampedOffset,
+    rows: rows.slice(clampedOffset, clampedOffset + safeWindow),
+    maxOffset,
+  }
 }

--- a/test/cli/tui/actions-bar.test.ts
+++ b/test/cli/tui/actions-bar.test.ts
@@ -67,8 +67,8 @@ describe('buildActionHints', () => {
       autoRefresh: false,
     })
 
-    expect(hints.line1).toContain('[j/k]scroll logs [f]refresh')
+    expect(hints.line1).toContain('[j/k]select log [J/K]scroll raw [f]refresh')
     expect(hints.line1).toContain('[1]issues [2]projects [3]stats [q]quit')
-    expect(hints.line2).toBe('')
+    expect(hints.line2).toContain('raw log pane')
   })
 })

--- a/test/cli/tui/app-input.test.ts
+++ b/test/cli/tui/app-input.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { moveProjectSelection, resolveTabHotkey } from '../../../src/cli/tui/app.js'
+import {
+  moveLogSelection,
+  moveProjectSelection,
+  reconcileLogSelectionSnapshot,
+  reconcileSelectedLogId,
+  resolveLogWindowSize,
+  resolveSelectedLogIndex,
+  resolveTabHotkey,
+} from '../../../src/cli/tui/app.js'
 
 describe('tui app input helpers', () => {
   it('maps tab hotkeys to tab ids', () => {
@@ -25,5 +33,85 @@ describe('tui app input helpers', () => {
   it('keeps index stable when no repos are configured', () => {
     expect(moveProjectSelection(0, 1, 0)).toBe(0)
     expect(moveProjectSelection(4, -1, 0)).toBe(0)
+  })
+
+  it('clamps log selection movement to available rows', () => {
+    const logs = [
+      { id: 10, createdAt: '2026-04-01T00:00:00.000Z', level: 'info', message: 'a' },
+      { id: 11, createdAt: '2026-04-01T00:00:01.000Z', level: 'warn', message: 'b' },
+      { id: 12, createdAt: '2026-04-01T00:00:02.000Z', level: 'error', message: 'c' },
+    ]
+
+    expect(moveLogSelection(logs, 10, 1)).toBe(11)
+    expect(moveLogSelection(logs, 12, 1)).toBe(12)
+    expect(moveLogSelection(logs, 10, -1)).toBe(10)
+  })
+
+  it('uses a minimum log window size for short terminals', () => {
+    expect(resolveLogWindowSize(12)).toBe(4)
+    expect(resolveLogWindowSize(40)).toBe(23)
+  })
+
+  it('keeps selected log id stable when capped buffer drops from head', () => {
+    const before = Array.from({ length: 500 }, (_, index) => ({
+      id: index + 1,
+      createdAt: `2026-04-01T00:00:${String(index).padStart(2, '0')}.000Z`,
+      level: 'info' as const,
+      message: `line-${index + 1}`,
+    }))
+    const after = before.slice(1)
+    after.push({
+      id: 501,
+      createdAt: '2026-04-01T00:09:00.000Z',
+      level: 'warn',
+      message: 'line-501',
+    })
+
+    const selectedBefore = 250
+    const selectedIndexBefore = resolveSelectedLogIndex(before, selectedBefore)
+    const next = reconcileSelectedLogId(after, selectedBefore, selectedIndexBefore, before.length)
+
+    expect(next).toBe(250)
+  })
+
+  it('falls back deterministically when selected id was evicted', () => {
+    const before = [
+      { id: 1, createdAt: '2026-04-01T00:00:00.000Z', level: 'info', message: 'one' },
+      { id: 2, createdAt: '2026-04-01T00:00:01.000Z', level: 'info', message: 'two' },
+      { id: 3, createdAt: '2026-04-01T00:00:02.000Z', level: 'info', message: 'three' },
+    ]
+    const after = [
+      { id: 2, createdAt: '2026-04-01T00:00:01.000Z', level: 'info', message: 'two' },
+      { id: 3, createdAt: '2026-04-01T00:00:02.000Z', level: 'info', message: 'three' },
+      { id: 4, createdAt: '2026-04-01T00:00:03.000Z', level: 'warn', message: 'four' },
+    ]
+
+    const nextHead = reconcileSelectedLogId(after, 1, resolveSelectedLogIndex(before, 1), before.length)
+    expect(nextHead).toBe(2)
+
+    const nextTail = reconcileSelectedLogId(after, 3, resolveSelectedLogIndex(before, 3), before.length)
+    expect(nextTail).toBe(4)
+  })
+
+  it('follows tail during capped-buffer rollover when previously at tail', () => {
+    const before = Array.from({ length: 500 }, (_, index) => ({
+      id: index + 1,
+      createdAt: `2026-04-01T00:00:${String(index).padStart(2, '0')}.000Z`,
+      level: 'info' as const,
+      message: `line-${index + 1}`,
+    }))
+    const after = before.slice(1)
+    after.push({
+      id: 501,
+      createdAt: '2026-04-01T00:09:00.000Z',
+      level: 'warn',
+      message: 'line-501',
+    })
+
+    const snapshot = reconcileLogSelectionSnapshot(after, 500, 499, 500)
+
+    expect(snapshot.selectedLogId).toBe(501)
+    expect(snapshot.selectedLogIndex).toBe(499)
+    expect(snapshot.logCount).toBe(500)
   })
 })

--- a/test/cli/tui/logs-view.test.ts
+++ b/test/cli/tui/logs-view.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToString } from 'ink'
+import type { TuiLogLine } from '../../../src/cli/tui/types.js'
+import {
+  buildLogDetailLines,
+  LogsView,
+  resolveLogLevelColor,
+  sliceRowsByOffset,
+} from '../../../src/cli/tui/logs-view.js'
+
+function buildLogs(): TuiLogLine[] {
+  return [
+    {
+      id: 1,
+      createdAt: '2026-04-01T12:00:00.000Z',
+      level: 'info',
+      message: 'startup complete',
+    },
+    {
+      id: 2,
+      createdAt: '2026-04-01T12:00:01.000Z',
+      level: 'warn',
+      message: 'selected payload line 1\nline 2',
+    },
+    {
+      id: 3,
+      createdAt: '2026-04-01T12:00:02.000Z',
+      level: 'error',
+      message: 'fatal issue',
+    },
+  ]
+}
+
+describe('logs view', () => {
+  it('renders empty state with guidance', () => {
+    const output = renderToString(React.createElement(LogsView, {
+      logs: [],
+      selectedIndex: -1,
+      windowSize: 6,
+      detailScrollOffset: 0,
+    }))
+
+    expect(output).toContain('Logs (0)')
+    expect(output).toContain('No logs yet')
+    expect(output).toContain('Select a log row to')
+    expect(output).toContain('Press j/k to select log row, J/K to scroll raw detail')
+  })
+
+  it('renders selected row marker and raw detail content', () => {
+    const output = renderToString(React.createElement(LogsView, {
+      logs: buildLogs(),
+      selectedIndex: 1,
+      windowSize: 6,
+      detailScrollOffset: 0,
+    }))
+
+    expect(output).toContain('Logs (3)')
+    expect(output).toContain('▶')
+    expect(output).toContain('002')
+    expect(output).toContain('selected payload line 1')
+    expect(output).toContain('id 2')
+    expect(output).toContain('detail 1-')
+  })
+
+  it('shows raw json when detail pane is scrolled', () => {
+    const output = renderToString(React.createElement(LogsView, {
+      logs: buildLogs(),
+      selectedIndex: 1,
+      windowSize: 6,
+      detailScrollOffset: 10,
+    }))
+
+    expect(output).toContain('raw')
+    expect(output).toContain('"id": 2')
+  })
+
+  it('color-codes levels with deterministic mapping', () => {
+    expect(resolveLogLevelColor('info')).toBe('cyan')
+    expect(resolveLogLevelColor('warn')).toBe('yellow')
+    expect(resolveLogLevelColor('error')).toBe('red')
+  })
+
+  it('windows detail rows by scroll offset and clamps to bounds', () => {
+    const lines = buildLogDetailLines(buildLogs()[1]!)
+    const windowed = sliceRowsByOffset(lines, 2, 4)
+
+    expect(windowed.rows).toHaveLength(4)
+    expect(windowed.offset).toBe(2)
+
+    const clamped = sliceRowsByOffset(lines, 999, 4)
+    expect(clamped.offset).toBe(clamped.maxOffset)
+    expect(clamped.rows).toHaveLength(4)
+  })
+})


### PR DESCRIPTION
Closes #40

## Plan
**Objective:** Enhance TUI logs view with full-height layout, selectable rows, detail pane for raw data, and color-coded log levels

1. Update app.tsx: (a) Replace logScrollOffset with selectedLogIndex state (number|null). (b) Remove hardcoded LOG_WINDOW_SIZE=18, compute dynamically as termRows-8. (c) Change logs tab j/k handler from scroll offset to selection index movement (clamp to 0..logLines.length-1). (d) Pass selectedLogIndex and computed windowSize to LogsView. (e) Add auto-selection of newest log when new logs arrive and nothing is selected. (f) Clamp selectedLogIndex when logLines shrinks (circular buffer eviction).
2. Rewrite logs-view.tsx with split-pane layout: (a) Left pane (~70%) shows log rows with selection indicator (cyan ▶ for selected, space otherwise). Each row shows colored level badge, timestamp, and truncated message. Use sliceWindow() from view-model.ts centered on selectedLogIndex for automatic scroll-into-view. (b) Right pane (~30%) with bordered box shows full detail of selected log: level (colored), full ISO timestamp, and the complete untruncated message (word-wrapped by Ink). (c) Use full available height by accepting windowSize prop from app.tsx. (d) Color scheme: error=red, warn=yellow, info=white/default — applied to the level badge text, with selected row's text in cyan.
3. Update actions-bar.tsx: Change the logs tab hints from '[j/k]scroll logs' to '[j/k]select log [f]refresh' to reflect the new selection behavior.
4. Add formatLogLevel() helper in format.ts that returns the uppercase padded level string (used by both the list row and detail pane) to avoid duplicating the level formatting logic.

## Implementation
Implemented the final retry fixes for the logs TUI and addressed the remaining major rollover bug. Selection is now reconciled via a pre-update snapshot path (`reconcileLogSelectionSnapshot`) so capped-buffer rollover correctly tail-follows when previously at tail, while still preserving stable ID-based selection otherwise. Raw/detail pane remains windowed and scrollable (`J/K`) with bounded rendering and range indicators. Updated action hints and expanded tests, including a regression test for capped-buffer tail rollover through the same snapshot reconciliation wiring, plus logs-view rendering/windowing coverage. Validation passed with `pnpm test` (full suite), `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/cli/tui/app.tsx`
- `src/cli/tui/logs-view.tsx`
- `src/cli/tui/actions-bar.tsx`
- `test/cli/tui/app-input.test.ts`
- `test/cli/tui/actions-bar.test.ts`
- `test/cli/tui/logs-view.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
No blocking findings. The changes address the requested logs UX updates: full-height layout wiring, row selection by stable log id with capped-buffer reconciliation, raw-detail pane windowing/scrolling, and level color mapping. I validated changed files end-to-end plus adjacent TUI helpers/patterns, and re-ran verification (`pnpm typecheck`, `pnpm lint`, targeted TUI tests, and full `pnpm test`), all passing. Residual risk is mainly test granularity: keybinding/state wiring is validated via helper/render tests rather than a full App-level interactive input test.

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex