### PR TITLE
[CHORE] Web - adjust issue lists - title/colors (night-orch / #63)

### DIFF
--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -314,9 +314,12 @@ async function handleListRuns(
         repo: row.repo,
         issue: row.issue_number,
         status: row.status,
+        issueTitle: row.issue_title,
+        prNumber: row.pr_number,
         phase: row.current_phase,
         iterations: row.iteration_count ?? 0,
         costUsd: row.estimated_cost_usd ?? 0,
+        lastError: row.last_error,
         startedAt: row.started_at,
         endedAt: row.ended_at,
       })),
@@ -347,9 +350,12 @@ async function handleListRuns(
         repo: row.repo,
         issue: row.issue_number,
         status: row.status,
+        issueTitle: row.issue_title,
+        prNumber: row.pr_number,
         phase: row.current_phase,
         iterations: row.iteration_count ?? 0,
         costUsd: row.estimated_cost_usd ?? 0,
+        lastError: row.last_error,
         startedAt: hasRun ? timing?.started_at ?? null : null,
         endedAt: hasRun ? timing?.ended_at ?? null : null,
       }
@@ -367,9 +373,12 @@ interface CompletedRunRow extends RunTimingRow {
   repo: string
   issue_number: number
   status: string
+  issue_title: string | null
+  pr_number: number | null
   current_phase: string | null
   iteration_count: number | null
   estimated_cost_usd: number | null
+  last_error: string | null
 }
 
 function queryCompletedRuns(
@@ -391,9 +400,12 @@ function queryCompletedRuns(
          repo,
          issue_number,
          status,
+         issue_title,
+         pr_number,
          current_phase,
          iteration_count,
          estimated_cost_usd,
+         last_error,
          started_at,
          ended_at
        FROM runs

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -90,12 +90,38 @@ describe('MCP Tools', () => {
 
   it('list-runs returns filtered results', async () => {
     const runManager = new RunManager(db)
-    runManager.create({ repo: 'org/repo', issueNumber: 1, issueNodeId: '', planner: 'claude', coder: 'claude', reviewer: 'claude' })
+    runManager.create({
+      repo: 'org/repo',
+      issueNumber: 1,
+      issueTitle: 'Queue run title',
+      issueNodeId: '',
+      planner: 'claude',
+      coder: 'claude',
+      reviewer: 'claude',
+    })
     const r2 = runManager.create({ repo: 'org/repo', issueNumber: 2, issueNodeId: '', planner: 'claude', coder: 'claude', reviewer: 'claude' })
-    runManager.update(r2.id, { status: 'error' })
+    runManager.update(r2.id, { status: 'error', prNumber: 42, lastError: 'verify failed' })
 
-    const result = await handleToolCall('night-orch-list-runs', { status: 'queued' }, deps) as { count: number }
+    const result = await handleToolCall('night-orch-list-runs', { status: 'queued' }, deps) as {
+      count: number
+      runs: Array<{ issueTitle: string | null; prNumber: number | null; lastError: string | null }>
+    }
     expect(result.count).toBe(1)
+    expect(result.runs[0]).toMatchObject({
+      issueTitle: 'Queue run title',
+      prNumber: null,
+      lastError: null,
+    })
+
+    const errored = await handleToolCall('night-orch-list-runs', { status: 'error' }, deps) as {
+      count: number
+      runs: Array<{ prNumber: number | null; lastError: string | null }>
+    }
+    expect(errored.count).toBe(1)
+    expect(errored.runs[0]).toMatchObject({
+      prNumber: 42,
+      lastError: 'verify failed',
+    })
   })
 
   it('list-runs includes tracked issues with no run rows', async () => {

--- a/test/web/run-tone.test.ts
+++ b/test/web/run-tone.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  STATUS_BADGE_TONE,
+  badgeToneForCostUsd,
+  badgeToneForIterationCount,
+  badgeToneForPhase,
+  badgeToneForPrNumber,
+} from '../../web/src/lib/run-tone.js'
+
+describe('web run tone helpers', () => {
+  it('maps run statuses to expected badge tones', () => {
+    expect(STATUS_BADGE_TONE.running).toBe('badge-warning')
+    expect(STATUS_BADGE_TONE.queued).toBe('badge-info')
+    expect(STATUS_BADGE_TONE.review_ready).toBe('badge-secondary')
+    expect(STATUS_BADGE_TONE.completed).toBe('badge-success')
+    expect(STATUS_BADGE_TONE.blocked).toBe('badge-error')
+    expect(STATUS_BADGE_TONE.error).toBe('badge-error')
+  })
+
+  it('resolves phase tones from direct and inferred phase names', () => {
+    expect(badgeToneForPhase(null)).toBe('badge-neutral')
+    expect(badgeToneForPhase('review')).toBe('badge-secondary')
+    expect(badgeToneForPhase('phase:verify_checks')).toBe('badge-success')
+    expect(badgeToneForPhase('blocked_by_ci')).toBe('badge-error')
+    expect(badgeToneForPhase('waiting_for_approval')).toBe('badge-info')
+    expect(badgeToneForPhase('implement_fix')).toBe('badge-warning')
+    expect(badgeToneForPhase('release_candidate')).toBe('badge-success')
+    expect(badgeToneForPhase('mystery_phase')).toBe('badge-ghost')
+  })
+
+  it('colors iteration and cost thresholds like TUI', () => {
+    expect(badgeToneForIterationCount(null)).toBe('badge-success')
+    expect(badgeToneForIterationCount(1)).toBe('badge-success')
+    expect(badgeToneForIterationCount(2)).toBe('badge-warning')
+    expect(badgeToneForIterationCount(3)).toBe('badge-error')
+
+    expect(badgeToneForCostUsd(null)).toBe('badge-neutral')
+    expect(badgeToneForCostUsd(0)).toBe('badge-neutral')
+    expect(badgeToneForCostUsd(0.49)).toBe('badge-success')
+    expect(badgeToneForCostUsd(0.5)).toBe('badge-warning')
+    expect(badgeToneForCostUsd(1.99)).toBe('badge-warning')
+    expect(badgeToneForCostUsd(2)).toBe('badge-error')
+  })
+
+  it('colors PR presence', () => {
+    expect(badgeToneForPrNumber(undefined)).toBe('badge-neutral')
+    expect(badgeToneForPrNumber(null)).toBe('badge-neutral')
+    expect(badgeToneForPrNumber(123)).toBe('badge-info')
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,25 +6,16 @@ import { OperationsPanel } from './components/OperationsPanel.js'
 import { RunEventStream } from './components/RunEventStream.js'
 import { RunsPanel } from './components/RunsPanel.js'
 import { extractMessage, formatTimestamp } from './lib/format.js'
+import { STATUS_BADGE_TONE } from './lib/run-tone.js'
 import { asRunEventsPayload, mergeRunEvents } from './lib/run-events.js'
 import {
   type DashboardPage,
   type DashboardSnapshot,
   type RunEvent,
-  type RunStatus,
   type SessionResponse,
   type UpdateStatus,
   type WsEnvelope,
 } from './types/dashboard.js'
-
-const STATUS_TONE: Record<RunStatus, string> = {
-  queued: 'badge-info',
-  running: 'badge-warning',
-  blocked: 'badge-secondary',
-  review_ready: 'badge-success',
-  error: 'badge-error',
-  completed: 'badge-neutral',
-}
 
 const MUTATION_INTENT_HEADER = 'x-night-orch-intent'
 const MUTATION_INTENT_VALUE = 'mutate'
@@ -536,7 +527,7 @@ export function App(): ReactElement {
                 filteredRuns={filteredRuns}
                 selectedRunId={selectedRunId}
                 onSelectedRunChange={setSelectedRunId}
-                statusTone={STATUS_TONE}
+                statusTone={STATUS_BADGE_TONE}
               />
 
               <OperationsPanel

--- a/web/src/components/RunsPanel.tsx
+++ b/web/src/components/RunsPanel.tsx
@@ -1,6 +1,12 @@
 import { type ReactElement } from 'react'
 
-import { formatMoney, formatRunTime } from '../lib/format.js'
+import { formatMoney, formatRunTime, truncate } from '../lib/format.js'
+import {
+  badgeToneForCostUsd,
+  badgeToneForIterationCount,
+  badgeToneForPhase,
+  badgeToneForPrNumber,
+} from '../lib/run-tone.js'
 import { type RunStatus, type RunSummary } from '../types/dashboard.js'
 
 interface RunsPanelProps {
@@ -73,24 +79,43 @@ export function RunsPanel({
                     : 'border-base-300/70 bg-base-100/50 hover:border-info/40 hover:bg-base-100/80'
                 }`}
               >
-                <div className="card-body gap-2 p-3">
+                <div className="card-body gap-2.5 p-3">
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div>
-                      <p className="text-sm font-semibold text-base-content">{run.repo} #{run.issue}</p>
-                      <p className="text-xs text-base-content/60">
+                      <p className="text-xs font-medium uppercase tracking-wide text-base-content/70">
+                        {run.repo} #{run.issue}
+                      </p>
+                      <p className="mt-0.5 text-sm font-semibold text-base-content">
+                        {truncate(resolveIssueTitle(run.issueTitle), 110)}
+                      </p>
+                      <p className="mt-0.5 text-xs text-base-content/55">
                         {run.hasRun ? run.runId : 'Tracked issue (no run yet)'}
                       </p>
                     </div>
-                    <span className={`badge badge-sm badge-outline capitalize ${statusTone[run.status]}`}>
+                    <span className={`badge badge-sm capitalize ${statusTone[run.status]}`}>
                       {run.status.replaceAll('_', ' ')}
                     </span>
                   </div>
-                  <div className="grid grid-cols-2 gap-2 text-xs text-base-content/75 md:grid-cols-4">
-                    <span>Phase: {run.phase ?? '-'}</span>
-                    <span>Iter: {run.iterations}</span>
-                    <span>Cost: ${formatMoney(run.costUsd)}</span>
-                    <span>{formatRunTime(run)}</span>
+                  <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                    <span className={`badge badge-xs ${badgeToneForPhase(run.phase)}`}>
+                      phase {truncate(resolvePhaseLabel(run.phase), 18)}
+                    </span>
+                    <span className={`badge badge-xs ${badgeToneForIterationCount(run.iterations)}`}>
+                      iter {run.iterations}
+                    </span>
+                    <span className={`badge badge-xs ${badgeToneForCostUsd(run.costUsd)}`}>
+                      ${formatMoney(run.costUsd)}
+                    </span>
+                    <span className={`badge badge-xs ${badgeToneForPrNumber(run.prNumber)}`}>
+                      {run.prNumber !== null ? `PR #${run.prNumber}` : 'no PR'}
+                    </span>
+                    <span className="ml-auto text-[11px] text-base-content/65">{formatRunTime(run)}</span>
                   </div>
+                  {run.lastError && (
+                    <p className="rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
+                      {truncate(run.lastError, 220)}
+                    </p>
+                  )}
                 </div>
               </button>
             ))}
@@ -99,4 +124,14 @@ export function RunsPanel({
       </div>
     </div>
   )
+}
+
+function resolveIssueTitle(issueTitle: string | null): string {
+  const title = issueTitle?.trim()
+  return title && title.length > 0 ? title : '(title unavailable)'
+}
+
+function resolvePhaseLabel(phase: string | null): string {
+  const value = phase?.trim()
+  return value && value.length > 0 ? value : '-'
 }

--- a/web/src/lib/run-tone.ts
+++ b/web/src/lib/run-tone.ts
@@ -1,0 +1,120 @@
+import { type RunStatus } from '../types/dashboard.js'
+
+type TuiColor = 'white' | 'gray' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'
+
+const PHASE_COLORS: Record<string, TuiColor> = {
+  queued: 'cyan',
+  plan: 'cyan',
+  planner: 'cyan',
+  planning: 'cyan',
+  code: 'yellow',
+  coder: 'yellow',
+  review: 'magenta',
+  reviewer: 'magenta',
+  verify: 'green',
+  verification: 'green',
+  publish: 'green',
+  merge: 'green',
+  merged: 'green',
+}
+
+export const STATUS_BADGE_TONE: Record<RunStatus, string> = {
+  running: 'badge-warning',
+  queued: 'badge-info',
+  review_ready: 'badge-secondary',
+  completed: 'badge-success',
+  blocked: 'badge-error',
+  error: 'badge-error',
+}
+
+export function badgeToneForPhase(phase: string | null | undefined): string {
+  return badgeToneFromTuiColor(colorForPhase(phase))
+}
+
+export function badgeToneForIterationCount(iterationCount: number | null | undefined): string {
+  return badgeToneFromTuiColor(colorForIterationCount(iterationCount))
+}
+
+export function badgeToneForCostUsd(costUsd: number | null | undefined): string {
+  return badgeToneFromTuiColor(colorForCostUsd(costUsd))
+}
+
+export function badgeToneForPrNumber(prNumber: number | null | undefined): string {
+  return badgeToneFromTuiColor(colorForPrNumber(prNumber))
+}
+
+function colorForPhase(phase: string | null | undefined): TuiColor {
+  const normalized = normalizeLabel(phase)
+  if (!normalized) return 'gray'
+
+  const direct = PHASE_COLORS[normalized]
+  if (direct) return direct
+
+  const tokens = normalized.split(/[\s:_-]+/)
+  for (const token of tokens) {
+    const tokenColor = PHASE_COLORS[token]
+    if (tokenColor) return tokenColor
+  }
+
+  if (tokens.some((token) => token.includes('error') || token.includes('fail') || token.includes('block'))) {
+    return 'red'
+  }
+  if (tokens.some((token) => token.includes('queue') || token.includes('wait') || token.includes('pending'))) {
+    return 'cyan'
+  }
+  if (tokens.some((token) => token.includes('review'))) return 'magenta'
+  if (tokens.some((token) => token.includes('plan'))) return 'cyan'
+  if (tokens.some((token) => token.includes('code') || token.includes('implement') || token.includes('fix'))) {
+    return 'yellow'
+  }
+  if (tokens.some((token) => token.includes('verify') || token.includes('test') || token.includes('check'))) {
+    return 'green'
+  }
+  if (tokens.some((token) => token.includes('publish') || token.includes('merge') || token.includes('release'))) {
+    return 'green'
+  }
+
+  return 'white'
+}
+
+function colorForPrNumber(prNumber: number | null | undefined): TuiColor {
+  return typeof prNumber === 'number' ? 'cyan' : 'gray'
+}
+
+function colorForIterationCount(iterationCount: number | null | undefined): TuiColor {
+  const iteration = iterationCount ?? 0
+  if (iteration <= 1) return 'green'
+  if (iteration <= 2) return 'yellow'
+  return 'red'
+}
+
+function colorForCostUsd(costUsd: number | null | undefined): TuiColor {
+  const cost = costUsd ?? 0
+  if (cost <= 0) return 'gray'
+  if (cost < 0.5) return 'green'
+  if (cost < 2) return 'yellow'
+  return 'red'
+}
+
+function normalizeLabel(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? ''
+}
+
+function badgeToneFromTuiColor(color: TuiColor): string {
+  switch (color) {
+    case 'red':
+      return 'badge-error'
+    case 'yellow':
+      return 'badge-warning'
+    case 'cyan':
+      return 'badge-info'
+    case 'magenta':
+      return 'badge-secondary'
+    case 'green':
+      return 'badge-success'
+    case 'gray':
+      return 'badge-neutral'
+    default:
+      return 'badge-ghost'
+  }
+}

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -11,10 +11,13 @@ export interface RunSummary {
   hasRun: boolean
   repo: string
   issue: number
+  issueTitle: string | null
   status: RunStatus
+  prNumber: number | null
   phase: string | null
   iterations: number
   costUsd: number
+  lastError: string | null
   startedAt: string | null
   endedAt: string | null
 }


### PR DESCRIPTION
Closes #63

## Plan
**Objective:** Rebase the issue-63 branch onto master, resolving merge conflicts while preserving web issue list color/title improvements

1. Reset local branch to the remote branch tip (b6445c4) so local has the prior work commits: git reset --hard remotes/origin/orch/63-web-adjust-issue-lists-title-colors
2. Start interactive-less rebase onto master: git rebase master. This will likely conflict on files changed by both branches. Identify each conflict file.
3. Resolve conflict in web/src/App.tsx: Keep the branch's change moving STATUS_TONE to run-tone.ts as STATUS_BADGE_TONE import, and fix the indentation of RunsPanel props to match master's formatting (4-space indent inside JSX). Master may have added new imports or changed surrounding layout code from #70 (Extend app layout) — preserve those additions while applying the STATUS_BADGE_TONE import.
4. Resolve conflict in web/src/components/RunsPanel.tsx: Apply the branch's enhanced card layout (repo/issue as subtitle, issue title as heading, color-coded badges for phase/iter/cost/PR, lastError display). Master's version is the original simple layout. Take the branch version entirely, ensuring it references the current RunSummary fields (issueTitle, prNumber, lastError added in step 6).
5. Resolve conflict in src/mcp/tools/index.ts: The branch adds issueTitle, prNumber, lastError fields to handleListRuns response objects and changes the continue description. Master may have modified the surrounding code in the 6 new commits (especially #64 Issue missing, #70 Extend app layout, #75 Bug handle issue). Merge both: keep master's structural changes and apply the branch's new fields and description change.
6. Resolve conflict in web/src/types/dashboard.ts: Add issueTitle, prNumber, and lastError fields to RunSummary interface. Master's version lacks these. Straightforward addition.
7. Resolve conflict in src/runner/poller.ts: The branch removes postStatusComment, postErrorStatusComment, toErrorMessage, sanitizeErrorForComment helper functions and simplifies error reporting (inlines formatStatusComment + upsertBotComment). Master still has all these functions. The branch also changes String(err) vs toErrorMessage(err). Apply the branch's simplification while ensuring it works with any structural changes from master's 6 commits.
8. Resolve conflict in src/forge/status-comment.ts: Remove nextStep field from StatusCommentSections interface and the corresponding rendering block in formatStatusComment.
9. Resolve conflict in src/ops/continue.ts: Change CONTINUABLE_STATUSES from Set(['blocked', 'review_ready', 'error']) to Set(['blocked', 'review_ready']) and update error message.
10. Resolve conflicts in remaining source files: src/cli/index.ts (continue description), src/cli/tui/app.tsx (remove error from continue target filter), src/publishing/publisher.ts (add error comment on publish failure), docs/CONFIGURATION.md and docs/USAGE.md (continue description updates).
11. Resolve conflicts in test files: test/forge/status-comment.test.ts (remove nextStep from error test), test/mcp/tools.test.ts (add issueTitle/prNumber/lastError assertions to list-runs test), test/ops/continue.test.ts (change error-run test to reject instead of queue), test/web/run-tone.test.ts (new file, no conflict expected).
12. After resolving all conflicts, continue rebase (git rebase --continue) for each commit. Repeat conflict resolution if the second commit (b6445c4) also conflicts.
13. Verify the rebase result: run pnpm typecheck && pnpm lint && pnpm test to ensure everything compiles and passes.
14. Force-push the rebased branch to origin (with user confirmation) to update the PR.

## Implementation
Manually reapplied the issue-63 web issue-list improvements onto the current master-based branch state: `night-orch-list-runs` now includes `issueTitle`/`prNumber`/`lastError`, web run summary types were extended, the runs panel now shows issue titles and TUI-style color-coded badges (status/phase/iteration/cost/PR) plus last-error context, and shared run-tone helpers with tests were added. Verification passed with `pnpm test`, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/mcp/tools/index.ts`
- `test/mcp/tools.test.ts`
- `web/src/App.tsx`
- `web/src/components/RunsPanel.tsx`
- `web/src/types/dashboard.ts`
- `web/src/lib/run-tone.ts`
- `test/web/run-tone.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files in full and validated adjacent implementations in `src/cli/tui/constants.ts` and `src/cli/tui/data.ts` for parity/context. The change set correctly propagates `issueTitle`/`prNumber`/`lastError` through `night-orch-list-runs` (`src/mcp/tools/index.ts`), updates web run rendering and tone logic (`web/src/components/RunsPanel.tsx`, `web/src/lib/run-tone.ts`, `web/src/App.tsx`, `web/src/types/dashboard.ts`), and adds/updates relevant tests (`test/mcp/tools.test.ts`, `test/web/run-tone.test.ts`). I also ran `pnpm test -- test/mcp/tools.test.ts test/web/run-tone.test.ts test/web/server.test.ts`; tests passed.

---

**Triage:** standard | **Iterations:** 0 | **Roles:** plan=claude code=codex review=codex