### PR TITLE
[CHORE] Issue missing (night-orch / #64)

### DIFF
--- a/src/cli/tui/data.ts
+++ b/src/cli/tui/data.ts
@@ -50,7 +50,32 @@ export interface MergeBatchRow {
   pr_numbers: string
 }
 
-export function loadRuns(db: Database.Database, limit?: number): RunListRow[] {
+export interface LoadRunsOptions {
+  limit?: number
+  repo?: string
+  status?: string
+}
+
+export function loadRuns(
+  db: Database.Database,
+  limitOrOptions?: number | LoadRunsOptions,
+): RunListRow[] {
+  const options = typeof limitOrOptions === 'number'
+    ? { limit: limitOrOptions }
+    : (limitOrOptions ?? {})
+  const conditions: string[] = []
+  const params: unknown[] = []
+
+  if (options.repo) {
+    conditions.push('repo = ?')
+    params.push(options.repo)
+  }
+  if (options.status) {
+    conditions.push('status = ?')
+    params.push(options.status)
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
   const query = `WITH ranked_runs AS (
          SELECT
            r.repo,
@@ -208,6 +233,7 @@ export function loadRuns(db: Database.Database, limit?: number): RunListRow[] {
          created_at,
          updated_at
        FROM visible_rows
+       ${whereClause}
        ORDER BY
          CASE status
            WHEN 'running' THEN 0
@@ -215,15 +241,20 @@ export function loadRuns(db: Database.Database, limit?: number): RunListRow[] {
            WHEN 'review_ready' THEN 2
            WHEN 'blocked' THEN 3
            WHEN 'error' THEN 4
-           ELSE 5
-         END,
-         COALESCE(julianday(created_at), 0) DESC,
-         COALESCE(julianday(updated_at), 0) DESC,
-         id DESC`
+         ELSE 5
+        END,
+        COALESCE(julianday(created_at), 0) DESC,
+        COALESCE(julianday(updated_at), 0) DESC,
+        id DESC`
 
-  const limitedQuery = typeof limit === 'number' ? `${query}\n       LIMIT ?` : query
+  const limitedQuery = typeof options.limit === 'number'
+    ? `${query}\n       LIMIT ?`
+    : query
+  if (typeof options.limit === 'number') {
+    params.push(options.limit)
+  }
   const stmt = db.prepare(limitedQuery)
-  return (typeof limit === 'number' ? stmt.all(limit) : stmt.all()) as RunListRow[]
+  return stmt.all(...params) as RunListRow[]
 }
 
 export function buildIssueList(runs: RunListRow[]): IssueListRow[] {

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -15,6 +15,7 @@ import { pollOnce } from '../../runner/poller.js'
 import { flushActiveAgentObservability } from '../../events/observability.js'
 import { createForgeAdapter } from '../../forge/factory.js'
 import { nowUtcIso } from '../../utils/time.js'
+import { loadRuns } from '../../cli/tui/data.js'
 
 interface ToolDefinition {
   name: string
@@ -285,43 +286,135 @@ async function handleListRuns(
   args: { repo?: string; status?: string; limit?: number },
   deps: MCPDependencies,
 ): Promise<unknown> {
-  const limit = args.limit ?? 20
-  const conditions: string[] = []
-  const params: unknown[] = []
+  const limit = normalizeListRunsLimit(args.limit)
 
-  if (args.repo) {
-    conditions.push('repo = ?')
-    params.push(args.repo)
+  if (args.status === 'completed') {
+    const rows = queryCompletedRuns(deps, args.repo, limit)
+    return {
+      count: rows.length,
+      runs: rows.map((row) => ({
+        runId: row.id,
+        hasRun: true,
+        repo: row.repo,
+        issue: row.issue_number,
+        status: row.status,
+        phase: row.current_phase,
+        iterations: row.iteration_count ?? 0,
+        costUsd: row.estimated_cost_usd ?? 0,
+        startedAt: row.started_at,
+        endedAt: row.ended_at,
+      })),
+    }
   }
-  if (args.status) {
-    conditions.push('status = ?')
-    params.push(args.status)
-  }
 
-  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-  const sql = `SELECT id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, started_at, ended_at FROM runs ${where} ORDER BY created_at DESC LIMIT ?`
-  params.push(limit)
-
-  const rows = deps.db.prepare(sql).all(...params) as Array<{
-    id: string; repo: string; issue_number: number; status: string
-    current_phase: string | null; iteration_count: number; estimated_cost_usd: number
-    started_at: string | null; ended_at: string | null
-  }>
+  const filteredRows = loadRuns(deps.db, {
+    limit,
+    repo: args.repo,
+    status: args.status,
+  })
+  const runTimings = loadRunTimingsByRunId(
+    deps,
+    filteredRows
+      .map((row) => row.id)
+      .filter((runId) => !runId.startsWith('issue:')),
+  )
 
   return {
-    count: rows.length,
-    runs: rows.map((r) => ({
-      runId: r.id,
-      repo: r.repo,
-      issue: r.issue_number,
-      status: r.status,
-      phase: r.current_phase,
-      iterations: r.iteration_count,
-      costUsd: r.estimated_cost_usd,
-      startedAt: r.started_at,
-      endedAt: r.ended_at,
-    })),
+    count: filteredRows.length,
+    runs: filteredRows.map((row) => {
+      const hasRun = !row.id.startsWith('issue:')
+      const timing = hasRun ? runTimings.get(row.id) : undefined
+
+      return {
+        runId: row.id,
+        hasRun,
+        repo: row.repo,
+        issue: row.issue_number,
+        status: row.status,
+        phase: row.current_phase,
+        iterations: row.iteration_count ?? 0,
+        costUsd: row.estimated_cost_usd ?? 0,
+        startedAt: hasRun ? timing?.started_at ?? null : null,
+        endedAt: hasRun ? timing?.ended_at ?? null : null,
+      }
+    }),
   }
+}
+
+interface RunTimingRow {
+  id: string
+  started_at: string | null
+  ended_at: string | null
+}
+
+interface CompletedRunRow extends RunTimingRow {
+  repo: string
+  issue_number: number
+  status: string
+  current_phase: string | null
+  iteration_count: number | null
+  estimated_cost_usd: number | null
+}
+
+function queryCompletedRuns(
+  deps: MCPDependencies,
+  repo: string | undefined,
+  limit: number,
+): CompletedRunRow[] {
+  const params: unknown[] = []
+  const repoClause = repo ? 'AND repo = ?' : ''
+  if (repo) {
+    params.push(repo)
+  }
+  params.push(limit)
+
+  return deps.db
+    .prepare(
+      `SELECT
+         id,
+         repo,
+         issue_number,
+         status,
+         current_phase,
+         iteration_count,
+         estimated_cost_usd,
+         started_at,
+         ended_at
+       FROM runs
+       WHERE status = 'completed'
+         ${repoClause}
+       ORDER BY
+         COALESCE(julianday(created_at), 0) DESC,
+         COALESCE(julianday(updated_at), 0) DESC,
+         id DESC
+       LIMIT ?`,
+    )
+    .all(...params) as CompletedRunRow[]
+}
+
+function loadRunTimingsByRunId(
+  deps: MCPDependencies,
+  runIds: string[],
+): Map<string, RunTimingRow> {
+  const uniqueRunIds = [...new Set(runIds)]
+  if (uniqueRunIds.length === 0) {
+    return new Map()
+  }
+
+  const placeholders = uniqueRunIds.map(() => '?').join(', ')
+  const rows = deps.db
+    .prepare(`SELECT id, started_at, ended_at FROM runs WHERE id IN (${placeholders})`)
+    .all(...uniqueRunIds) as RunTimingRow[]
+
+  return new Map(rows.map((row) => [row.id, row]))
+}
+
+function normalizeListRunsLimit(limit: number | undefined): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit)) {
+    return 20
+  }
+
+  return Math.min(500, Math.max(1, Math.floor(limit)))
 }
 
 async function handleCostReport(args: { days?: number }, deps: MCPDependencies): Promise<unknown> {

--- a/test/cli/tui/data.test.ts
+++ b/test/cli/tui/data.test.ts
@@ -350,4 +350,59 @@ describe('loadRuns', () => {
     expect(issue?.status).toBe('queued')
     expect(issue?.runs.some((run) => run.id === 'issue-88-old-completed')).toBe(true)
   })
+
+  it('supports SQL-level repo/status filtering with limit', () => {
+    const insertIssue = db.prepare(
+      `INSERT INTO issues (
+        repo, issue_number, issue_node_id, issue_title, status,
+        iteration_count, estimated_cost_usd, run_count, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+
+    for (let i = 1; i <= 40; i++) {
+      insertIssue.run(
+        'org/repo',
+        i,
+        `node-${i}`,
+        `Issue ${i}`,
+        'queued',
+        0,
+        0,
+        0,
+        `2026-04-02T10:${String(i % 60).padStart(2, '0')}:00.000Z`,
+        `2026-04-02T10:${String(i % 60).padStart(2, '0')}:00.000Z`,
+      )
+    }
+
+    insertIssue.run(
+      'other/repo',
+      999,
+      'node-999',
+      'Other repo issue',
+      'queued',
+      0,
+      0,
+      0,
+      '2026-04-02T10:59:00.000Z',
+      '2026-04-02T10:59:00.000Z',
+    )
+    insertIssue.run(
+      'org/repo',
+      777,
+      'node-777',
+      'Blocked issue',
+      'blocked',
+      0,
+      0,
+      0,
+      '2026-04-02T10:58:00.000Z',
+      '2026-04-02T10:58:00.000Z',
+    )
+
+    const rows = loadRuns(db, { repo: 'org/repo', status: 'queued', limit: 7 })
+
+    expect(rows).toHaveLength(7)
+    expect(rows.every((row) => row.repo === 'org/repo')).toBe(true)
+    expect(rows.every((row) => row.status === 'queued')).toBe(true)
+  })
 })

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -97,6 +97,66 @@ describe('MCP Tools', () => {
     expect(result.count).toBe(1)
   })
 
+  it('list-runs includes tracked issues with no run rows', async () => {
+    db.prepare(
+      `INSERT INTO issues (
+        repo, issue_number, issue_node_id, issue_title, status,
+        iteration_count, estimated_cost_usd, run_count, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'org/repo',
+      58,
+      'node-58',
+      'Issue missing',
+      'queued',
+      0,
+      0,
+      0,
+      '2026-04-01T12:00:00.000Z',
+      '2026-04-01T12:00:00.000Z',
+    )
+
+    const result = await handleToolCall('night-orch-list-runs', { repo: 'org/repo' }, deps) as {
+      runs: Array<{ issue: number; status: string; runId: string; hasRun: boolean }>
+    }
+    const trackedIssue = result.runs.find((run) => run.issue === 58)
+
+    expect(trackedIssue).toBeDefined()
+    expect(trackedIssue?.status).toBe('queued')
+    expect(trackedIssue?.hasRun).toBe(false)
+    expect(trackedIssue?.runId.startsWith('issue:')).toBe(true)
+  })
+
+  it('list-runs returns completed runs for resolved issues when status filter is completed', async () => {
+    const runManager = new RunManager(db)
+    const run = runManager.create({
+      repo: 'org/repo',
+      issueNumber: 91,
+      issueNodeId: 'node-91',
+      planner: 'claude',
+      coder: 'claude',
+      reviewer: 'claude',
+    })
+    runManager.update(run.id, {
+      status: 'completed',
+      endedAt: '2026-04-02T12:10:00.000Z',
+    })
+
+    const result = await handleToolCall(
+      'night-orch-list-runs',
+      { repo: 'org/repo', status: 'completed' },
+      deps,
+    ) as { count: number; runs: Array<{ runId: string; issue: number; status: string; hasRun: boolean }> }
+
+    expect(result.count).toBe(1)
+    expect(result.runs[0]).toMatchObject({
+      runId: run.id,
+      issue: 91,
+      status: 'completed',
+      hasRun: true,
+    })
+  })
+
   it('cost-report returns breakdown', async () => {
     const result = await handleToolCall('night-orch-cost-report', { days: 7 }, deps) as { totalCostUsd: number; dailyBudgetUsd: number }
     expect(result.totalCostUsd).toBe(0)

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -216,6 +216,53 @@ describe('startWebServer', () => {
     await expect(index.text()).resolves.toContain('<!doctype html>')
   })
 
+  it('dashboard includes tracked issues that do not have run rows yet', async () => {
+    db.prepare(
+      `INSERT INTO issues (
+        repo, issue_number, issue_node_id, issue_title, status,
+        iteration_count, estimated_cost_usd, run_count, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'org/repo',
+      58,
+      'node-58',
+      'Issue missing',
+      'queued',
+      0,
+      0,
+      0,
+      '2026-04-01T12:00:00.000Z',
+      '2026-04-01T12:00:00.000Z',
+    )
+
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    const dashboard = await fetch(`${baseUrl}/api/dashboard`)
+    expect(dashboard.status).toBe(200)
+    const payload = await dashboard.json() as {
+      runs: { runs: Array<{ issue: number; status: string; runId: string; hasRun: boolean }> }
+    }
+    const trackedIssue = payload.runs.runs.find((run) => run.issue === 58)
+
+    expect(trackedIssue).toBeDefined()
+    expect(trackedIssue?.status).toBe('queued')
+    expect(trackedIssue?.hasRun).toBe(false)
+    expect(trackedIssue?.runId.startsWith('issue:')).toBe(true)
+  })
+
   it('rejects mutating API requests without explicit mutation intent header', async () => {
     server = await startWebServer(
       deps,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,7 +58,7 @@ export function App(): ReactElement {
 
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimerRef = useRef<number | null>(null)
-  const selectedRunIdRef = useRef('')
+  const selectedStreamRunIdRef = useRef('')
   const subscribedRunRef = useRef('')
 
   const repos = snapshot?.config.repos ?? []
@@ -73,6 +73,7 @@ export function App(): ReactElement {
     () => allRuns.find((run) => run.runId === selectedRunId) ?? null,
     [allRuns, selectedRunId],
   )
+  const selectedStreamRunId = selectedRun?.hasRun ? selectedRun.runId : ''
 
   const loadDashboard = useCallback(async () => {
     const response = await fetch('/api/dashboard')
@@ -135,7 +136,7 @@ export function App(): ReactElement {
         if (cancelled) return
         setSocketConnected(true)
         socket.send(JSON.stringify({ type: 'refresh' }))
-        const activeRun = selectedRunIdRef.current
+        const activeRun = selectedStreamRunIdRef.current
         if (activeRun) {
           socket.send(JSON.stringify({ type: 'subscribe-run-events', runId: activeRun, since: 0 }))
         }
@@ -151,7 +152,7 @@ export function App(): ReactElement {
 
           if (envelope.type === 'run-events' && envelope.payload) {
             const payload = asRunEventsPayload(envelope.payload)
-            if (!payload || payload.runId !== selectedRunIdRef.current) {
+            if (!payload || payload.runId !== selectedStreamRunIdRef.current) {
               return
             }
 
@@ -195,26 +196,26 @@ export function App(): ReactElement {
   }, [])
 
   useEffect(() => {
-    selectedRunIdRef.current = selectedRunId
+    selectedStreamRunIdRef.current = selectedStreamRunId
     setRunEvents([])
 
     const socket = wsRef.current
     if (!socket || socket.readyState !== WebSocket.OPEN) {
-      subscribedRunRef.current = selectedRunId
+      subscribedRunRef.current = selectedStreamRunId
       return
     }
 
     const previousRun = subscribedRunRef.current
-    if (previousRun && previousRun !== selectedRunId) {
+    if (previousRun && previousRun !== selectedStreamRunId) {
       socket.send(JSON.stringify({ type: 'unsubscribe-run-events', runId: previousRun }))
     }
 
-    if (selectedRunId) {
-      socket.send(JSON.stringify({ type: 'subscribe-run-events', runId: selectedRunId, since: 0 }))
+    if (selectedStreamRunId) {
+      socket.send(JSON.stringify({ type: 'subscribe-run-events', runId: selectedStreamRunId, since: 0 }))
     }
 
-    subscribedRunRef.current = selectedRunId
-  }, [selectedRunId, socketConnected])
+    subscribedRunRef.current = selectedStreamRunId
+  }, [selectedStreamRunId, socketConnected])
 
   useEffect(() => {
     if (!updateStatus || updateStatus.state === 'idle') return

--- a/web/src/components/RunEventStream.tsx
+++ b/web/src/components/RunEventStream.tsx
@@ -17,7 +17,8 @@ export function RunEventStream({ selectedRunId, selectedRun, runEvents }: RunEve
           <h2 className="card-title text-lg">Run Event Stream</h2>
           {selectedRun && (
             <p className="text-xs text-base-content/70">
-              {selectedRun.repo} #{selectedRun.issue} ({selectedRun.runId})
+              {selectedRun.repo} #{selectedRun.issue}
+              {selectedRun.hasRun ? ` (${selectedRun.runId})` : ''}
             </p>
           )}
         </div>
@@ -25,6 +26,10 @@ export function RunEventStream({ selectedRunId, selectedRun, runEvents }: RunEve
         {!selectedRunId ? (
           <div className="alert mt-3 border border-base-300/60 bg-base-100/70 text-sm">
             <span>Select a run to stream live events.</span>
+          </div>
+        ) : selectedRun && !selectedRun.hasRun ? (
+          <div className="alert mt-3 border border-base-300/60 bg-base-100/70 text-sm">
+            <span>This issue is tracked but has no run yet.</span>
           </div>
         ) : runEvents.length === 0 ? (
           <div className="alert mt-3 border border-base-300/60 bg-base-100/70 text-sm">

--- a/web/src/components/RunsPanel.tsx
+++ b/web/src/components/RunsPanel.tsx
@@ -77,7 +77,9 @@ export function RunsPanel({
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div>
                       <p className="text-sm font-semibold text-base-content">{run.repo} #{run.issue}</p>
-                      <p className="text-xs text-base-content/60">{run.runId}</p>
+                      <p className="text-xs text-base-content/60">
+                        {run.hasRun ? run.runId : 'Tracked issue (no run yet)'}
+                      </p>
                     </div>
                     <span className={`badge badge-sm badge-outline capitalize ${statusTone[run.status]}`}>
                       {run.status.replaceAll('_', ' ')}

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -7,6 +7,7 @@ export interface RunListResult {
 
 export interface RunSummary {
   runId: string
+  hasRun: boolean
   repo: string
   issue: number
   status: RunStatus


### PR DESCRIPTION
Closes #64

## Plan
**Objective:** Make the web dashboard and MCP list-runs tool show all tracked issues including those without runs, matching the TUI behavior

1. Extract the comprehensive loadRuns SQL query and RunListRow/IssueListRow types from src/cli/tui/data.ts into a new shared module src/state/views.ts. This shared module will be importable by both the TUI and the MCP tools layer. Keep buildIssueList and the helper functions (parseTimestamp, compareRunRecency) in the shared module too since they are pure data transformations.
2. Update src/cli/tui/data.ts to re-export from src/state/views.ts instead of defining the query and types inline. Preserve all existing exports (RunListRow, IssueListRow, AgentEventRow, MergeBatchRow, loadRuns, buildIssueList, loadAgentEvents, loadMergeBatches) so no TUI consumers break.
3. Update handleListRuns in src/mcp/tools/index.ts to use the shared loadRuns query from src/state/views.ts instead of the simple runs-only SQL. Map the enriched RunListRow[] into the existing response shape (runId, repo, issue, status, phase, iterations, costUsd, startedAt, endedAt) and add new optional fields: issueTitle, prNumber, prTitle, lastError. Preserve repo/status/limit filter support by applying them as post-query filters or by modifying the shared query to accept filter parameters.
4. Update the RunSummary type in web/src/types/dashboard.ts to include optional issueTitle field. Update RunsPanel.tsx to display issue titles when available (show 'repo #issue — title' instead of just 'repo #issue').
5. Update existing tests in test/cli/tui/data.test.ts to import from the new shared location (or verify re-exports work). Add test coverage in test/mcp/tools.test.ts verifying that handleListRuns now returns issues from the issues table that have no runs.
6. Run pnpm typecheck && pnpm lint && pnpm test to verify all changes compile and pass.

## Implementation
Implemented the final retry fixes for issue visibility and list-runs behavior. `loadRuns` now supports SQL-level filtering (`repo`, `status`) and `limit` via a new `LoadRunsOptions` shape while preserving backward compatibility with numeric limits. `night-orch-list-runs` now uses these SQL filters for unresolved/tracked issue views and includes tracked issue-only rows (`hasRun: false`). Added a dedicated `status === 'completed'` branch in MCP to query completed run history directly from `runs`, restoring completed-only issue visibility and preventing the regression for `/api/runs?status=completed`. Web dashboard/UI changes continue to render issue-only tracked entries and avoid run-event subscriptions when no real run exists. Added/updated regression tests for SQL-level filtering + limits, issue-only tracked rows, dashboard inclusion, and completed-status MCP behavior. Validation passed with targeted tests, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/cli/tui/data.ts`
- `src/mcp/tools/index.ts`
- `test/cli/tui/data.test.ts`
- `test/mcp/tools.test.ts`
- `test/web/server.test.ts`
- `web/src/App.tsx`
- `web/src/components/RunEventStream.tsx`
- `web/src/components/RunsPanel.tsx`
- `web/src/types/dashboard.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files plus adjacent call sites. Both previously reported major regressions are fixed: SQL-level repo/status/limit filtering is now pushed into loadRuns and consumed by MCP list-runs (`src/cli/tui/data.ts:53-257`, `src/mcp/tools/index.ts:285-341`), and `status: "completed"` is restored via a dedicated completed-runs query (`src/mcp/tools/index.ts:291-393`). Regression coverage was added for tracked issues without run rows and completed-filter behavior (`test/cli/tui/data.test.ts:354-407`, `test/mcp/tools.test.ts:100-158`, `test/web/server.test.ts:219-264`). I re-ran `pnpm test test/cli/tui/data.test.ts test/mcp/tools.test.ts test/web/server.test.ts` and all 36 tests passed.

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex