### PR TITLE
[CHORE] Web/TUI - git sha simpler (night-orch / #86)

### DIFF
--- a/test/web/dashboard-header.test.ts
+++ b/test/web/dashboard-header.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { DashboardHeader } from '../../web/src/components/DashboardHeader.js'
+
+type DashboardHeaderProps = React.ComponentProps<typeof DashboardHeader>
+
+function renderHeader(overrides: Partial<DashboardHeaderProps>): string {
+  const props: DashboardHeaderProps = {
+    activePage: 'issues',
+    onPageChange: () => {},
+    currentStateLabel: 'idle',
+    currentStateToneClass: 'badge-ghost',
+    frontendVersion: '1.2.3',
+    frontendGitSha: '1111111111111111111111111111111111111111',
+    backendVersion: '2.3.4',
+    backendGitSha: '1111111111111111111111111111111111111111',
+    ...overrides,
+  }
+
+  return renderToStaticMarkup(React.createElement(DashboardHeader, props))
+}
+
+function shaLineCount(output: string): number {
+  return (output.match(/ sha /g) ?? []).length
+}
+
+describe('DashboardHeader SHA rendering', () => {
+  it('renders one SHA line when frontend and backend SHAs are equal', () => {
+    const output = renderHeader({})
+
+    expect(output).toContain('frontend v1.2.3 · backend v2.3.4 · sha 111111111111')
+    expect(shaLineCount(output)).toBe(1)
+    expect(output).toContain('text-[10px]')
+  })
+
+  it('renders one SHA line when one SHA is a prefix of the other', () => {
+    const output = renderHeader({
+      frontendGitSha: 'abcdef0123456789abcdef0123456789abcdef01',
+      backendGitSha: 'abcdef0',
+    })
+
+    expect(output).toContain('frontend v1.2.3 · backend v2.3.4 · sha abcdef012345')
+    expect(shaLineCount(output)).toBe(1)
+  })
+
+  it('renders separate frontend/backend SHA lines when commits differ', () => {
+    const output = renderHeader({
+      frontendGitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      backendGitSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    })
+
+    expect(output).toContain('frontend v1.2.3 · sha aaaaaaaaaaaa')
+    expect(output).toContain('backend v2.3.4 · sha bbbbbbbbbbbb')
+    expect(shaLineCount(output)).toBe(2)
+  })
+
+  it('handles unknown/null SHAs consistently', () => {
+    const knownVsUnknown = renderHeader({
+      frontendGitSha: 'cccccccccccccccccccccccccccccccccccccccc',
+      backendGitSha: null,
+    })
+    expect(shaLineCount(knownVsUnknown)).toBe(2)
+    expect(knownVsUnknown).toContain('backend v2.3.4 · sha unknown')
+
+    const unknownVsUnknown = renderHeader({
+      frontendGitSha: 'unknown',
+      backendGitSha: null,
+    })
+    expect(shaLineCount(unknownVsUnknown)).toBe(1)
+    expect(unknownVsUnknown).toContain('frontend v1.2.3 · backend v2.3.4 · sha unknown')
+  })
+})

--- a/web/src/components/DashboardHeader.tsx
+++ b/web/src/components/DashboardHeader.tsx
@@ -20,6 +20,32 @@ const PAGES: Array<{ id: DashboardPage, label: string }> = [
   { id: 'settings', label: 'settings' },
 ]
 
+function normalizeShaForCompare(sha: string | null): string {
+  const normalized = (sha ?? 'unknown').trim().toLowerCase()
+  return normalized.length > 0 ? normalized : 'unknown'
+}
+
+function shasRepresentSameCommit(frontendSha: string, backendSha: string | null): boolean {
+  const frontendNormalized = normalizeShaForCompare(frontendSha)
+  const backendNormalized = normalizeShaForCompare(backendSha)
+
+  if (frontendNormalized === 'unknown' || backendNormalized === 'unknown') {
+    return frontendNormalized === backendNormalized
+  }
+
+  return (
+    frontendNormalized === backendNormalized
+    || frontendNormalized.startsWith(backendNormalized)
+    || backendNormalized.startsWith(frontendNormalized)
+  )
+}
+
+function shortSha(sha: string | null): string {
+  const normalized = (sha ?? 'unknown').trim()
+  if (normalized.length === 0) return 'unknown'
+  return normalized.toLowerCase() === 'unknown' ? 'unknown' : normalized.slice(0, 12)
+}
+
 export function DashboardHeader({
   activePage,
   onPageChange,
@@ -30,8 +56,9 @@ export function DashboardHeader({
   backendVersion,
   backendGitSha,
 }: DashboardHeaderProps): ReactElement {
-  const frontendShortSha = frontendGitSha.slice(0, 12)
-  const backendShortSha = backendGitSha ? backendGitSha.slice(0, 12) : 'unknown'
+  const frontendShortSha = shortSha(frontendGitSha)
+  const backendShortSha = shortSha(backendGitSha)
+  const shasMatch = shasRepresentSameCommit(frontendGitSha, backendGitSha)
 
   return (
     <header className="sticky top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
@@ -39,8 +66,16 @@ export function DashboardHeader({
         <div className="flex items-center justify-between gap-3 py-3">
           <div className="flex flex-col">
             <p className="text-lg font-semibold tracking-wide text-base-content sm:text-xl">night-orch</p>
-            <p className="text-xs font-mono text-base-content/70">frontend v{frontendVersion} · sha {frontendShortSha}</p>
-            <p className="text-[11px] font-mono text-base-content/50">backend v{backendVersion} · sha {backendShortSha}</p>
+            {shasMatch ? (
+              <p className="text-[10px] font-mono text-base-content/60">
+                frontend v{frontendVersion} · backend v{backendVersion} · sha {frontendShortSha}
+              </p>
+            ) : (
+              <>
+                <p className="text-[10px] font-mono text-base-content/70">frontend v{frontendVersion} · sha {frontendShortSha}</p>
+                <p className="text-[10px] font-mono text-base-content/50">backend v{backendVersion} · sha {backendShortSha}</p>
+              </>
+            )}
           </div>
           <div className="flex flex-col items-end gap-1">
             <span className="text-[10px] uppercase tracking-[0.22em] text-base-content/65">Current State</span>


### PR DESCRIPTION
Closes #86

## Plan
**Objective:** Tests confirmed passing. As noted above, the implementation is already complete on this branch — no further changes needed.

## Implementation
No additional implementation was required. The branch already contains the issue fix in commit 867efc2 (single SHA shown when backend/frontend SHAs match, both shown when different, with reduced font size). I verified the tree is clean and re-ran the targeted test: test/web/dashboard-header.test.ts (passes).

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Implementation matches the issue intent: SHA display is consolidated when commits are treated as equivalent, split when not, and header SHA text size is reduced. I reviewed changed files fully, checked adjacent code paths (`web/src/App.tsx`, `src/utils/build-info.ts`, `web/vite.config.ts`), and reran verification (`pnpm test`, `pnpm lint`, `pnpm typecheck`) successfully.

---

**Triage:** standard | **Iterations:** 0 | **Roles:** plan=claude code=codex review=codex