### PR TITLE
[CHORE] Web/TUI - Display git sha/Version (night-orch / #79)

### DIFF
--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -22,6 +22,7 @@ import { collectMissingTitleTargets, hasReadableTitle, type TitleLookup } from '
 import { TABS } from './constants.js'
 import type { RunsViewMode, TabId, TuiLogLine } from './types.js'
 import { formatUtcClock, nowUtcIso } from '../../utils/time.js'
+import { getBuildInfo } from '../../utils/build-info.js'
 
 interface AppProps {
   db: Database.Database
@@ -42,6 +43,7 @@ const MIN_LOG_WINDOW_SIZE = 4
 const LOG_WINDOW_RESERVED_ROWS = 17
 const EXIT_GRACE_TIMEOUT_MS = 15_000
 const CLEANUP_CONFIRM_TIMEOUT_MS = 5_000
+const BUILD_INFO = getBuildInfo()
 
 export function resolveTabHotkey(input: string): TabId | null {
   if (input === '1') return 'runs'
@@ -939,6 +941,7 @@ export function App({
         status={stats}
         autoRefresh={autoRefresh}
         lastRefreshAt={lastRefreshAt}
+        buildInfo={BUILD_INFO}
       />
 
       <Box marginBottom={1}>

--- a/src/cli/tui/header.tsx
+++ b/src/cli/tui/header.tsx
@@ -4,6 +4,7 @@ import type { TuiStatsSnapshot } from '../../state/stats.js'
 import { TABS } from './constants.js'
 import type { TabId } from './types.js'
 import { formatTime } from './format.js'
+import type { BuildInfo } from '../../utils/build-info.js'
 
 interface HeaderProps {
   activeTab: TabId
@@ -12,6 +13,7 @@ interface HeaderProps {
   status: TuiStatsSnapshot
   autoRefresh: boolean
   lastRefreshAt: string
+  buildInfo: BuildInfo
 }
 
 export function Header({
@@ -21,11 +23,16 @@ export function Header({
   status,
   autoRefresh,
   lastRefreshAt,
+  buildInfo,
 }: HeaderProps): React.ReactElement {
+  const shortSha = buildInfo.gitSha ? buildInfo.gitSha.slice(0, 12) : 'unknown'
+
   return (
     <Box flexDirection="column" marginBottom={1} borderStyle="round" borderColor="blue" paddingX={1}>
       <Box>
         <Text bold color="white">NIGHT-ORCH CONTROL ROOM</Text>
+        <Text color="gray">  v{buildInfo.version}</Text>
+        <Text color="gray">  sha {shortSha}</Text>
         <Text color="gray">  refresh {pollIntervalMs / 1000}s</Text>
         {dryRun && <Text color="yellow">  [dry-run]</Text>}
         <Text color={autoRefresh ? 'green' : 'yellow'}>  {autoRefresh ? '● live' : '○ paused'}</Text>

--- a/src/utils/build-info.ts
+++ b/src/utils/build-info.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_VERSION = '0.1.0'
+const SHA_PATTERN = /^[0-9a-f]{7,40}$/i
+
+export interface BuildInfo {
+  version: string
+  gitSha: string | null
+}
+
+let cachedBuildInfo: BuildInfo | null = null
+
+export function getBuildInfo(): BuildInfo {
+  if (cachedBuildInfo) {
+    return cachedBuildInfo
+  }
+
+  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+  cachedBuildInfo = {
+    version: readPackageVersion(projectRoot) ?? DEFAULT_VERSION,
+    gitSha: readGitSha(projectRoot),
+  }
+
+  return cachedBuildInfo
+}
+
+function readPackageVersion(projectRoot: string): string | null {
+  try {
+    const raw = readFileSync(resolve(projectRoot, 'package.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { version?: unknown }
+    if (typeof parsed.version !== 'string') {
+      return null
+    }
+    const version = parsed.version.trim()
+    return version.length > 0 ? version : null
+  } catch {
+    return null
+  }
+}
+
+function readGitSha(projectRoot: string): string | null {
+  const envSha = normalizeSha(process.env.NIGHT_ORCH_GIT_SHA)
+  if (envSha) {
+    return envSha
+  }
+
+  try {
+    const sha = execFileSync('git', ['-C', projectRoot, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    return normalizeSha(sha)
+  } catch {
+    return null
+  }
+}
+
+function normalizeSha(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  return SHA_PATTERN.test(normalized) ? normalized : null
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -10,6 +10,7 @@ import type { MCPDependencies } from '../mcp/server.js'
 import { handleToolCall } from '../mcp/tools/index.js'
 import { handleResourceRead } from '../mcp/resources/index.js'
 import { loadTuiStats } from '../state/stats.js'
+import { getBuildInfo } from '../utils/build-info.js'
 import { logger } from '../utils/logger.js'
 import { nowUtcIso } from '../utils/time.js'
 
@@ -31,6 +32,10 @@ interface DashboardSnapshot {
   status: unknown
   runs: unknown
   cost: unknown
+  build: {
+    version: string
+    gitSha: string | null
+  }
   config: {
     repos: string[]
     pollIntervalSeconds: number
@@ -54,6 +59,7 @@ const DEFAULT_SNAPSHOT_INTERVAL_MS = 3000
 const MUTATION_INTENT_HEADER = 'x-night-orch-intent'
 const MUTATION_INTENT_VALUE = 'mutate'
 const WEB_AUTH_TOKEN_HEADER = 'x-night-orch-web-token'
+const BUILD_INFO = getBuildInfo()
 const CONTENT_TYPES: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
   '.html': 'text/html; charset=utf-8',
@@ -876,6 +882,7 @@ async function buildDashboardSnapshot(deps: MCPDependencies): Promise<DashboardS
     status,
     runs,
     cost,
+    build: BUILD_INFO,
     config: {
       repos: deps.config.repos.map((repo) => repo.repo),
       pollIntervalSeconds: deps.config.github.pollIntervalSeconds,

--- a/test/utils/build-info.test.ts
+++ b/test/utils/build-info.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockExecFileSync, mockReadFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+}))
+
+describe('getBuildInfo', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    delete process.env.NIGHT_ORCH_GIT_SHA
+  })
+
+  it('prefers NIGHT_ORCH_GIT_SHA over git command output', async () => {
+    process.env.NIGHT_ORCH_GIT_SHA = 'ABCDEF1234567'
+    mockReadFileSync.mockReturnValueOnce('{"version":"2.3.4"}')
+
+    const { getBuildInfo } = await import('../../src/utils/build-info.js')
+    expect(getBuildInfo()).toEqual({
+      version: '2.3.4',
+      gitSha: 'abcdef1234567',
+    })
+    expect(mockExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to git rev-parse when env SHA is invalid', async () => {
+    process.env.NIGHT_ORCH_GIT_SHA = 'not-a-sha'
+    mockReadFileSync.mockReturnValueOnce('{"version":"3.0.0"}')
+    mockExecFileSync.mockReturnValueOnce('1234567890ABCDEF\n')
+
+    const { getBuildInfo } = await import('../../src/utils/build-info.js')
+    expect(getBuildInfo()).toEqual({
+      version: '3.0.0',
+      gitSha: '1234567890abcdef',
+    })
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses safe fallbacks when package or git metadata is unavailable', async () => {
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw new Error('missing package')
+    })
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('git unavailable')
+    })
+
+    const { getBuildInfo } = await import('../../src/utils/build-info.js')
+    expect(getBuildInfo()).toEqual({
+      version: '0.1.0',
+      gitSha: null,
+    })
+  })
+
+  it('rejects invalid git outputs', async () => {
+    mockReadFileSync.mockReturnValueOnce('{"version":"1.0.0"}')
+    mockExecFileSync.mockReturnValueOnce('definitely-not-a-sha')
+
+    const { getBuildInfo } = await import('../../src/utils/build-info.js')
+    expect(getBuildInfo()).toEqual({
+      version: '1.0.0',
+      gitSha: null,
+    })
+  })
+})

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -253,10 +253,15 @@ describe('startWebServer', () => {
     const dashboard = await fetch(`${baseUrl}/api/dashboard`)
     expect(dashboard.status).toBe(200)
     const payload = await dashboard.json() as {
+      build: { version: string; gitSha: string | null }
       runs: { runs: Array<{ issue: number; status: string; runId: string; hasRun: boolean }> }
     }
     const trackedIssue = payload.runs.runs.find((run) => run.issue === 58)
 
+    expect(payload.build.version).toMatch(/\S+/)
+    if (payload.build.gitSha !== null) {
+      expect(payload.build.gitSha).toMatch(/^[0-9a-f]{7,40}$/)
+    }
     expect(trackedIssue).toBeDefined()
     expect(trackedIssue?.status).toBe('queued')
     expect(trackedIssue?.hasRun).toBe(false)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,8 @@ import {
 const MUTATION_INTENT_HEADER = 'x-night-orch-intent'
 const MUTATION_INTENT_VALUE = 'mutate'
 const WEB_AUTH_TOKEN_HEADER = 'x-night-orch-web-token'
+const FRONTEND_BUILD_VERSION = import.meta.env.VITE_BUILD_VERSION ?? 'unknown'
+const FRONTEND_BUILD_GIT_SHA = import.meta.env.VITE_BUILD_GIT_SHA ?? 'unknown'
 
 interface PlaceholderPageProps {
   title: string
@@ -491,6 +493,10 @@ export function App(): ReactElement {
         onPageChange={setActivePage}
         currentStateLabel={currentState.label}
         currentStateToneClass={currentState.toneClass}
+        frontendVersion={FRONTEND_BUILD_VERSION}
+        frontendGitSha={FRONTEND_BUILD_GIT_SHA}
+        backendVersion={snapshot?.build?.version ?? 'unknown'}
+        backendGitSha={snapshot?.build?.gitSha ?? null}
       />
 
       <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 pt-[var(--orch-header-offset)] sm:px-6 lg:px-8">

--- a/web/src/components/DashboardHeader.tsx
+++ b/web/src/components/DashboardHeader.tsx
@@ -7,6 +7,10 @@ interface DashboardHeaderProps {
   onPageChange: (page: DashboardPage) => void
   currentStateLabel: string
   currentStateToneClass: string
+  frontendVersion: string
+  frontendGitSha: string
+  backendVersion: string
+  backendGitSha: string | null
 }
 
 const PAGES: Array<{ id: DashboardPage, label: string }> = [
@@ -21,12 +25,23 @@ export function DashboardHeader({
   onPageChange,
   currentStateLabel,
   currentStateToneClass,
+  frontendVersion,
+  frontendGitSha,
+  backendVersion,
+  backendGitSha,
 }: DashboardHeaderProps): ReactElement {
+  const frontendShortSha = frontendGitSha.slice(0, 12)
+  const backendShortSha = backendGitSha ? backendGitSha.slice(0, 12) : 'unknown'
+
   return (
     <header className="fixed inset-x-0 top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between gap-3 py-3">
-          <p className="text-lg font-semibold tracking-wide text-base-content sm:text-xl">night-orch</p>
+          <div className="flex flex-col">
+            <p className="text-lg font-semibold tracking-wide text-base-content sm:text-xl">night-orch</p>
+            <p className="text-xs font-mono text-base-content/70">frontend v{frontendVersion} · sha {frontendShortSha}</p>
+            <p className="text-[11px] font-mono text-base-content/50">backend v{backendVersion} · sha {backendShortSha}</p>
+          </div>
           <div className="flex flex-col items-end gap-1">
             <span className="text-[10px] uppercase tracking-[0.22em] text-base-content/65">Current State</span>
             <span className={`badge badge-sm capitalize ${currentStateToneClass}`}>{currentStateLabel}</span>

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -32,6 +32,10 @@ export interface DashboardSnapshot {
   cost: {
     dailyBudgetUsd: number
   }
+  build?: {
+    version: string
+    gitSha: string | null
+  }
   config: {
     repos: string[]
     pollIntervalSeconds: number

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BUILD_VERSION?: string
+  readonly VITE_BUILD_GIT_SHA?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,20 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+
+const FRONTEND_VERSION = readPackageVersion() ?? '0.1.0'
+const FRONTEND_GIT_SHA = readGitSha() ?? 'unknown'
 
 export default defineConfig({
   root: resolve(import.meta.dirname),
   plugins: [tailwindcss(), react()],
+  define: {
+    'import.meta.env.VITE_BUILD_VERSION': JSON.stringify(FRONTEND_VERSION),
+    'import.meta.env.VITE_BUILD_GIT_SHA': JSON.stringify(FRONTEND_GIT_SHA),
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,
@@ -21,3 +30,29 @@ export default defineConfig({
     strictPort: true,
   },
 })
+
+function readPackageVersion(): string | null {
+  try {
+    const packagePath = resolve(import.meta.dirname, '../package.json')
+    const raw = readFileSync(packagePath, 'utf8')
+    const parsed = JSON.parse(raw) as { version?: unknown }
+    if (typeof parsed.version !== 'string') return null
+    const version = parsed.version.trim()
+    return version.length > 0 ? version : null
+  } catch {
+    return null
+  }
+}
+
+function readGitSha(): string | null {
+  try {
+    const projectRoot = resolve(import.meta.dirname, '..')
+    const sha = execFileSync('git', ['-C', projectRoot, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim().toLowerCase()
+    return /^[0-9a-f]{7,40}$/.test(sha) ? sha : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Closes #79

## Plan
**Objective:** Display git SHA and package version in both the Web dashboard header and terminal TUI header

1. Create src/utils/version.ts — export a getVersionInfo() async function that runs `git rev-parse --short HEAD` via execa and reads version from package.json (using import). Returns { version: string, gitSha: string | null }. Cache the result after first call. Also export a synchronous getVersionLabel() that formats 'v0.1.0 (abc1234)' from cached values.
2. Update web/vite.config.ts to inject __NIGHT_ORCH_VERSION__ and __NIGHT_ORCH_GIT_SHA__ at build time using Vite's `define` option, reading from execSync('git rev-parse --short HEAD') and package.json version.
3. Create web/src/env.d.ts to declare the global constants __NIGHT_ORCH_VERSION__ and __NIGHT_ORCH_GIT_SHA__ for TypeScript.
4. Update /api/session response in src/web/server.ts to include version and gitSha fields from getVersionInfo(). This gives the web frontend runtime access too.
5. Update SessionResponse type in web/src/types/dashboard.ts to include optional version and gitSha fields.
6. Update DashboardHeader component to accept and display a version label (e.g., 'v0.1.0 (abc1234)') next to the 'night-orch' title text, styled as a small dimmed badge.
7. Update web App.tsx to read version/gitSha from the build-time constants (__NIGHT_ORCH_VERSION__, __NIGHT_ORCH_GIT_SHA__) and pass them as a versionLabel prop to DashboardHeader.
8. Update TUI Header component to accept and display a versionLabel prop, shown dimmed after the title text.
9. Update TUI app.tsx to call getVersionInfo() on mount (in a useEffect) and pass the formatted label to Header.
10. Run pnpm typecheck && pnpm lint to verify everything compiles and passes lint.

## Implementation
Addressed all review findings. Fixed the unsafe optional chaining in the web app (`snapshot?.build?.…`) and made `build` optional in the dashboard payload type for mixed-version compatibility. Added frontend build metadata injection in `web/vite.config.ts` (`VITE_BUILD_VERSION`, `VITE_BUILD_GIT_SHA`) and updated the web header to display both frontend and backend version/SHA so stale frontend assets are visible. Kept TUI header build metadata display via shared `getBuildInfo()`. Added test coverage for dashboard `build` payload shape and new `getBuildInfo()` behavior (env override, git fallback, invalid SHA handling, safe defaults). Validation completed with `pnpm typecheck` and focused Vitest run passing.

**Changed files:**
- `src/cli/tui/app.tsx`
- `src/cli/tui/header.tsx`
- `src/utils/build-info.ts`
- `src/web/server.ts`
- `web/src/App.tsx`
- `web/src/components/DashboardHeader.tsx`
- `web/src/types/dashboard.ts`
- `web/src/vite-env.d.ts`
- `web/vite.config.ts`
- `test/web/server.test.ts`
- `test/utils/build-info.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files in full plus adjacent runtime/test context. Previous issues are resolved: nested optional chaining prevents mixed-payload crashes in `web/src/App.tsx:498-499`; frontend build metadata is now injected at build time and rendered alongside backend metadata (`web/vite.config.ts:8-17`, `web/src/App.tsx:23-24,496-499`, `web/src/components/DashboardHeader.tsx:33-43`); backend snapshot includes build metadata (`src/web/server.ts:30-38,62,873-886`); TUI header shows version/SHA (`src/cli/tui/app.tsx:25,46,937-945`, `src/cli/tui/header.tsx:28-36`); and coverage was added (`test/web/server.test.ts:253-264`, `test/utils/build-info.test.ts:23-72`). Verification passed: `pnpm typecheck`, `pnpm lint`, `pnpm test` (127 files / 1078 tests), and `pnpm web:build`.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex