### PR TITLE
[CHORE] Web - make header/navi sticky/fixed to the page (night-orch / #90)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -544,7 +544,7 @@ export function App(): ReactElement {
         backendGitSha={snapshot?.build?.gitSha ?? null}
       />
 
-      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 pt-[var(--orch-header-offset)] sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 sm:px-6 lg:px-8">
         {errorMessage && (
           <div className="alert alert-error shadow-sm">
             <span>{errorMessage}</span>

--- a/web/src/components/DashboardHeader.tsx
+++ b/web/src/components/DashboardHeader.tsx
@@ -34,7 +34,7 @@ export function DashboardHeader({
   const backendShortSha = backendGitSha ? backendGitSha.slice(0, 12) : 'unknown'
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between gap-3 py-3">
           <div className="flex flex-col">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -59,16 +59,6 @@ body {
   color: hsl(var(--bc));
 }
 
-.orch-shell {
-  --orch-header-offset: 8.8rem;
-}
-
-@media (min-width: 640px) {
-  .orch-shell {
-    --orch-header-offset: 9rem;
-  }
-}
-
 .bg-orch-admin {
   background-image:
     radial-gradient(circle at 15% 0%, rgb(34 211 238 / 0.16), transparent 38%),


### PR DESCRIPTION
Closes #90

## Plan
**Objective:** Make the header/navigation sticky using CSS sticky positioning, replacing the current fixed+offset approach for a more robust solution

1. Change DashboardHeader from `fixed inset-x-0 top-0` to `sticky top-0` positioning. Remove `inset-x-0` since sticky elements are already full-width in normal flow. Keep z-40, backdrop-blur, and visual styling unchanged.
2. Remove `pt-[var(--orch-header-offset)]` from the content container in App.tsx since sticky positioning keeps the header in document flow and content naturally starts below it.
3. Remove the `--orch-header-offset` CSS variable declarations from `.orch-shell` and its `@media (min-width: 640px)` block in index.css, as they are no longer needed.

## Implementation
Switched the web dashboard header/navigation from `fixed` to `sticky` (`top-0`), removed the old fixed-header content offset in `App.tsx`, and deleted the now-unused `--orch-header-offset` CSS variable/media block. Validation passed with `pnpm typecheck` and `pnpm lint`.

**Changed files:**
- `web/src/components/DashboardHeader.tsx`
- `web/src/App.tsx`
- `web/src/index.css`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed `web/src/App.tsx`, `web/src/components/DashboardHeader.tsx`, and `web/src/index.css` in full, plus adjacent web tests (`test/web/server.test.ts`, `test/web/run-tone.test.ts`). The change cleanly replaces fixed-header + manual top offset with flow-based sticky positioning (`DashboardHeader.tsx:37`, `App.tsx:547`) and removes now-unused offset CSS (`index.css:62` onward). No functional, security, or error-handling regressions were identified. Verification rerun: `pnpm typecheck`, `pnpm lint`, and `pnpm test` all passed (127 files / 1080 tests).

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex