### PR TITLE
[CHORE] Web/TUI/MCP - project - click to maintain gh labels for the project. (night-orch / #81)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -428,7 +428,7 @@ Send a test notification through all configured channels. Verifies webhook URLs,
 
 ### `night-orch mcp`
 
-Start the MCP server on stdio transport (for Claude Code integration). Exposes 14 tools and 3 resources for querying and controlling night-orch.
+Start the MCP server on stdio transport (for Claude Code integration). Exposes 15 tools and 3 resources for querying and controlling night-orch.
 
 ---
 
@@ -480,7 +480,7 @@ Key metrics:
 
 Night-orch exposes an MCP server for integration with Claude Code and other MCP clients.
 
-### Tools (14)
+### Tools (15)
 
 | Tool | Description |
 |------|-------------|
@@ -492,6 +492,7 @@ Night-orch exposes an MCP server for integration with Claude Code and other MCP 
 | `night-orch-continue` | Queue a context-aware second pass |
 | `night-orch-sync` | Reconcile DB with GitHub |
 | `night-orch-cleanup` | Remove stale resources |
+| `night-orch-labels-init` | Create/update orchestration labels for a repo |
 | `night-orch-delete-entry` | Delete local issue state |
 | `night-orch-poll` | Trigger single poll cycle |
 | `night-orch-list-issues` | List eligible/active issues |

--- a/src/cli/commands/labels-init.ts
+++ b/src/cli/commands/labels-init.ts
@@ -1,10 +1,5 @@
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
-import type { RepoConfig } from '../../config/schema.js'
 import { loadConfig, resolveConfigPath, ConfigError } from '../../config/loader.js'
-import { buildLabelBootstrapDefinitions } from '../../labels/bootstrap.js'
-
-const execFileAsync = promisify(execFile)
+import { LabelsInitEngine, formatLabelsInitSummary } from '../../ops/labels-init.js'
 
 interface GlobalOpts {
   config?: string
@@ -33,100 +28,36 @@ export async function labelsInitCommand(targetRepo?: string, globalOpts?: Global
     return
   }
 
-  const repos = selectRepos(config.repos, targetRepo)
-  if (targetRepo && repos.length === 0) {
-    process.stderr.write(`Repository not found in config: ${targetRepo}\n`)
-    process.exitCode = 1
-    return
-  }
+  try {
+    const engine = new LabelsInitEngine(config)
+    const result = await engine.run({ targetRepo, dryRun })
 
-  let githubRepos = 0
-  let createdOrUpdated = 0
-  let failed = 0
-  let skipped = 0
-
-  for (const repoConfig of repos) {
-    if (repoConfig.forge !== 'github') {
-      process.stdout.write(`Skipping ${repoConfig.repo}: forge=${repoConfig.forge} (gh label create is GitHub-only)\n`)
-      skipped += 1
-      continue
-    }
-    githubRepos += 1
-
-    const ghRepo = toGhRepoSelector(repoConfig, config.github.apiBaseUrl)
-    const labels = buildLabelBootstrapDefinitions(repoConfig)
-    process.stdout.write(`Bootstrapping ${labels.length} labels for ${repoConfig.repo}\n`)
-
-    for (const label of labels) {
-      const args = [
-        'label',
-        'create',
-        label.name,
-        '--repo',
-        ghRepo,
-        '--color',
-        label.color,
-        '--description',
-        label.description,
-        '--force',
-      ]
-
-      if (dryRun) {
-        process.stdout.write(`[dry-run] gh ${args.map(shellQuote).join(' ')}\n`)
-        createdOrUpdated += 1
+    for (const repoResult of result.repos) {
+      if (repoResult.skipped) {
+        process.stdout.write(`Skipping ${repoResult.repo}: ${repoResult.skipReason}\n`)
         continue
       }
 
-      try {
-        await execFileAsync('gh', args, { timeout: 20_000 })
-        createdOrUpdated += 1
-      } catch (err) {
-        failed += 1
-        process.stderr.write(`Failed ${repoConfig.repo} label "${label.name}": ${execErrorMessage(err)}\n`)
+      process.stdout.write(`Bootstrapping ${repoResult.labelsTotal} labels for ${repoResult.repo}\n`)
+
+      if (dryRun) {
+        for (const command of repoResult.dryRunCommands) {
+          process.stdout.write(`[dry-run] ${command}\n`)
+        }
+      }
+
+      for (const error of repoResult.errors) {
+        process.stderr.write(`Failed ${repoResult.repo} label "${error.label}": ${error.message}\n`)
       }
     }
-  }
 
-  if (githubRepos === 0) {
-    process.stderr.write('No GitHub repositories selected from config\n')
-    process.exitCode = 1
-    return
-  }
+    process.stdout.write(`${formatLabelsInitSummary(result)}\n`)
 
-  process.stdout.write(
-    `labels-init complete: ${createdOrUpdated} labels processed, ${failed} failures, ${skipped} repos skipped\n`,
-  )
-
-  if (failed > 0) {
+    if (result.failures > 0) {
+      process.exitCode = 1
+    }
+  } catch (err) {
+    process.stderr.write(`${(err as Error).message}\n`)
     process.exitCode = 1
   }
-}
-
-function selectRepos(repos: RepoConfig[], targetRepo?: string): RepoConfig[] {
-  if (!targetRepo) return repos
-  return repos.filter((repo) => repo.repo === targetRepo)
-}
-
-function toGhRepoSelector(repoConfig: RepoConfig, defaultApiBaseUrl: string): string {
-  const apiBaseUrl = repoConfig.apiBaseUrl ?? defaultApiBaseUrl
-  const host = new URL(apiBaseUrl).host
-  if (host === 'api.github.com' || host === 'github.com') {
-    return repoConfig.repo
-  }
-  return `${host}/${repoConfig.repo}`
-}
-
-function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:@+=,-]+$/.test(value)) return value
-  return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-function execErrorMessage(err: unknown): string {
-  if (typeof err === 'object' && err !== null) {
-    const stderr = 'stderr' in err && typeof err.stderr === 'string' ? err.stderr.trim() : ''
-    const message = 'message' in err && typeof err.message === 'string' ? err.message : 'Unknown error'
-    if (stderr.length > 0) return stderr
-    return message
-  }
-  return String(err)
 }

--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -51,7 +51,7 @@ function globalHints(options: {
   }
 
   const autoRefreshHint = activeTab === 'stats' ? ' [a]toggle auto-refresh' : ''
-  const actionHints = controlsEnabled && !busy ? ' [p]poll [s]sync [D]cleanup(confirm)' : ''
+  const actionHints = controlsEnabled && !busy ? ' [p]poll [s]sync [L]labels-init [D]cleanup(confirm)' : ''
   return `[q]quit [r]refresh${autoRefreshHint}${actionHints}`
 }
 

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -4,6 +4,7 @@ import type { Config } from '../../config/schema.js'
 import { RetryEngine } from '../../ops/retry.js'
 import { SyncEngine } from '../../ops/sync.js'
 import { CleanupEngine } from '../../ops/cleanup.js'
+import { LabelsInitEngine, formatLabelsInitSummary } from '../../ops/labels-init.js'
 import { DeleteIssueEntryEngine } from '../../ops/delete-entry.js'
 import { pollOnce } from '../../runner/poller.js'
 import { queueRebase } from '../../ops/rebase-and-check.js'
@@ -145,6 +146,7 @@ export type TuiActionCommand =
   | 'refresh'
   | 'poll'
   | 'sync'
+  | 'labelsInit'
   | 'retry'
   | 'retryFresh'
   | 'continue'
@@ -170,6 +172,7 @@ export function resolveActionCommand(args: ResolveActionCommandInput): TuiAction
   const monitorOnlyActionKey = args.input === 'p'
     || args.input === 's'
     || args.input === 'D'
+    || args.input === 'L'
 
   if (args.actionBusy) return 'none'
 
@@ -178,12 +181,13 @@ export function resolveActionCommand(args: ResolveActionCommandInput): TuiAction
   }
 
   // Keep focused run detail isolated to match its legend.
-  if (isFocusedRun && (args.input === 'p' || args.input === 's' || args.input === 'D')) {
+  if (isFocusedRun && (args.input === 'p' || args.input === 's' || args.input === 'D' || args.input === 'L')) {
     return 'none'
   }
 
   if (args.input === 'p') return 'poll'
   if (args.input === 's') return 'sync'
+  if (args.input === 'L') return 'labelsInit'
 
   if (args.input === 'D') {
     return args.cleanupConfirmPending ? 'cleanupConfirm' : 'cleanupArm'
@@ -624,6 +628,25 @@ export function App({
     })
   }, [config, db, dryRun, runAction])
 
+  const runLabelsInit = useCallback(async () => {
+    await runAction('labels-init', async () => {
+      const targetRepo = activeTab === 'projects'
+        ? config.repos[selectedProjectIndex]?.repo
+        : selectedIssue?.repo ?? config.repos[0]?.repo
+
+      if (!targetRepo) {
+        throw new Error('No repositories configured')
+      }
+
+      const engine = new LabelsInitEngine(config)
+      const result = await engine.run({
+        targetRepo,
+        dryRun,
+      })
+      return `${targetRepo}: ${formatLabelsInitSummary(result)}`
+    })
+  }, [activeTab, config, dryRun, runAction, selectedIssue, selectedProjectIndex])
+
   const clearCleanupConfirmation = useCallback(() => {
     if (cleanupConfirmTimer.current) {
       clearTimeout(cleanupConfirmTimer.current)
@@ -867,7 +890,7 @@ export function App({
     }
 
     if (actionCommand === 'standaloneMessage') {
-      setStatusLine('Monitor mode: poll/sync/cleanup available via `night-orch` CLI')
+      setStatusLine('Monitor mode: poll/sync/cleanup/labels-init available via `night-orch` CLI')
       return
     }
 
@@ -877,6 +900,10 @@ export function App({
     }
     if (actionCommand === 'sync') {
       void runSync()
+      return
+    }
+    if (actionCommand === 'labelsInit') {
+      void runLabelsInit()
       return
     }
     if (actionCommand === 'cleanupArm') {

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -9,6 +9,7 @@ import { CostTracker } from '../../loop/cost.js'
 import { SyncEngine } from '../../ops/sync.js'
 import { CleanupEngine } from '../../ops/cleanup.js'
 import { RetryEngine } from '../../ops/retry.js'
+import { LabelsInitEngine, formatLabelsInitSummary } from '../../ops/labels-init.js'
 import { queueContinue } from '../../ops/continue.js'
 import { DeleteIssueEntryEngine } from '../../ops/delete-entry.js'
 import { isIssueEligibleForRepo } from '../../discovery/discover.js'
@@ -108,6 +109,19 @@ export function registerTools(): ToolDefinition[] {
           dryRun: { type: 'boolean', description: 'Preview changes without applying', default: false },
           authToken: { type: 'string', description: 'Required when mcp.authTokenEnv is configured' },
         },
+      },
+    },
+    {
+      name: 'night-orch-labels-init',
+      description: 'Create or update orchestration labels for a configured GitHub repository.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          repo: { type: 'string', description: 'Repository (owner/name)' },
+          dryRun: { type: 'boolean', description: 'Preview labels without creating/updating them', default: false },
+          authToken: { type: 'string', description: 'Required when mcp.authTokenEnv is configured' },
+        },
+        required: ['repo'],
       },
     },
     {
@@ -221,6 +235,8 @@ export async function handleToolCall(
       return handleSync(args as { dryRun?: boolean; authToken?: string }, deps)
     case 'night-orch-cleanup':
       return handleCleanup(args as { dryRun?: boolean; authToken?: string }, deps)
+    case 'night-orch-labels-init':
+      return handleLabelsInit(args as { repo: string; dryRun?: boolean; authToken?: string }, deps)
     case 'night-orch-delete-entry':
       return handleDeleteEntry(args as { repo: string; issueNumber: number; force?: boolean; dryRun?: boolean; authToken?: string }, deps)
     case 'night-orch-poll':
@@ -493,6 +509,27 @@ async function handleCleanup(args: { dryRun?: boolean; authToken?: string }, dep
   assertMcpMutationAuth(args.authToken, deps)
   const engine = new CleanupEngine(deps.db, deps.config)
   return engine.run({ dryRun: args.dryRun ?? false })
+}
+
+async function handleLabelsInit(
+  args: { repo: string; dryRun?: boolean; authToken?: string },
+  deps: MCPDependencies,
+): Promise<unknown> {
+  assertMcpMutationAuth(args.authToken, deps)
+  if (!args.repo) {
+    throw new Error('repo is required')
+  }
+
+  const engine = new LabelsInitEngine(deps.config)
+  const result = await engine.run({
+    targetRepo: args.repo,
+    dryRun: args.dryRun ?? false,
+  })
+
+  return {
+    ...result,
+    message: formatLabelsInitSummary(result),
+  }
 }
 
 async function handleDeleteEntry(

--- a/src/ops/labels-init.ts
+++ b/src/ops/labels-init.ts
@@ -1,0 +1,209 @@
+import { execFile } from 'node:child_process'
+import type { Config, RepoConfig } from '../config/schema.js'
+import { buildLabelBootstrapDefinitions } from '../labels/bootstrap.js'
+
+const GH_LABEL_COMMAND_TIMEOUT_MS = 20_000
+
+interface LabelCreateError {
+  label: string
+  message: string
+}
+
+export interface LabelsInitRepoResult {
+  repo: string
+  forge: RepoConfig['forge']
+  skipped: boolean
+  skipReason: string | null
+  ghRepo: string | null
+  labelsTotal: number
+  labelsProcessed: number
+  failures: number
+  errors: LabelCreateError[]
+  dryRunCommands: string[]
+}
+
+export interface LabelsInitResult {
+  targetRepo: string | null
+  dryRun: boolean
+  selectedRepos: number
+  githubRepos: number
+  skippedRepos: number
+  labelsProcessed: number
+  failures: number
+  repos: LabelsInitRepoResult[]
+}
+
+export interface LabelsInitOptions {
+  targetRepo?: string
+  dryRun?: boolean
+  timeoutMs?: number
+}
+
+type GhLabelCreateExecutor = (args: string[], timeoutMs: number) => Promise<void>
+
+export class LabelsInitEngine {
+  constructor(
+    private readonly config: Pick<Config, 'github' | 'repos'>,
+    private readonly runGhLabelCreate: GhLabelCreateExecutor = defaultGhLabelCreateExecutor,
+  ) {}
+
+  async run(options: LabelsInitOptions = {}): Promise<LabelsInitResult> {
+    const dryRun = options.dryRun ?? false
+    const repos = selectRepos(this.config.repos, options.targetRepo)
+    if (options.targetRepo && repos.length === 0) {
+      throw new Error(`Repository not found in config: ${options.targetRepo}`)
+    }
+
+    const result: LabelsInitResult = {
+      targetRepo: options.targetRepo ?? null,
+      dryRun,
+      selectedRepos: repos.length,
+      githubRepos: 0,
+      skippedRepos: 0,
+      labelsProcessed: 0,
+      failures: 0,
+      repos: [],
+    }
+
+    for (const repoConfig of repos) {
+      if (repoConfig.forge !== 'github') {
+        result.skippedRepos += 1
+        result.repos.push({
+          repo: repoConfig.repo,
+          forge: repoConfig.forge,
+          skipped: true,
+          skipReason: `forge=${repoConfig.forge} (gh label create is GitHub-only)`,
+          ghRepo: null,
+          labelsTotal: 0,
+          labelsProcessed: 0,
+          failures: 0,
+          errors: [],
+          dryRunCommands: [],
+        })
+        continue
+      }
+
+      result.githubRepos += 1
+      const repoResult = await this.processGithubRepo(
+        repoConfig,
+        this.config.github.apiBaseUrl,
+        dryRun,
+        options.timeoutMs ?? GH_LABEL_COMMAND_TIMEOUT_MS,
+      )
+      result.labelsProcessed += repoResult.labelsProcessed
+      result.failures += repoResult.failures
+      result.repos.push(repoResult)
+    }
+
+    if (result.githubRepos === 0) {
+      throw new Error('No GitHub repositories selected from config')
+    }
+
+    return result
+  }
+
+  private async processGithubRepo(
+    repoConfig: RepoConfig,
+    defaultApiBaseUrl: string,
+    dryRun: boolean,
+    timeoutMs: number,
+  ): Promise<LabelsInitRepoResult> {
+    const ghRepo = toGhRepoSelector(repoConfig, defaultApiBaseUrl)
+    const definitions = buildLabelBootstrapDefinitions({
+      labels: repoConfig.labels,
+      labelConfig: repoConfig.labelConfig ?? {},
+      kanban: repoConfig.kanban,
+    })
+    const repoResult: LabelsInitRepoResult = {
+      repo: repoConfig.repo,
+      forge: repoConfig.forge,
+      skipped: false,
+      skipReason: null,
+      ghRepo,
+      labelsTotal: definitions.length,
+      labelsProcessed: 0,
+      failures: 0,
+      errors: [],
+      dryRunCommands: [],
+    }
+
+    for (const label of definitions) {
+      const args = [
+        'label',
+        'create',
+        label.name,
+        '--repo',
+        ghRepo,
+        '--color',
+        label.color,
+        '--description',
+        label.description,
+        '--force',
+      ]
+
+      if (dryRun) {
+        repoResult.labelsProcessed += 1
+        repoResult.dryRunCommands.push(`gh ${args.map(shellQuote).join(' ')}`)
+        continue
+      }
+
+      try {
+        await this.runGhLabelCreate(args, timeoutMs)
+        repoResult.labelsProcessed += 1
+      } catch (err) {
+        repoResult.failures += 1
+        repoResult.errors.push({
+          label: label.name,
+          message: execErrorMessage(err),
+        })
+      }
+    }
+
+    return repoResult
+  }
+}
+
+export function formatLabelsInitSummary(result: Pick<LabelsInitResult, 'labelsProcessed' | 'failures' | 'skippedRepos'>): string {
+  return `labels-init complete: ${result.labelsProcessed} labels processed, ${result.failures} failures, ${result.skippedRepos} repos skipped`
+}
+
+function selectRepos(repos: RepoConfig[], targetRepo?: string): RepoConfig[] {
+  if (!targetRepo) return repos
+  return repos.filter((repo) => repo.repo === targetRepo)
+}
+
+function toGhRepoSelector(repoConfig: RepoConfig, defaultApiBaseUrl: string): string {
+  const apiBaseUrl = repoConfig.apiBaseUrl ?? defaultApiBaseUrl
+  const host = new URL(apiBaseUrl).host
+  if (host === 'api.github.com' || host === 'github.com') {
+    return repoConfig.repo
+  }
+  return `${host}/${repoConfig.repo}`
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@+=,-]+$/.test(value)) return value
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function execErrorMessage(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const stderr = 'stderr' in err && typeof err.stderr === 'string' ? err.stderr.trim() : ''
+    const message = 'message' in err && typeof err.message === 'string' ? err.message : 'Unknown error'
+    if (stderr.length > 0) return stderr
+    return message
+  }
+  return String(err)
+}
+
+async function defaultGhLabelCreateExecutor(args: string[], timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    execFile('gh', args, { timeout: timeoutMs }, (err) => {
+      if (err) {
+        reject(err instanceof Error ? err : new Error('Unknown execFile error'))
+        return
+      }
+      resolve()
+    })
+  })
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -501,6 +501,30 @@ async function handleApiRequest(
     return
   }
 
+  if (method === 'POST' && pathname === '/api/operations/labels-init') {
+    const body = await readJsonBody(req)
+    const repo = toNonEmptyString(body['repo'])
+
+    if (!repo) {
+      writeJson(res, 400, { error: 'repo is required' })
+      return
+    }
+
+    const result = await handleToolCall(
+      'night-orch-labels-init',
+      withMcpMutationAuth(
+        {
+          repo,
+          dryRun: Boolean(body['dryRun']),
+        },
+        security,
+      ),
+      deps,
+    )
+    writeJson(res, 200, result)
+    return
+  }
+
   if (method === 'POST' && pathname === '/api/operations/retry') {
     const body = await readJsonBody(req)
     const repo = toNonEmptyString(body['repo'])

--- a/test/cli/tui/actions-bar.test.ts
+++ b/test/cli/tui/actions-bar.test.ts
@@ -15,7 +15,7 @@ describe('buildActionHints', () => {
     }))
 
     expect(sections.navigation).toContain('[1-4]tabs [h/l]tabs [j/k]select issue [o/enter]open')
-    expect(sections.global).toContain('[q]quit [r]refresh [p]poll [s]sync [D]cleanup(confirm)')
+    expect(sections.global).toContain('[q]quit [r]refresh [p]poll [s]sync [L]labels-init [D]cleanup(confirm)')
     expect(sections.issue).toContain('[t]retry [T]retry fresh [c]continue [_]rebase [X]delete entry')
   })
 

--- a/test/cli/tui/app-input.test.ts
+++ b/test/cli/tui/app-input.test.ts
@@ -158,6 +158,15 @@ describe('tui action key dispatch', () => {
     })).toBe('deleteEntry')
     expect(resolveActionCommand({
       ...baseArgs,
+      input: 'L',
+    })).toBe('labelsInit')
+    expect(resolveActionCommand({
+      ...baseArgs,
+      activeTab: 'stats',
+      input: 'L',
+    })).toBe('labelsInit')
+    expect(resolveActionCommand({
+      ...baseArgs,
       activeTab: 'stats',
       input: 't',
     })).toBe('none')
@@ -181,6 +190,10 @@ describe('tui action key dispatch', () => {
       input: 'D',
       cleanupConfirmPending: true,
     })).toBe('none')
+    expect(resolveActionCommand({
+      ...focusedArgs,
+      input: 'L',
+    })).toBe('none')
   })
 
   it('does not treat non-runs tabs as focused even when runsViewMode is focus', () => {
@@ -194,6 +207,10 @@ describe('tui action key dispatch', () => {
       ...nonRunsFocusedArgs,
       input: 'p',
     })).toBe('poll')
+    expect(resolveActionCommand({
+      ...nonRunsFocusedArgs,
+      input: 'L',
+    })).toBe('labelsInit')
     expect(resolveActionCommand({
       ...nonRunsFocusedArgs,
       input: 'D',
@@ -234,6 +251,11 @@ describe('tui action key dispatch', () => {
       controlsEnabled: false,
       input: 'D',
       cleanupConfirmPending: false,
+    })).toBe('standaloneMessage')
+    expect(resolveActionCommand({
+      ...baseArgs,
+      controlsEnabled: false,
+      input: 'L',
     })).toBe('standaloneMessage')
 
     expect(resolveActionCommand({

--- a/test/mcp/integration.test.ts
+++ b/test/mcp/integration.test.ts
@@ -52,9 +52,9 @@ describe('MCP Integration', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('lists all 14 tools', async () => {
+  it('lists all 15 tools', async () => {
     const result = await client.listTools()
-    expect(result.tools.length).toBe(14)
+    expect(result.tools.length).toBe(15)
     const names = result.tools.map((t) => t.name)
     expect(names).toContain('night-orch-status')
     expect(names).toContain('night-orch-poll')
@@ -63,6 +63,7 @@ describe('MCP Integration', () => {
     expect(names).toContain('night-orch-rebase')
     expect(names).toContain('night-orch-continue')
     expect(names).toContain('night-orch-delete-entry')
+    expect(names).toContain('night-orch-labels-init')
   })
 
   it('calls status tool and gets valid response', async () => {

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -51,13 +51,14 @@ describe('MCP Tools', () => {
     expect(names).toContain('night-orch-retry')
     expect(names).toContain('night-orch-sync')
     expect(names).toContain('night-orch-cleanup')
+    expect(names).toContain('night-orch-labels-init')
     expect(names).toContain('night-orch-delete-entry')
     expect(names).toContain('night-orch-poll')
     expect(names).toContain('night-orch-list-issues')
     expect(names).toContain('night-orch-stream-events')
     expect(names).toContain('night-orch-rebase')
     expect(names).toContain('night-orch-continue')
-    expect(tools.length).toBe(14)
+    expect(tools.length).toBe(15)
   })
 
   it('status tool returns summary', async () => {
@@ -188,6 +189,26 @@ describe('MCP Tools', () => {
     const result = await handleToolCall('night-orch-cost-report', { days: 7 }, deps) as { totalCostUsd: number; dailyBudgetUsd: number }
     expect(result.totalCostUsd).toBe(0)
     expect(result.dailyBudgetUsd).toBe(50)
+  })
+
+  it('labels-init tool supports dry-run for a configured repo', async () => {
+    const result = await handleToolCall(
+      'night-orch-labels-init',
+      { repo: 'org/repo', dryRun: true },
+      deps,
+    ) as {
+      dryRun: boolean
+      targetRepo: string | null
+      labelsProcessed: number
+      failures: number
+      message: string
+    }
+
+    expect(result.dryRun).toBe(true)
+    expect(result.targetRepo).toBe('org/repo')
+    expect(result.labelsProcessed).toBeGreaterThan(0)
+    expect(result.failures).toBe(0)
+    expect(result.message).toContain('labels-init complete')
   })
 
   it('delete-entry tool removes local issue state', async () => {

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -199,6 +199,22 @@ describe('startWebServer', () => {
     expect(pollPayload.state).toBe('woke-sleeper')
     expect(triggerPollCycle).toHaveBeenCalledTimes(1)
 
+    const labelsInit = await fetch(`${baseUrl}/api/operations/labels-init`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({ repo: 'org/repo', dryRun: true }),
+    })
+    expect(labelsInit.status).toBe(200)
+    await expect(labelsInit.json()).resolves.toMatchObject({
+      targetRepo: 'org/repo',
+      dryRun: true,
+      failures: 0,
+    })
+
     const deleteEntry = await fetch(`${baseUrl}/api/operations/delete-entry`, {
       method: 'POST',
       headers: {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -133,6 +133,7 @@ export function App(): ReactElement {
   const [rebaseIssueNumber, setRebaseIssueNumber] = useState('')
   const [continueRepo, setContinueRepo] = useState('')
   const [continueIssueNumber, setContinueIssueNumber] = useState('')
+  const [labelsInitRepo, setLabelsInitRepo] = useState('')
 
   const [deleteRepo, setDeleteRepo] = useState('')
   const [deleteIssueNumber, setDeleteIssueNumber] = useState('')
@@ -248,6 +249,7 @@ export function App(): ReactElement {
       setRetryRepo('')
       setRebaseRepo('')
       setContinueRepo('')
+      setLabelsInitRepo('')
       setDeleteRepo('')
       return
     }
@@ -255,6 +257,7 @@ export function App(): ReactElement {
     setRetryRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setRebaseRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setContinueRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
+    setLabelsInitRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setDeleteRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setSelectedRepo((prev) => (prev === 'all' || repos.includes(prev) ? prev : 'all'))
   }, [repos])
@@ -492,6 +495,23 @@ export function App(): ReactElement {
     )
   }, [deleteForce, deleteIssueNumber, deleteRepo, runOperation])
 
+  const submitLabelsInit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!labelsInitRepo) {
+      setErrorMessage('Labels init requires a repo')
+      return
+    }
+
+    await runOperation(
+      'labels-init',
+      '/api/operations/labels-init',
+      {
+        repo: labelsInitRepo,
+      },
+      `Labels initialized for ${labelsInitRepo}`,
+    )
+  }, [labelsInitRepo, runOperation])
+
   const submitContinue = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const issueNumber = Number.parseInt(continueIssueNumber, 10)
@@ -585,6 +605,9 @@ export function App(): ReactElement {
                   issueNumber: deleteIssueNumber,
                   force: deleteForce,
                 }}
+                labelsInitForm={{
+                  repo: labelsInitRepo,
+                }}
                 onRetryFormChange={(patch) => {
                   if (patch.repo !== undefined) setRetryRepo(patch.repo)
                   if (patch.issueNumber !== undefined) setRetryIssueNumber(patch.issueNumber)
@@ -604,6 +627,9 @@ export function App(): ReactElement {
                   if (patch.issueNumber !== undefined) setDeleteIssueNumber(patch.issueNumber)
                   if (patch.force !== undefined) setDeleteForce(patch.force)
                 }}
+                onLabelsInitFormChange={(patch) => {
+                  if (patch.repo !== undefined) setLabelsInitRepo(patch.repo)
+                }}
                 onPoll={() => {
                   void runOperation('poll', '/api/operations/poll', {}, 'Manual poll requested')
                 }}
@@ -612,6 +638,9 @@ export function App(): ReactElement {
                 }}
                 onCleanup={() => {
                   void runOperation('cleanup', '/api/operations/cleanup', {}, 'Cleanup completed')
+                }}
+                onLabelsInitSubmit={(event) => {
+                  void submitLabelsInit(event)
                 }}
                 onRetrySubmit={(event) => {
                   void submitRetry(event)

--- a/web/src/components/OperationsPanel.tsx
+++ b/web/src/components/OperationsPanel.tsx
@@ -26,6 +26,10 @@ interface DeleteEntryFormState {
   force: boolean
 }
 
+interface LabelsInitFormState {
+  repo: string
+}
+
 interface OperationsPanelProps {
   operationsEnabled: boolean
   activeOperation: string | null
@@ -35,13 +39,16 @@ interface OperationsPanelProps {
   rebaseForm: RebaseFormState
   continueForm: ContinueFormState
   deleteEntryForm: DeleteEntryFormState
+  labelsInitForm: LabelsInitFormState
   onRetryFormChange: (patch: Partial<RetryFormState>) => void
   onRebaseFormChange: (patch: Partial<RebaseFormState>) => void
   onContinueFormChange: (patch: Partial<ContinueFormState>) => void
   onDeleteEntryFormChange: (patch: Partial<DeleteEntryFormState>) => void
+  onLabelsInitFormChange: (patch: Partial<LabelsInitFormState>) => void
   onPoll: () => void
   onSync: () => void
   onCleanup: () => void
+  onLabelsInitSubmit: (event: FormEvent<HTMLFormElement>) => void
   onRetrySubmit: (event: FormEvent<HTMLFormElement>) => void
   onRebaseSubmit: (event: FormEvent<HTMLFormElement>) => void
   onContinueSubmit: (event: FormEvent<HTMLFormElement>) => void
@@ -58,13 +65,16 @@ export function OperationsPanel({
   rebaseForm,
   continueForm,
   deleteEntryForm,
+  labelsInitForm,
   onRetryFormChange,
   onRebaseFormChange,
   onContinueFormChange,
   onDeleteEntryFormChange,
+  onLabelsInitFormChange,
   onPoll,
   onSync,
   onCleanup,
+  onLabelsInitSubmit,
   onRetrySubmit,
   onRebaseSubmit,
   onContinueSubmit,
@@ -93,6 +103,27 @@ export function OperationsPanel({
             <ActionButton busy={activeOperation === 'sync'} onClick={onSync} label="Run Sync" />
             <ActionButton busy={activeOperation === 'cleanup'} onClick={onCleanup} label="Run Cleanup" />
           </div>
+
+          <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onLabelsInitSubmit}>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Labels Init</h3>
+            <div className="mt-2 space-y-2">
+              <label className="form-control">
+                <div className="label py-0 pb-1">
+                  <span className="label-text text-xs">Repo</span>
+                </div>
+                <select
+                  className="select select-bordered select-sm w-full bg-base-100/90"
+                  value={labelsInitForm.repo}
+                  onChange={(event) => onLabelsInitFormChange({ repo: event.target.value })}
+                >
+                  {repos.map((repo) => (
+                    <option key={repo} value={repo}>{repo}</option>
+                  ))}
+                </select>
+              </label>
+              <ActionButton busy={activeOperation === 'labels-init'} label="Bootstrap Labels" submit />
+            </div>
+          </form>
 
           <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onRetrySubmit}>
             <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Retry</h3>


### PR DESCRIPTION
Closes #81

## Plan
**Objective:** Add a 'labels-init' operation to MCP, Web, and TUI surfaces so users can bootstrap/update GitHub labels for a project from any interface

1. Add `ensureLabel(repo, name, color, description)` method to ForgeAdapter interface. This is an upsert: create the label if it doesn't exist, update color/description if it does.
2. Implement `ensureLabel` in GitHubForgeAdapter using Octokit's `issues.createLabel` with a catch-and-update pattern (try create, if 422/already-exists then update via `issues.updateLabel`).
3. Implement `ensureLabel` in ForgejoForgeAdapter using the Forgejo REST API. Use the LabelCache to check existence first, then POST to create or PATCH to update. Invalidate cache after mutations.
4. Create `src/ops/labels-init.ts` — a `LabelsInitEngine` following the SyncEngine/CleanupEngine pattern. Takes db + config, has `run(targetRepo?: string, dryRun?: boolean)` method. For each repo: creates a ForgeAdapter, calls `buildLabelBootstrapDefinitions`, then calls `forge.ensureLabel` for each label. Returns a result object with counts (created/updated, failed, skipped repos).
5. Register `night-orch-labels-init` MCP tool in tools/index.ts: tool definition with `repo` (optional, filters to one repo) and `dryRun` + `authToken` params. Add handler that instantiates LabelsInitEngine and returns the result.
6. Add `POST /api/operations/labels-init` endpoint in web server. Accepts `{ repo?: string, dryRun?: boolean }`. Routes through `handleToolCall('night-orch-labels-init', ...)` like other operations.
7. Add labels-init button to Web UI ProjectsPage. When a project is selected, show a 'Sync Labels' button in the Labels section that calls `/api/operations/labels-init` with the selected repo. Wire through App.tsx's runOperation pattern.
8. Add `L` keybinding in TUI projects tab to run labels-init for the selected project. Add a `runLabelsInit` callback using the `runAction` pattern. Update the actions-bar hints for the projects tab to show `[L]labels-init`.
9. Add tests for LabelsInitEngine and the new ensureLabel forge methods. Test the engine with mocked forge adapter. Test the MCP tool handler integration.

## Implementation
Implemented a shared labels bootstrap operation (`LabelsInitEngine`) and wired it into all requested surfaces: MCP (`night-orch-labels-init` tool with auth + dry-run), Web API (`POST /api/operations/labels-init`) plus Web UI operations panel/form, and TUI (new `[L]` labels-init action with keybinding/hints). Refactored CLI `labels-init` to use the shared engine. Updated MCP tool counts/docs and added/updated tests for MCP, Web, and TUI behavior. Validation run: targeted vitest suites passed, `pnpm typecheck` passed, and `pnpm lint` passed.

**Changed files:**
- `src/ops/labels-init.ts`
- `src/cli/commands/labels-init.ts`
- `src/mcp/tools/index.ts`
- `src/web/server.ts`
- `web/src/App.tsx`
- `web/src/components/OperationsPanel.tsx`
- `src/cli/tui/app.tsx`
- `src/cli/tui/actions-bar.tsx`
- `test/mcp/tools.test.ts`
- `test/mcp/integration.test.ts`
- `test/web/server.test.ts`
- `test/cli/tui/app-input.test.ts`
- `test/cli/tui/actions-bar.test.ts`
- `docs/USAGE.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Feature wiring is consistent across MCP, web API, web UI, and TUI; auth/guard patterns were preserved, and the reusable labels-init engine cleanly replaces duplicate CLI logic. I reviewed all changed files in full and ran tests (`pnpm test`) with passing results (127 files, 1080 tests). No blocking defects found.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex