### PR TITLE
[CHORE] Web - stats (night-orch / #87)

### DIFF
--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -10,6 +10,7 @@ import { RunManager } from '../../src/state/runs.js'
 import { startWebServer } from '../../src/web/server.js'
 import type { MCPDependencies } from '../../src/mcp/server.js'
 import type Database from 'better-sqlite3'
+import type { TuiStatsSnapshot } from '../../src/state/stats.js'
 
 const MUTATION_INTENT_HEADER = 'x-night-orch-intent'
 const WEB_AUTH_TOKEN_HEADER = 'x-night-orch-web-token'
@@ -282,6 +283,103 @@ describe('startWebServer', () => {
     expect(trackedIssue?.status).toBe('queued')
     expect(trackedIssue?.hasRun).toBe(false)
     expect(trackedIssue?.runId.startsWith('issue:')).toBe(true)
+  })
+
+  it('dashboard includes full stats snapshot fields for the web stats page', async () => {
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    const dashboard = await fetch(`${baseUrl}/api/dashboard`)
+    expect(dashboard.status).toBe(200)
+    const payload = await dashboard.json() as { stats: TuiStatsSnapshot }
+
+    expect(payload.stats).toMatchObject({
+      updatedAt: expect.any(String),
+      overview: {
+        totalRuns: expect.any(Number),
+        activeRuns: expect.any(Number),
+        queuedRuns: expect.any(Number),
+        runningRuns: expect.any(Number),
+        reviewReadyRuns: expect.any(Number),
+        completedRuns: expect.any(Number),
+        blockedRuns: expect.any(Number),
+        errorRuns: expect.any(Number),
+      },
+      throughput: {
+        runs24h: expect.any(Number),
+        runs7d: expect.any(Number),
+        runs30d: expect.any(Number),
+        completed7d: expect.any(Number),
+        blocked7d: expect.any(Number),
+        error7d: expect.any(Number),
+        successRate7d: expect.any(Number),
+        avgDurationMinutes7d: expect.any(Number),
+        avgIterations7d: expect.any(Number),
+      },
+      reliability: {
+        failureCount7d: expect.any(Number),
+        failureRate7d: expect.any(Number),
+      },
+      cost: {
+        todayCostUsd: expect.any(Number),
+        todayRunCount: expect.any(Number),
+        cost7d: expect.any(Number),
+        cost30d: expect.any(Number),
+        avgDailyCost7d: expect.any(Number),
+      },
+      efficiency: {
+        totalCostUsd7d: expect.any(Number),
+        avgCostPerRun7d: expect.any(Number),
+        avgCostPerSuccess7d: expect.any(Number),
+        avgCostPerIteration7d: expect.any(Number),
+        completedPerDollar7d: expect.any(Number),
+      },
+      resources: {
+        activeLeases: expect.any(Number),
+        expiringLeases: expect.any(Number),
+        expiredLeases: expect.any(Number),
+        leasedRepos: expect.any(Number),
+        activeWorktrees: expect.any(Number),
+        missingWorktrees: expect.any(Number),
+        staleWorktrees: expect.any(Number),
+      },
+      timing: {
+        sampleSize30d: expect.any(Number),
+        p50Minutes: expect.any(Number),
+        p90Minutes: expect.any(Number),
+        p99Minutes: expect.any(Number),
+      },
+      queue: {
+        activeBatches: expect.any(Number),
+      },
+      agents: {
+        eventsTotal: expect.any(Number),
+        events24h: expect.any(Number),
+        events7d: expect.any(Number),
+        toolCalls24h: expect.any(Number),
+        thinking24h: expect.any(Number),
+        uniqueRuns7d: expect.any(Number),
+      },
+    })
+    expect(Array.isArray(payload.stats.statusCounts)).toBe(true)
+    expect(Array.isArray(payload.stats.phaseCounts)).toBe(true)
+    expect(Array.isArray(payload.stats.reliability.topErrorPatterns7d)).toBe(true)
+    expect(Array.isArray(payload.stats.cost.dailyHistory)).toBe(true)
+    expect(Array.isArray(payload.stats.queue.statuses)).toBe(true)
+    expect(Array.isArray(payload.stats.agents.roleBreakdown7d)).toBe(true)
+    expect(Array.isArray(payload.stats.topRepos30d)).toBe(true)
   })
 
   it('returns projects config snapshot for the web projects page', async () => {

--- a/test/web/stats-page.test.ts
+++ b/test/web/stats-page.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { StatsPage } from '../../web/src/components/StatsPage.js'
+import { type DashboardSnapshot } from '../../web/src/types/dashboard.js'
+
+const FULL_SNAPSHOT: DashboardSnapshot = {
+  generatedAt: '2026-04-01T10:00:00.000Z',
+  status: {
+    activeRuns: 5,
+    dailyCostUsd: 12.34,
+  },
+  runs: {
+    count: 1,
+    runs: [],
+  },
+  cost: {
+    dailyBudgetUsd: 50,
+  },
+  build: {
+    version: '1.2.3',
+    gitSha: '0123456789abcdef0123456789abcdef01234567',
+  },
+  config: {
+    repos: ['org/repo-a', 'org/repo-b'],
+    pollIntervalSeconds: 30,
+  },
+  stats: {
+    updatedAt: '2026-04-01T10:00:00.000Z',
+    overview: {
+      totalRuns: 20,
+      activeRuns: 5,
+      queuedRuns: 2,
+      runningRuns: 2,
+      reviewReadyRuns: 1,
+      completedRuns: 12,
+      blockedRuns: 1,
+      errorRuns: 2,
+    },
+    statusCounts: [
+      { status: 'completed', count: 12 },
+      { status: 'running', count: 2 },
+      { status: 'queued', count: 2 },
+      { status: 'error', count: 2 },
+      { status: 'blocked', count: 1 },
+      { status: 'review_ready', count: 1 },
+    ],
+    phaseCounts: [
+      { phase: 'implement', count: 2 },
+      { phase: 'review', count: 1 },
+    ],
+    throughput: {
+      runs24h: 4,
+      runs7d: 10,
+      runs30d: 35,
+      completed7d: 6,
+      blocked7d: 2,
+      error7d: 2,
+      successRate7d: 60,
+      avgDurationMinutes7d: 18.5,
+      avgIterations7d: 1.8,
+    },
+    reliability: {
+      failureCount7d: 4,
+      failureRate7d: 40,
+      topErrorPatterns7d: [
+        { pattern: 'failed to fetch', count: 3 },
+        { pattern: 'timeout waiting for checks', count: 2 },
+      ],
+    },
+    cost: {
+      todayCostUsd: 8.1,
+      todayRunCount: 3,
+      cost7d: 36.2,
+      cost30d: 160.4,
+      avgDailyCost7d: 5.1,
+      dailyHistory: [
+        { date: '2026-04-01', totalCostUsd: 8.1, runCount: 3 },
+        { date: '2026-03-31', totalCostUsd: 4.1, runCount: 2 },
+        { date: '2026-03-30', totalCostUsd: 1.4, runCount: 1 },
+      ],
+    },
+    efficiency: {
+      totalCostUsd7d: 36.2,
+      avgCostPerRun7d: 3.62,
+      avgCostPerSuccess7d: 6.03,
+      avgCostPerIteration7d: 1.2,
+      completedPerDollar7d: 0.17,
+    },
+    resources: {
+      activeLeases: 3,
+      expiringLeases: 1,
+      expiredLeases: 0,
+      leasedRepos: 2,
+      activeWorktrees: 4,
+      missingWorktrees: 1,
+      staleWorktrees: 2,
+    },
+    timing: {
+      sampleSize30d: 12,
+      p50Minutes: 10,
+      p90Minutes: 30,
+      p99Minutes: 75,
+    },
+    queue: {
+      activeBatches: 2,
+      statuses: [
+        { status: 'running', count: 1 },
+        { status: 'queued', count: 1 },
+      ],
+    },
+    agents: {
+      eventsTotal: 150,
+      events24h: 45,
+      events7d: 120,
+      toolCalls24h: 20,
+      thinking24h: 9,
+      uniqueRuns7d: 14,
+      roleBreakdown7d: [
+        { role: 'planner', events: 40, toolCalls: 5 },
+        { role: 'coder', events: 70, toolCalls: 14 },
+      ],
+    },
+    topRepos30d: [
+      {
+        repo: 'org/alpha-repo',
+        totalRuns: 10,
+        completedRuns: 8,
+        blockedRuns: 1,
+        errorRuns: 1,
+        totalCostUsd: 40.2,
+        avgIterations: 1.6,
+      },
+    ],
+  },
+}
+
+describe('StatsPage', () => {
+  it('renders all rich stats sections and derived values', () => {
+    const text = renderStatsPageText(FULL_SNAPSHOT, true)
+
+    expect(text).toContain('System Signals')
+    expect(text).toContain('Run Health')
+    expect(text).toContain('Throughput')
+    expect(text).toContain('Cost')
+    expect(text).toContain('Agent Activity')
+    expect(text).toContain('Reliability')
+    expect(text).toContain('Resources')
+    expect(text).toContain('Merge Queue')
+    expect(text).toContain('Top Repositories (30d)')
+
+    expect(text).toContain('Tail Ratio (p90 / p50) 3.00x')
+    expect(text).toContain('Websocket Connected')
+    expect(text).toContain('org/alpha-repo')
+    expect(text).toMatch(/success\s+80\s*%/)
+  })
+
+  it('renders a loading shell when snapshot is unavailable', () => {
+    const text = renderStatsPageText(null, false)
+    expect(text).toContain('Stats snapshot is loading.')
+  })
+
+  it('shows empty-state fallbacks for sparse stats snapshots', () => {
+    const sparseSnapshot: DashboardSnapshot = {
+      ...FULL_SNAPSHOT,
+      stats: {
+        ...FULL_SNAPSHOT.stats,
+        timing: {
+          sampleSize30d: 0,
+          p50Minutes: 0,
+          p90Minutes: 0,
+          p99Minutes: 0,
+        },
+        cost: {
+          ...FULL_SNAPSHOT.stats.cost,
+          dailyHistory: [],
+        },
+        reliability: {
+          ...FULL_SNAPSHOT.stats.reliability,
+          topErrorPatterns7d: [],
+        },
+        agents: {
+          ...FULL_SNAPSHOT.stats.agents,
+          roleBreakdown7d: [],
+        },
+        topRepos30d: [],
+      },
+    }
+
+    const text = renderStatsPageText(sparseSnapshot, false)
+
+    expect(text).toContain('Websocket Reconnecting')
+    expect(text).toContain('No daily cost rows in the last 7 days.')
+    expect(text).toContain('No agent activity in the last 7 days.')
+    expect(text).toContain('None in the last 7 days.')
+    expect(text).toContain('No repository run history in the last 30 days.')
+    expect(text).toContain('Tail Ratio (p90 / p50) -')
+  })
+})
+
+function renderStatsPageText(snapshot: DashboardSnapshot | null, socketConnected: boolean): string {
+  const html = renderToStaticMarkup(React.createElement(StatsPage, { snapshot, socketConnected }))
+  return normalizeWhitespace(html.replace(/<[^>]*>/g, ' '))
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { OperationsPanel } from './components/OperationsPanel.js'
 import { ProjectsPage } from './components/ProjectsPage.js'
 import { RunEventStream } from './components/RunEventStream.js'
 import { RunsPanel } from './components/RunsPanel.js'
+import { StatsPage } from './components/StatsPage.js'
 import { extractMessage, formatTimestamp } from './lib/format.js'
 import { STATUS_BADGE_TONE } from './lib/run-tone.js'
 import { asRunEventsPayload, mergeRunEvents } from './lib/run-events.js'
@@ -43,67 +44,6 @@ function PlaceholderPage({ title, description, detail }: PlaceholderPageProps): 
         </div>
       </div>
     </section>
-  )
-}
-
-interface StatsPageProps {
-  snapshot: DashboardSnapshot | null
-  socketConnected: boolean
-}
-
-function StatsPage({ snapshot, socketConnected }: StatsPageProps): ReactElement {
-  const overview = snapshot?.stats.overview
-
-  return (
-    <div className="flex flex-col gap-5">
-      <DashboardMetrics snapshot={snapshot} />
-
-      <section className="grid gap-5 xl:grid-cols-[1.45fr_1fr]">
-        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
-          <div className="card-body p-4 sm:p-5">
-            <h2 className="card-title text-lg">Queue Overview</h2>
-            <div className="mt-2 grid gap-3 sm:grid-cols-2">
-              {[
-                { label: 'Queued Runs', value: overview?.queuedRuns ?? 0, tone: 'text-info' },
-                { label: 'Running Runs', value: overview?.runningRuns ?? 0, tone: 'text-warning' },
-                { label: 'Review Ready', value: overview?.reviewReadyRuns ?? 0, tone: 'text-success' },
-                { label: 'Blocked Runs', value: overview?.blockedRuns ?? 0, tone: 'text-secondary' },
-                { label: 'Error Runs', value: overview?.errorRuns ?? 0, tone: 'text-error' },
-              ].map((item) => (
-                <div key={item.label} className="rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
-                  <p className="text-xs uppercase tracking-wide text-base-content/60">{item.label}</p>
-                  <p className={`mt-1 text-2xl font-semibold ${item.tone}`}>{item.value}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </article>
-
-        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
-          <div className="card-body p-4 sm:p-5">
-            <h2 className="card-title text-lg">System Signals</h2>
-            <dl className="mt-2 space-y-2 text-sm text-base-content/80">
-              <div className="flex items-center justify-between gap-3 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
-                <dt className="text-base-content/70">Poll Interval</dt>
-                <dd>{snapshot?.config.pollIntervalSeconds ?? '-'}s</dd>
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
-                <dt className="text-base-content/70">Tracked Repos</dt>
-                <dd>{snapshot?.config.repos.length ?? 0}</dd>
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
-                <dt className="text-base-content/70">Websocket</dt>
-                <dd>{socketConnected ? 'Connected' : 'Reconnecting'}</dd>
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
-                <dt className="text-base-content/70">Last Refresh</dt>
-                <dd>{snapshot?.generatedAt ? formatTimestamp(snapshot.generatedAt) : '--'}</dd>
-              </div>
-            </dl>
-          </div>
-        </article>
-      </section>
-    </div>
   )
 }
 
@@ -532,7 +472,7 @@ export function App(): ReactElement {
   }, [continueIssueNumber, continueRepo, runOperation])
 
   return (
-    <main data-theme="black" className="orch-shell min-h-screen bg-orch-admin">
+    <main data-theme="black" className="min-h-screen bg-orch-admin">
       <DashboardHeader
         activePage={activePage}
         onPageChange={setActivePage}
@@ -544,7 +484,7 @@ export function App(): ReactElement {
         backendGitSha={snapshot?.build?.gitSha ?? null}
       />
 
-      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 pt-[var(--orch-header-offset)] sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 sm:px-6 lg:px-8">
         {errorMessage && (
           <div className="alert alert-error shadow-sm">
             <span>{errorMessage}</span>

--- a/web/src/components/DashboardHeader.tsx
+++ b/web/src/components/DashboardHeader.tsx
@@ -34,7 +34,7 @@ export function DashboardHeader({
   const backendShortSha = backendGitSha ? backendGitSha.slice(0, 12) : 'unknown'
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between gap-3 py-3">
           <div className="flex flex-col">

--- a/web/src/components/StatsPage.tsx
+++ b/web/src/components/StatsPage.tsx
@@ -1,0 +1,440 @@
+import { type ReactElement, type ReactNode } from 'react'
+
+import { formatMoney, formatTimestamp, truncate } from '../lib/format.js'
+import { type DashboardSnapshot, type StatusAggregate } from '../types/dashboard.js'
+import { DashboardMetrics } from './DashboardMetrics.js'
+
+interface StatsPageProps {
+  snapshot: DashboardSnapshot | null
+  socketConnected: boolean
+}
+
+type Tone = 'success' | 'warning' | 'error' | 'neutral'
+
+export function StatsPage({ snapshot, socketConnected }: StatsPageProps): ReactElement {
+  if (!snapshot) {
+    return (
+      <div className="flex flex-col gap-5">
+        <DashboardMetrics snapshot={snapshot} />
+        <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-6">
+            <h2 className="card-title text-lg">Stats</h2>
+            <p className="text-sm text-base-content/75">Stats snapshot is loading.</p>
+            <div className="mt-2 space-y-2">
+              <div className="skeleton h-16 w-full" />
+              <div className="skeleton h-16 w-full" />
+              <div className="skeleton h-16 w-full" />
+            </div>
+          </div>
+        </section>
+      </div>
+    )
+  }
+
+  const { stats } = snapshot
+
+  const successTone = toneForHigherIsBetter(stats.throughput.successRate7d, 80, 60)
+  const failureRateTone = toneForLowerIsBetter(stats.reliability.failureRate7d, 10, 25)
+  const blockedOverviewTone = toneForPresence(stats.overview.blockedRuns, 1, 2)
+  const errorOverviewTone = toneForPresence(stats.overview.errorRuns, 1, 2)
+  const blockedThroughputTone = toneForPresence(stats.throughput.blocked7d, 1, 2)
+  const errorThroughputTone = toneForPresence(stats.throughput.error7d, 1, 2)
+  const todayCostTone = toneForRatioToBaseline(stats.cost.todayCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)
+  const costPerRunTone = toneForLowerIsBetter(stats.efficiency.avgCostPerRun7d, 1.5, 3)
+  const costPerSuccessTone = toneForLowerIsBetter(stats.efficiency.avgCostPerSuccess7d, 3, 6)
+  const expiringLeaseTone = toneForPresence(stats.resources.expiringLeases, 1, 3)
+  const expiredLeaseTone = toneForPresence(stats.resources.expiredLeases, 1, 2)
+  const missingWorktreeTone = toneForPresence(stats.resources.missingWorktrees, 1, 2)
+  const staleWorktreeTone = toneForPresence(stats.resources.staleWorktrees, 1, 2)
+
+  const hasLatencySample = stats.timing.sampleSize30d > 0 && stats.timing.p50Minutes > 0
+  const tailLatencyRatio = hasLatencySample ? stats.timing.p90Minutes / stats.timing.p50Minutes : 0
+  const tailLatencyTone = toneForLowerIsBetter(tailLatencyRatio, 2.5, 4.5)
+
+  const costTrend = buildAsciiSparkline(stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd))
+
+  return (
+    <div className="flex flex-col gap-5">
+      <DashboardMetrics snapshot={snapshot} />
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">System Signals</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow label="Stats Updated" value={formatTimestamp(stats.updatedAt)} />
+              <SignalRow label="Dashboard Generated" value={formatTimestamp(snapshot.generatedAt)} />
+              <SignalRow label="Poll Interval" value={`${snapshot.config.pollIntervalSeconds}s`} />
+              <SignalRow label="Tracked Repositories" value={snapshot.config.repos.length} />
+              <SignalRow label="Websocket" value={socketConnected ? 'Connected' : 'Reconnecting'} />
+            </div>
+          </div>
+        </article>
+
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Run Health</h2>
+            <div className="mt-2 grid gap-3 sm:grid-cols-2">
+              <OverviewStat label="Total Runs" value={stats.overview.totalRuns} />
+              <OverviewStat label="Active Runs" value={stats.overview.activeRuns} />
+              <OverviewStat label="Running Runs" value={stats.overview.runningRuns} />
+              <OverviewStat label="Queued Runs" value={stats.overview.queuedRuns} />
+              <OverviewStat label="Review Ready" value={stats.overview.reviewReadyRuns} />
+              <OverviewStat label="Completed Runs" value={stats.overview.completedRuns} />
+              <OverviewStat
+                label="Blocked Runs"
+                value={stats.overview.blockedRuns}
+                toneClass={toTextClass(blockedOverviewTone)}
+              />
+              <OverviewStat
+                label="Error Runs"
+                value={stats.overview.errorRuns}
+                toneClass={toTextClass(errorOverviewTone)}
+              />
+            </div>
+            <p className="mt-3 text-xs text-base-content/65">Status mix {formatStatusMix(stats.statusCounts)}</p>
+          </div>
+        </article>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Throughput</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow
+                label="Runs (24h / 7d / 30d)"
+                value={`${stats.throughput.runs24h} / ${stats.throughput.runs7d} / ${stats.throughput.runs30d}`}
+              />
+              <SignalRow label="Completed (7d)" value={stats.throughput.completed7d} />
+              <SignalRow
+                label="Blocked (7d)"
+                value={stats.throughput.blocked7d}
+                valueClassName={toTextClass(blockedThroughputTone)}
+              />
+              <SignalRow
+                label="Errors (7d)"
+                value={stats.throughput.error7d}
+                valueClassName={toTextClass(errorThroughputTone)}
+              />
+              <SignalRow
+                label="Success Rate (7d)"
+                value={`${stats.throughput.successRate7d.toFixed(1)}%`}
+                valueClassName={toTextClass(successTone)}
+              />
+              <SignalRow
+                label="Failure Rate (7d)"
+                value={`${stats.reliability.failureRate7d.toFixed(1)}%`}
+                valueClassName={toTextClass(failureRateTone)}
+              />
+              <SignalRow label="Average Duration (7d)" value={formatMinutes(stats.throughput.avgDurationMinutes7d)} />
+              <SignalRow label="Average Iterations (7d)" value={stats.throughput.avgIterations7d.toFixed(2)} />
+              <SignalRow
+                label="Latency (p50 / p90 / p99)"
+                value={`${formatMinutes(stats.timing.p50Minutes)} / ${formatMinutes(stats.timing.p90Minutes)} / ${formatMinutes(stats.timing.p99Minutes)}`}
+              />
+              <SignalRow
+                label="Tail Ratio (p90 / p50)"
+                value={hasLatencySample ? `${tailLatencyRatio.toFixed(2)}x` : '-'}
+                valueClassName={toTextClass(tailLatencyTone)}
+              />
+              <SignalRow label="Timing Sample Size (30d)" value={stats.timing.sampleSize30d} />
+            </div>
+          </div>
+        </article>
+
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Cost</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow
+                label="Today"
+                value={`$${formatMoney(stats.cost.todayCostUsd)} (${stats.cost.todayRunCount} runs)`}
+                valueClassName={toTextClass(todayCostTone)}
+              />
+              <SignalRow label="Cost (7d)" value={`$${formatMoney(stats.cost.cost7d)}`} />
+              <SignalRow label="Cost (30d)" value={`$${formatMoney(stats.cost.cost30d)}`} />
+              <SignalRow label="Average Daily Cost (7d)" value={`$${formatMoney(stats.cost.avgDailyCost7d)}`} />
+              <SignalRow label="Total Cost (7d)" value={`$${formatMoney(stats.efficiency.totalCostUsd7d)}`} />
+              <SignalRow
+                label="Cost Per Run (7d)"
+                value={`$${formatMoney(stats.efficiency.avgCostPerRun7d)}`}
+                valueClassName={toTextClass(costPerRunTone)}
+              />
+              <SignalRow
+                label="Cost Per Success (7d)"
+                value={`$${formatMoney(stats.efficiency.avgCostPerSuccess7d)}`}
+                valueClassName={toTextClass(costPerSuccessTone)}
+              />
+              <SignalRow label="Cost Per Iteration (7d)" value={`$${formatMoney(stats.efficiency.avgCostPerIteration7d)}`} />
+              <SignalRow label="Completed Per Dollar (7d)" value={stats.efficiency.completedPerDollar7d.toFixed(2)} />
+              <SignalRow label="Cost Trend (7d)" value={costTrend} />
+            </div>
+            <div className="mt-3 space-y-1">
+              {stats.cost.dailyHistory.length === 0 && (
+                <p className="text-xs text-base-content/60">No daily cost rows in the last 7 days.</p>
+              )}
+              {stats.cost.dailyHistory.map((row) => (
+                <p key={row.date} className="text-xs text-base-content/70">
+                  {row.date} ${formatMoney(row.totalCostUsd)} ({row.runCount})
+                </p>
+              ))}
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Agent Activity</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow label="Events Total" value={stats.agents.eventsTotal} />
+              <SignalRow label="Events (24h)" value={stats.agents.events24h} />
+              <SignalRow label="Events (7d)" value={stats.agents.events7d} />
+              <SignalRow label="Tool Calls (24h)" value={stats.agents.toolCalls24h} />
+              <SignalRow label="Thinking Events (24h)" value={stats.agents.thinking24h} />
+              <SignalRow label="Unique Runs (7d)" value={stats.agents.uniqueRuns7d} />
+            </div>
+            <div className="mt-3 space-y-1">
+              <p className="text-xs uppercase tracking-wide text-base-content/60">Role breakdown (7d)</p>
+              {stats.agents.roleBreakdown7d.length === 0 && (
+                <p className="text-xs text-base-content/60">No agent activity in the last 7 days.</p>
+              )}
+              {stats.agents.roleBreakdown7d.map((row) => (
+                <p key={row.role} className="text-xs text-base-content/80">
+                  {row.role}: {row.events} events, {row.toolCalls} tool calls
+                </p>
+              ))}
+            </div>
+          </div>
+        </article>
+
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Reliability</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow
+                label="Failures (7d)"
+                value={stats.reliability.failureCount7d}
+                valueClassName={toTextClass(failureRateTone)}
+              />
+              <SignalRow
+                label="Failure Rate (7d)"
+                value={`${stats.reliability.failureRate7d.toFixed(1)}%`}
+                valueClassName={toTextClass(failureRateTone)}
+              />
+              <SignalRow label="Median Duration" value={formatMinutes(stats.timing.p50Minutes)} />
+              <SignalRow
+                label="Tail Latency (p90 / p50)"
+                value={hasLatencySample ? `${tailLatencyRatio.toFixed(2)}x` : '-'}
+                valueClassName={toTextClass(tailLatencyTone)}
+              />
+            </div>
+            <div className="mt-3 space-y-1">
+              <p className="text-xs uppercase tracking-wide text-base-content/60">Top error patterns (7d)</p>
+              {stats.reliability.topErrorPatterns7d.length === 0 && (
+                <p className="text-xs text-base-content/60">None in the last 7 days.</p>
+              )}
+              {stats.reliability.topErrorPatterns7d.map((row) => (
+                <p key={`${row.pattern}-${row.count}`} className="text-xs text-base-content/80">
+                  <span className={toTextClass(toneForPresence(row.count, 2, 4))}>{row.count}x</span>
+                  {' '}
+                  {truncate(row.pattern, 120)}
+                </p>
+              ))}
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Resources</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow label="Active Leases" value={stats.resources.activeLeases} />
+              <SignalRow label="Leased Repositories" value={stats.resources.leasedRepos} />
+              <SignalRow
+                label="Expiring Leases"
+                value={stats.resources.expiringLeases}
+                valueClassName={toTextClass(expiringLeaseTone)}
+              />
+              <SignalRow
+                label="Expired Leases"
+                value={stats.resources.expiredLeases}
+                valueClassName={toTextClass(expiredLeaseTone)}
+              />
+              <SignalRow label="Active Worktrees" value={stats.resources.activeWorktrees} />
+              <SignalRow
+                label="Missing Worktrees"
+                value={stats.resources.missingWorktrees}
+                valueClassName={toTextClass(missingWorktreeTone)}
+              />
+              <SignalRow
+                label="Stale Completed Worktrees"
+                value={stats.resources.staleWorktrees}
+                valueClassName={toTextClass(staleWorktreeTone)}
+              />
+            </div>
+          </div>
+        </article>
+
+        <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+          <div className="card-body p-4 sm:p-5">
+            <h2 className="card-title text-lg">Merge Queue</h2>
+            <div className="mt-2 space-y-2 text-sm">
+              <SignalRow label="Active Batches" value={stats.queue.activeBatches} />
+              <SignalRow label="Batch Statuses" value={formatStatusMix(stats.queue.statuses)} />
+              <SignalRow
+                label="Active Phases"
+                value={stats.phaseCounts.length > 0 ? stats.phaseCounts.map((row) => `${row.phase}:${row.count}`).join(' | ') : '-'}
+              />
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+        <div className="card-body p-4 sm:p-5">
+          <h2 className="card-title text-lg">Top Repositories (30d)</h2>
+          {stats.topRepos30d.length === 0 ? (
+            <p className="mt-2 text-sm text-base-content/70">No repository run history in the last 30 days.</p>
+          ) : (
+            <div className="mt-3 grid gap-2">
+              {stats.topRepos30d.map((row) => {
+                const terminalCount = row.completedRuns + row.blockedRuns + row.errorRuns
+                const successPct = terminalCount > 0 ? (row.completedRuns / terminalCount) * 100 : 0
+                const successToneClass = toTextClass(toneForHigherIsBetter(successPct, 80, 60))
+
+                return (
+                  <div
+                    key={row.repo}
+                    className="rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2 text-sm"
+                  >
+                    <p className="font-semibold text-base-content">{truncate(row.repo, 96)}</p>
+                    <p className="mt-1 text-xs text-base-content/80">
+                      runs {row.totalRuns} | completed {row.completedRuns} | blocked {row.blockedRuns} | error {row.errorRuns}
+                    </p>
+                    <p className="mt-1 text-xs text-base-content/80">
+                      success <span className={successToneClass}>{successPct.toFixed(0)}%</span>
+                      {' | '}
+                      cost ${formatMoney(row.totalCostUsd)}
+                      {' | '}
+                      avg iterations {row.avgIterations.toFixed(1)}
+                    </p>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+interface OverviewStatProps {
+  label: string
+  value: number
+  toneClass?: string
+}
+
+function OverviewStat({ label, value, toneClass }: OverviewStatProps): ReactElement {
+  return (
+    <div className="rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
+      <p className="text-xs uppercase tracking-wide text-base-content/60">{label}</p>
+      <p className={`mt-1 text-2xl font-semibold ${toneClass ?? 'text-base-content'}`}>{value}</p>
+    </div>
+  )
+}
+
+interface SignalRowProps {
+  label: string
+  value: ReactNode
+  valueClassName?: string
+}
+
+function SignalRow({ label, value, valueClassName }: SignalRowProps): ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-2">
+      <span className="text-base-content/70">{label}</span>
+      <span className={`text-right font-medium ${valueClassName ?? 'text-base-content'}`}>{value}</span>
+    </div>
+  )
+}
+
+function formatStatusMix(statuses: StatusAggregate[]): string {
+  if (statuses.length === 0) return '-'
+  return statuses.map((row) => `${row.status}:${row.count}`).join(' | ')
+}
+
+function formatMinutes(minutes: number): string {
+  if (minutes <= 0) return '-'
+  if (minutes < 1) return `${Math.round(minutes * 60)}s`
+  if (minutes < 60) return `${minutes.toFixed(1)}m`
+  const hours = Math.floor(minutes / 60)
+  const mins = Math.round(minutes % 60)
+  return `${hours}h${String(mins).padStart(2, '0')}m`
+}
+
+function toneForHigherIsBetter(value: number, greenAt: number, yellowAt: number): Tone {
+  if (value >= greenAt) return 'success'
+  if (value >= yellowAt) return 'warning'
+  return 'error'
+}
+
+function toneForLowerIsBetter(value: number, greenAt: number, yellowAt: number): Tone {
+  if (value <= greenAt) return 'success'
+  if (value <= yellowAt) return 'warning'
+  return 'error'
+}
+
+function toneForPresence(value: number, yellowAt = 1, redAt = 3): Tone {
+  if (value < yellowAt) return 'success'
+  if (value < redAt) return 'warning'
+  return 'error'
+}
+
+function toneForRatioToBaseline(
+  value: number,
+  baseline: number,
+  greenAtRatio: number,
+  yellowAtRatio: number,
+): Tone {
+  if (baseline <= 0) {
+    return value <= 0 ? 'success' : 'warning'
+  }
+  const ratio = value / baseline
+  if (ratio <= greenAtRatio) return 'success'
+  if (ratio <= yellowAtRatio) return 'warning'
+  return 'error'
+}
+
+function toTextClass(tone: Tone): string {
+  switch (tone) {
+    case 'success':
+      return 'text-success'
+    case 'warning':
+      return 'text-warning'
+    case 'error':
+      return 'text-error'
+    default:
+      return 'text-base-content'
+  }
+}
+
+function buildAsciiSparkline(values: number[]): string {
+  if (values.length === 0) return '-'
+  const max = Math.max(...values, 0)
+  if (max <= 0) return '.'.repeat(values.length)
+
+  const bars = '.:-=+*#%@'
+  return values
+    .map((value) => {
+      const ratio = Math.max(0, Math.min(1, value / max))
+      const index = Math.round(ratio * (bars.length - 1))
+      return bars[index] ?? '.'
+    })
+    .join('')
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -59,16 +59,6 @@ body {
   color: hsl(var(--bc));
 }
 
-.orch-shell {
-  --orch-header-offset: 8.8rem;
-}
-
-@media (min-width: 640px) {
-  .orch-shell {
-    --orch-header-offset: 9rem;
-  }
-}
-
 .bg-orch-admin {
   background-image:
     radial-gradient(circle at 15% 0%, rgb(34 211 238 / 0.16), transparent 38%),

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -22,6 +22,119 @@ export interface RunSummary {
   endedAt: string | null
 }
 
+export interface StatusAggregate {
+  status: string
+  count: number
+}
+
+export interface PhaseAggregate {
+  phase: string
+  count: number
+}
+
+export interface RepoAggregate {
+  repo: string
+  totalRuns: number
+  completedRuns: number
+  blockedRuns: number
+  errorRuns: number
+  totalCostUsd: number
+  avgIterations: number
+}
+
+export interface AgentRoleAggregate {
+  role: string
+  events: number
+  toolCalls: number
+}
+
+export interface DailyCostAggregate {
+  date: string
+  totalCostUsd: number
+  runCount: number
+}
+
+export interface ErrorPatternAggregate {
+  pattern: string
+  count: number
+}
+
+export interface TuiStatsSnapshot {
+  updatedAt: string
+  overview: {
+    totalRuns: number
+    activeRuns: number
+    queuedRuns: number
+    runningRuns: number
+    reviewReadyRuns: number
+    completedRuns: number
+    blockedRuns: number
+    errorRuns: number
+  }
+  statusCounts: StatusAggregate[]
+  phaseCounts: PhaseAggregate[]
+  throughput: {
+    runs24h: number
+    runs7d: number
+    runs30d: number
+    completed7d: number
+    blocked7d: number
+    error7d: number
+    successRate7d: number
+    avgDurationMinutes7d: number
+    avgIterations7d: number
+  }
+  reliability: {
+    failureCount7d: number
+    failureRate7d: number
+    topErrorPatterns7d: ErrorPatternAggregate[]
+  }
+  cost: {
+    todayCostUsd: number
+    todayRunCount: number
+    cost7d: number
+    cost30d: number
+    avgDailyCost7d: number
+    dailyHistory: DailyCostAggregate[]
+  }
+  efficiency: {
+    totalCostUsd7d: number
+    avgCostPerRun7d: number
+    avgCostPerSuccess7d: number
+    avgCostPerIteration7d: number
+    completedPerDollar7d: number
+  }
+  resources: {
+    activeLeases: number
+    expiringLeases: number
+    expiredLeases: number
+    leasedRepos: number
+    activeWorktrees: number
+    missingWorktrees: number
+    staleWorktrees: number
+  }
+  timing: {
+    sampleSize30d: number
+    p50Minutes: number
+    p90Minutes: number
+    p99Minutes: number
+  }
+  queue: {
+    activeBatches: number
+    statuses: StatusAggregate[]
+  }
+  agents: {
+    eventsTotal: number
+    events24h: number
+    events7d: number
+    toolCalls24h: number
+    thinking24h: number
+    uniqueRuns7d: number
+    roleBreakdown7d: AgentRoleAggregate[]
+  }
+  topRepos30d: RepoAggregate[]
+}
+
 export interface DashboardSnapshot {
   generatedAt: string
   status: {
@@ -40,19 +153,7 @@ export interface DashboardSnapshot {
     repos: string[]
     pollIntervalSeconds: number
   }
-  stats: {
-    throughput: {
-      runs24h: number
-      successRate7d: number
-    }
-    overview: {
-      queuedRuns: number
-      runningRuns: number
-      reviewReadyRuns: number
-      blockedRuns: number
-      errorRuns: number
-    }
-  }
+  stats: TuiStatsSnapshot
 }
 
 export interface RunEvent {


### PR DESCRIPTION
Closes #87

## Plan
**Objective:** Expand the web Stats page to show the same rich data the TUI displays, using the full TuiStatsSnapshot already served by the backend

1. Expand the DashboardSnapshot.stats type in dashboard.ts to include the full TuiStatsSnapshot shape: overview (add totalRuns, activeRuns, completedRuns), statusCounts, phaseCounts, throughput (add runs7d, runs30d, completed7d, blocked7d, error7d, avgDurationMinutes7d, avgIterations7d), reliability, cost (full), efficiency, resources, timing, queue, agents, topRepos30d. Add corresponding sub-interfaces (StatusAggregate, PhaseAggregate, RepoAggregate, AgentRoleAggregate, DailyCostAggregate, ErrorPatternAggregate).
2. Create web/src/lib/stats-tone.ts with CSS-class-based color helpers mirroring the TUI's colorForHigherIsBetter, colorForLowerIsBetter, colorForPresence, colorForRatioToBaseline. Return DaisyUI text color classes (text-success, text-warning, text-error, text-base-content/70). Also add a buildSparkline() function that returns a string of Unicode block characters for inline sparklines.
3. Add formatMinutes() helper to web/src/lib/format.ts for duration display (e.g. '12m', '1h 3m').
4. Create web/src/components/StatsPage.tsx as a dedicated component. Extract the StatsPage from App.tsx and rebuild it with 8 stat sections mirroring TUI: (1) Run Health - total/active/running/queued/review_ready/completed/blocked/error + status mix, (2) Throughput - runs 24h/7d/30d, completed/blocked/error 7d, success/failure rate, avg duration, avg iterations, p50/p90/p99, (3) Cost - today + runs, 7d/30d totals, avg daily, cost/run, cost/success, cost/iter, completed/$, trend sparkline, daily history table, (4) Agent Activity - events total/24h/7d, tool calls 24h, thinking 24h, unique runs 7d, role breakdown, (5) Reliability - failures 7d, failure rate, tail p90/p50 ratio, median, top error patterns, (6) Resources - leases (active/expiring/expired/repos), worktrees (active/missing/stale), (7) Merge Queue - active batches, statuses, active phases, (8) Top Repositories 30d - per-repo runs/success%/cost/iterations. Use the card pattern from existing components and color helpers from stats-tone.ts. Keep DashboardMetrics at the top.
5. Update App.tsx to import and use the new StatsPage component from its dedicated file, removing the inline StatsPage function. Pass snapshot and socketConnected props.

## Implementation
Implemented and validated the requested stats-page expansion with the review fixes: added automated coverage for the web stats contract and rendering logic, and removed the fragile fixed-header offset approach. Specifically, I added a `/api/dashboard` stats-shape test, added `StatsPage` component tests for rich and sparse snapshots (including derived values like tail ratio and repo success), switched the header back to `sticky`, removed hard-coded header offset CSS/usage, and kept the rich `TuiStatsSnapshot`-driven web stats UI/types in place. Verification passed with `pnpm exec vitest run test/web/stats-page.test.ts test/web/server.test.ts` and `pnpm typecheck`.

**Changed files:**
- `test/web/server.test.ts`
- `test/web/stats-page.test.ts`
- `web/src/App.tsx`
- `web/src/components/DashboardHeader.tsx`
- `web/src/index.css`
- `web/src/types/dashboard.ts`
- `web/src/components/StatsPage.tsx`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed full changed files and adjacent stats/server code paths. The previous blocking concerns are addressed: stats contract coverage was added in `test/web/server.test.ts` (including full snapshot sections/arrays), render/derivation coverage was added in `test/web/stats-page.test.ts` (rich, loading, and sparse cases), and the header overlap risk was resolved by switching to sticky header flow in `web/src/components/DashboardHeader.tsx` with offset CSS removed in `web/src/index.css` and `web/src/App.tsx`. Validation run passed: `pnpm typecheck`, `pnpm lint`, and `pnpm test` (128 files / 1084 tests).

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex