### PR TITLE
[CHORE] Adjust commit titles (night-orch / #67)

### DIFF
--- a/src/loop/commit.ts
+++ b/src/loop/commit.ts
@@ -3,9 +3,11 @@ import type { Config } from '../config/schema.js'
 import { logger } from '../utils/logger.js'
 import { normalizeRepoRelativePath } from '../planning/mode.js'
 import { runGit } from '../git/process.js'
+import { compilePRTitle } from '../publishing/pr-body.js'
 
 export interface CommitChangesOptions {
   planningOnlyPrdPath?: string
+  issueLabels?: string[]
 }
 
 export interface CommitChangesResult {
@@ -74,7 +76,7 @@ export async function commitChanges(
     }
   }
 
-  const message = `night-orch: implement #${issueNumber} ${sanitizeCommitTitle(issueTitle)}`
+  const message = compilePRTitle(issueNumber, issueTitle, opts.issueLabels ?? [])
   await runGit(['commit', '-m', message], { cwd: worktreePath })
 
   logger.info(
@@ -83,14 +85,6 @@ export async function commitChanges(
   )
 
   return { committed: true, reason: null, blockRun: false }
-}
-
-function sanitizeCommitTitle(title: string): string {
-  return title
-    .replace(/[\r\n]+/g, ' ')
-    .replace(/[ \t]{2,}/g, ' ')
-    .replace(/[^\w\s.,:;!?()[\]{}\-/#]/g, '')
-    .trim()
 }
 
 function normalizeGitPath(path: string): string {

--- a/src/loop/engine.ts
+++ b/src/loop/engine.ts
@@ -142,7 +142,10 @@ export async function executeLoop(
             ctx.issueNumber,
             ctx.issue.title,
             config.security,
-            { planningOnlyPrdPath },
+            {
+              planningOnlyPrdPath,
+              issueLabels: ctx.issue.labels,
+            },
           )
           if (!commitResult.committed) {
             logger.warn({ reason: commitResult.reason }, 'Commit skipped')

--- a/test/loop/commit.test.ts
+++ b/test/loop/commit.test.ts
@@ -65,7 +65,7 @@ describe('commitChanges', () => {
     )
     expect(mockExeca).toHaveBeenCalledWith(
       'git',
-      ['commit', '-m', 'night-orch: implement #42 Fix title'],
+      ['commit', '-m', '[CHORE] Fix title (night-orch / #42)'],
       expect.objectContaining({ cwd: '/tmp/wt', extendEnv: false }),
     )
   })
@@ -85,7 +85,27 @@ describe('commitChanges', () => {
 
     expect(mockExeca).toHaveBeenCalledWith(
       'git',
-      ['commit', '-m', 'night-orch: implement #1 Fix Injected trailer: value'],
+      ['commit', '-m', '[CHORE] Fix Injected trailer: value (night-orch / #1)'],
+      expect.objectContaining({ cwd: '/tmp/wt', extendEnv: false }),
+    )
+  })
+
+  it('uses label-derived category in commit message', async () => {
+    mockExeca
+      .mockResolvedValueOnce({ stdout: ' M src/a.ts\n' } as never)
+      .mockResolvedValueOnce({} as never)
+      .mockResolvedValueOnce({} as never)
+    mockCheckDiffSize.mockResolvedValue({
+      ok: true,
+      stats: { changedFiles: 1, insertions: 1, deletions: 0, totalChangedLines: 1 },
+      reason: null,
+    })
+
+    await commitChanges('/tmp/wt', 7, 'Fix parser edge-case', limits, { issueLabels: ['bug'] })
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      'git',
+      ['commit', '-m', '[FIX] Fix parser edge-case (night-orch / #7)'],
       expect.objectContaining({ cwd: '/tmp/wt', extendEnv: false }),
     )
   })


### PR DESCRIPTION
Closes #67

## Plan
**Objective:** Change commit message format from 'night-orch: implement #N Title' to '[CATEGORY] Title (night-orch / #N)' matching PR title format

1. Update commitChanges signature in src/loop/commit.ts to accept issueLabels parameter, import compilePRTitle from pr-body.ts, and replace the old message format on line 77 with compilePRTitle(issueNumber, issueTitle, issueLabels)
2. Update the call site in src/loop/engine.ts (line 140) to pass ctx.issue.labels to commitChanges
3. Update test/loop/commit.test.ts: add mock for compilePRTitle (or update expected messages to new format), pass labels array in all test calls to commitChanges

## Implementation
Updated commit message generation to reuse PR title formatting so commits now follow `[CATEGORY] Title (night-orch / #N)`. Added `issueLabels` to commit options, passed labels from the loop engine when committing, and updated commit tests (including a new label-derived `[FIX]` case). Verified with `pnpm test test/loop/commit.test.ts`, `pnpm test test/publishing/pr-body.test.ts test/publishing/publisher.test.ts`, and `pnpm typecheck`.

**Changed files:**
- `src/loop/commit.ts`
- `src/loop/engine.ts`
- `test/loop/commit.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Change is correct and aligns with the request: commit titles now reuse PR-title formatting via `compilePRTitle` in `src/loop/commit.ts:79`, and issue labels are forwarded from `src/loop/engine.ts:145-148` so category prefixes are label-derived. I reviewed the modified files in full plus adjacent formatter/publisher code and tests (`src/publishing/pr-body.ts`, `test/publishing/pr-body.test.ts`, `test/loop/engine.test.ts`), and validated locally with `pnpm test`, `pnpm lint`, and `pnpm typecheck` (all passing).

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex