### PR TITLE
[CHORE] Grafana - stats are broken (night-orch / #65)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -224,7 +224,7 @@ Requires `acpx` installed as a dependency (`pnpm add acpx`).
 | --- | --- | --- |
 | `enabled` | boolean | `true` |
 | `port` | positive int | `9090` |
-| `host` | string | `127.0.0.1` |
+| `host` | string | `0.0.0.0` |
 
 ## `observability`
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -334,3 +334,5 @@ curl http://127.0.0.1:9091/api/v1/targets
 
 If the target is down, check that the scrape target port in `prometheus.yml`
 matches the night-orch metrics port (default: 9090).
+Also ensure `metrics.host` in your night-orch config is reachable from Docker
+(`0.0.0.0` for the default monitoring stack).

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -82,7 +82,7 @@ workerProfiles:
 metrics:
   enabled: true
   port: 9090
-  host: 127.0.0.1
+  host: 0.0.0.0
 
 observability:
   agentStreaming: true

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -4,6 +4,6 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://127.0.0.1:9091
+    url: http://prometheus:9090
     isDefault: true
     editable: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -5,4 +5,4 @@ global:
 scrape_configs:
   - job_name: night-orch
     static_configs:
-      - targets: ["127.0.0.1:9090"]
+      - targets: ["host.docker.internal:9090"]

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -239,7 +239,7 @@ const SecuritySchema = z.object({
 const MetricsSchema = z.object({
   enabled: z.boolean().default(true),
   port: z.number().int().positive().default(9090),
-  host: z.string().default('127.0.0.1'),
+  host: z.string().default('0.0.0.0'),
 })
 
 // --- Observability schema ---

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -96,6 +96,7 @@ describe('ConfigSchema', () => {
       expect(result.data.github.pollIntervalSeconds).toBe(300)
       expect(result.data.loop.maxReviewIterations).toBe(4)
       expect(result.data.security.maxDailyCostUsd).toBe(50)
+      expect(result.data.metrics.host).toBe('0.0.0.0')
       expect(result.data.repos[0]?.maxConcurrentRuns).toBe(1)
       expect(result.data.repos[0]?.baseBranch).toBe('main')
       expect(result.data.repos[0]?.branchPrefix).toBe('orch')

--- a/test/monitoring/wiring.test.ts
+++ b/test/monitoring/wiring.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+
+type ComposeFile = {
+  services?: {
+    prometheus?: {
+      extra_hosts?: string[]
+    }
+  }
+}
+
+type PrometheusConfigFile = {
+  scrape_configs?: Array<{
+    job_name?: string
+    static_configs?: Array<{
+      targets?: string[]
+    }>
+  }>
+}
+
+type GrafanaDatasourcesFile = {
+  datasources?: Array<{
+    name?: string
+    url?: string
+  }>
+}
+
+function loadYamlFile<T>(relativePath: string): T {
+  const content = readFileSync(
+    resolve(import.meta.dirname, '../../', relativePath),
+    'utf-8',
+  )
+  return parseYaml(content) as T
+}
+
+describe('Monitoring Docker wiring', () => {
+  it('configures Prometheus to scrape a host-reachable metrics endpoint', () => {
+    const compose = loadYamlFile<ComposeFile>('docker-compose.example.yaml')
+    const prometheus = loadYamlFile<PrometheusConfigFile>('monitoring/prometheus.yml')
+
+    expect(compose.services?.prometheus?.extra_hosts ?? []).toContain('host.docker.internal:host-gateway')
+
+    const nightOrchJob = prometheus.scrape_configs?.find((job) => job.job_name === 'night-orch')
+    expect(nightOrchJob).toBeDefined()
+    const targets = (nightOrchJob?.static_configs ?? []).flatMap((entry) => entry.targets ?? [])
+
+    expect(targets).toContain('host.docker.internal:9090')
+    expect(targets).not.toContain('127.0.0.1:9090')
+  })
+
+  it('configures Grafana to query Prometheus over the Docker service network', () => {
+    const datasource = loadYamlFile<GrafanaDatasourcesFile>(
+      'monitoring/grafana/provisioning/datasources/prometheus.yml',
+    )
+
+    const prometheusDatasource = datasource.datasources?.find((item) => item.name === 'Prometheus')
+    expect(prometheusDatasource).toBeDefined()
+    expect(prometheusDatasource?.url).toBe('http://prometheus:9090')
+    expect(prometheusDatasource?.url).not.toContain('127.0.0.1')
+  })
+})


### PR DESCRIPTION
Closes #65

## Plan
**Objective:** Fix broken Grafana/Prometheus monitoring by restoring correct Docker networking configuration

1. Fix Prometheus scrape target: change '127.0.0.1:9090' to 'host.docker.internal:9090' so Prometheus container can reach the host-running night-orch metrics server
2. Fix Grafana datasource URL: change 'http://127.0.0.1:9091' back to 'http://prometheus:9090' so Grafana reaches Prometheus via Docker Compose service DNS
3. Change default metrics host from '127.0.0.1' to '0.0.0.0' in config schema so the metrics endpoint is accessible from Docker containers via host.docker.internal

## Implementation
Implemented the monitoring networking fix end-to-end and addressed both review findings. Restored Docker-reachable endpoints (`monitoring/prometheus.yml` now scrapes `host.docker.internal:9090`, Grafana datasource now uses `http://prometheus:9090`), aligned metrics bind defaults to support container scraping on Linux (`metrics.host` default changed to `0.0.0.0` in schema and example config), updated configuration/deployment docs accordingly, and added regression coverage with a new monitoring wiring smoke test plus a schema-default assertion. Validation passed: `pnpm lint`, `pnpm typecheck`, and `pnpm test` (124 files, 1045 tests).

**Changed files:**
- `src/config/schema.ts`
- `examples/config.example.yaml`
- `docs/CONFIGURATION.md`
- `docs/deployment.md`
- `monitoring/prometheus.yml`
- `monitoring/grafana/provisioning/datasources/prometheus.yml`
- `test/config/schema.test.ts`
- `test/monitoring/wiring.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The prior review findings are addressed. Monitoring wiring is now internally consistent for Docker: Prometheus scrapes `host.docker.internal:9090` (`monitoring/prometheus.yml:8`) and Grafana queries Prometheus over the service network (`monitoring/grafana/provisioning/datasources/prometheus.yml:7`). The metrics bind default is updated to a Docker-reachable host (`src/config/schema.ts:242`, `examples/config.example.yaml:85`, `docs/CONFIGURATION.md:227`, `docs/deployment.md:337-338`). Regression coverage was added for wiring and defaults (`test/monitoring/wiring.test.ts:37-61`, `test/config/schema.test.ts:99`). Verification run: `pnpm test`, `pnpm typecheck`, and `pnpm lint` all passed.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex