### PR TITLE
[CHORE] Web - self-update / pull restart improvements (night-orch / #88)

### DIFF
--- a/test/web/app-update-flow.test.ts
+++ b/test/web/app-update-flow.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createUpdateTransitionState,
+  pollAndApplyUpdateStatus,
+  resolveImmediateUpdateStatusAfterAccept,
+  type UpdateTransitionState,
+} from '../../web/src/lib/update-status-flow.js'
+import { type UpdateStatus } from '../../web/src/types/dashboard.js'
+
+describe('App update flow', () => {
+  it('polls through active update states and reloads when status returns to idle', async () => {
+    const fetchStatus = vi.fn<() => Promise<UpdateStatus | null>>()
+      .mockResolvedValueOnce({ state: 'draining' })
+      .mockResolvedValueOnce({ state: 'idle' })
+    const setStatus = vi.fn<(status: UpdateStatus) => void>()
+    const setError = vi.fn<(message: string) => void>()
+    const reloadPage = vi.fn<() => void>()
+
+    let transition: UpdateTransitionState = createUpdateTransitionState(1_000)
+
+    transition = await pollAndApplyUpdateStatus({
+      fetchUpdateStatus: fetchStatus,
+      transition,
+      onStatus: setStatus,
+      onError: setError,
+      onReload: reloadPage,
+      nowMs: () => 1_100,
+    })
+
+    transition = await pollAndApplyUpdateStatus({
+      fetchUpdateStatus: fetchStatus,
+      transition,
+      onStatus: setStatus,
+      onError: setError,
+      onReload: reloadPage,
+      nowMs: () => 2_500,
+    })
+
+    expect(setStatus).toHaveBeenNthCalledWith(1, { state: 'draining' })
+    expect(setStatus).toHaveBeenNthCalledWith(2, { state: 'idle' })
+    expect(setError).not.toHaveBeenCalled()
+    expect(reloadPage).toHaveBeenCalledTimes(1)
+    expect(transition).toEqual({ startedAtMs: null, sawActiveState: false })
+  })
+
+  it('ignores stale failed status immediately after update acceptance', async () => {
+    expect(resolveImmediateUpdateStatusAfterAccept({ state: 'failed', error: 'old failure' })).toBeNull()
+
+    const fetchStatus = vi.fn<() => Promise<UpdateStatus | null>>()
+      .mockResolvedValueOnce({ state: 'failed', error: 'old failure' })
+      .mockResolvedValueOnce({ state: 'pulling' })
+    const setStatus = vi.fn<(status: UpdateStatus) => void>()
+    const setError = vi.fn<(message: string) => void>()
+    const reloadPage = vi.fn<() => void>()
+
+    let transition: UpdateTransitionState = createUpdateTransitionState(10_000)
+
+    transition = await pollAndApplyUpdateStatus({
+      fetchUpdateStatus: fetchStatus,
+      transition,
+      onStatus: setStatus,
+      onError: setError,
+      onReload: reloadPage,
+      nowMs: () => 10_500,
+    })
+
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(setError).not.toHaveBeenCalled()
+    expect(reloadPage).not.toHaveBeenCalled()
+    expect(transition).toEqual({ startedAtMs: 10_000, sawActiveState: false })
+
+    transition = await pollAndApplyUpdateStatus({
+      fetchUpdateStatus: fetchStatus,
+      transition,
+      onStatus: setStatus,
+      onError: setError,
+      onReload: reloadPage,
+      nowMs: () => 11_000,
+    })
+
+    expect(setStatus).toHaveBeenCalledWith({ state: 'pulling' })
+    expect(setError).not.toHaveBeenCalled()
+    expect(reloadPage).not.toHaveBeenCalled()
+    expect(transition).toEqual({ startedAtMs: 10_000, sawActiveState: true })
+  })
+
+  it('treats failed as terminal after active polling has started', async () => {
+    const fetchStatus = vi.fn<() => Promise<UpdateStatus | null>>()
+      .mockResolvedValueOnce({ state: 'failed', error: 'health check failed' })
+    const setStatus = vi.fn<(status: UpdateStatus) => void>()
+    const setError = vi.fn<(message: string) => void>()
+    const reloadPage = vi.fn<() => void>()
+
+    const transition = await pollAndApplyUpdateStatus({
+      fetchUpdateStatus: fetchStatus,
+      transition: { startedAtMs: 20_000, sawActiveState: true },
+      onStatus: setStatus,
+      onError: setError,
+      onReload: reloadPage,
+      nowMs: () => 21_000,
+    })
+
+    expect(setStatus).toHaveBeenCalledWith({ state: 'failed', error: 'health check failed' })
+    expect(setError).toHaveBeenCalledWith('Update failed: health check failed')
+    expect(reloadPage).not.toHaveBeenCalled()
+    expect(transition).toEqual({ startedAtMs: null, sawActiveState: false })
+  })
+})

--- a/test/web/update-progress-modal.test.ts
+++ b/test/web/update-progress-modal.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { UpdateProgressModal } from '../../web/src/components/UpdateProgressModal.js'
+import { type UpdateStatus } from '../../web/src/types/dashboard.js'
+
+describe('UpdateProgressModal', () => {
+  it('renders live state details for standard update phases', () => {
+    const text = renderModalText({ state: 'pulling' })
+
+    expect(text).toContain('Applying self-update')
+    expect(text).toContain('Current stage: Pulling')
+    expect(text).toContain('Draining running services')
+    expect(text).toContain('Pulling latest code')
+    expect(text).toContain('Installing and building')
+    expect(text).toContain('Dashboard controls are temporarily blocked.')
+  })
+
+  it('shows rollback messaging when update enters rollback phase', () => {
+    const text = renderModalText({ state: 'rolling-back' })
+    expect(text).toContain('Current stage: Rolling Back')
+    expect(text).toContain('Rolling back to the previous known-good build.')
+  })
+})
+
+function renderModalText(status: UpdateStatus): string {
+  const html = renderToStaticMarkup(React.createElement(UpdateProgressModal, { status }))
+  return html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,9 +8,18 @@ import { RunEventStream } from './components/RunEventStream.js'
 import { RunsPanel } from './components/RunsPanel.js'
 import { SettingsPage } from './components/SettingsPage.js'
 import { StatsPage } from './components/StatsPage.js'
+import { UpdateProgressModal } from './components/UpdateProgressModal.js'
 import { extractMessage, formatTimestamp } from './lib/format.js'
 import { STATUS_BADGE_TONE } from './lib/run-tone.js'
 import { asRunEventsPayload, mergeRunEvents } from './lib/run-events.js'
+import {
+  clearUpdateTransitionState,
+  createUpdateTransitionState,
+  isUpdateInProgress,
+  pollAndApplyUpdateStatus,
+  resolveImmediateUpdateStatusAfterAccept,
+  type UpdateTransitionState,
+} from './lib/update-status-flow.js'
 import {
   type DashboardPage,
   type DashboardSnapshot,
@@ -27,6 +36,10 @@ const MUTATION_INTENT_VALUE = 'mutate'
 const WEB_AUTH_TOKEN_HEADER = 'x-night-orch-web-token'
 const FRONTEND_BUILD_VERSION = import.meta.env.VITE_BUILD_VERSION ?? 'unknown'
 const FRONTEND_BUILD_GIT_SHA = import.meta.env.VITE_BUILD_GIT_SHA ?? 'unknown'
+
+interface RunOperationOptions {
+  refreshAfterSuccess?: boolean
+}
 
 export function App(): ReactElement {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null)
@@ -69,11 +82,13 @@ export function App(): ReactElement {
   const reconnectTimerRef = useRef<number | null>(null)
   const selectedStreamRunIdRef = useRef('')
   const subscribedRunRef = useRef('')
+  const updateTransitionRef = useRef<UpdateTransitionState>(clearUpdateTransitionState())
 
   const repos = snapshot?.config.repos ?? []
   const allRuns = snapshot?.runs.runs ?? []
   const runningRuns = snapshot?.stats.overview.runningRuns ?? 0
   const queuedRuns = snapshot?.stats.overview.queuedRuns ?? 0
+  const updateInProgress = isUpdateInProgress(updateStatus)
 
   const filteredRuns = useMemo(() => {
     if (selectedRepo === 'all') return allRuns
@@ -87,10 +102,9 @@ export function App(): ReactElement {
   const selectedStreamRunId = selectedRun?.hasRun ? selectedRun.runId : ''
 
   const currentState = useMemo(() => {
-    const updateInProgress = updateStatus != null && updateStatus.state !== 'idle' && updateStatus.state !== 'failed'
     if (updateInProgress) {
       return {
-        label: `updating ${updateStatus.state}`,
+        label: `updating ${updateStatus?.state ?? 'starting'}`,
         toneClass: 'badge-warning',
       }
     }
@@ -120,7 +134,7 @@ export function App(): ReactElement {
       label: 'idle',
       toneClass: 'badge-neutral',
     }
-  }, [queuedRuns, runningRuns, socketConnected, updateStatus])
+  }, [queuedRuns, runningRuns, socketConnected, updateInProgress, updateStatus?.state])
 
   const loadDashboard = useCallback(async () => {
     const response = await fetch('/api/dashboard')
@@ -129,6 +143,14 @@ export function App(): ReactElement {
     }
     const payload = await response.json() as DashboardSnapshot
     setSnapshot(payload)
+  }, [])
+
+  const readUpdateStatus = useCallback(async (): Promise<UpdateStatus | null> => {
+    const response = await fetch('/api/update-status')
+    if (!response.ok) {
+      return null
+    }
+    return await response.json() as UpdateStatus
   }, [])
 
   const loadSessionToken = useCallback(async () => {
@@ -183,6 +205,30 @@ export function App(): ReactElement {
       }
     })()
   }, [loadDashboard, loadProjects, loadSessionToken, loadSettings])
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const status = await readUpdateStatus()
+        if (!status || cancelled) {
+          return
+        }
+        if (isUpdateInProgress(status)) {
+          updateTransitionRef.current = { startedAtMs: null, sawActiveState: true }
+        } else {
+          updateTransitionRef.current = clearUpdateTransitionState()
+        }
+        setUpdateStatus(status)
+      } catch {
+        // Update status availability is best-effort.
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [readUpdateStatus])
 
   useEffect(() => {
     if (repos.length === 0) {
@@ -305,39 +351,53 @@ export function App(): ReactElement {
   }, [selectedStreamRunId, socketConnected])
 
   useEffect(() => {
-    if (!updateStatus || updateStatus.state === 'idle') return
+    if (!updateInProgress) return
 
-    const interval = window.setInterval(async () => {
+    let cancelled = false
+    const pollUpdateStatus = async (): Promise<void> => {
       try {
-        const res = await fetch('/api/update-status')
-        if (res.ok) {
-          const status = await res.json() as UpdateStatus
-          setUpdateStatus(status)
-          if (status.state === 'idle' || status.state === 'failed') {
-            window.clearInterval(interval)
-            if (status.state === 'failed') {
-              setErrorMessage(`Update failed: ${status.error ?? 'unknown error'}`)
-            } else {
-              setFeedbackMessage('Update complete - services restarted')
-            }
-          }
+        const nextTransition = await pollAndApplyUpdateStatus({
+          fetchUpdateStatus: readUpdateStatus,
+          transition: updateTransitionRef.current,
+          onStatus: (status) => {
+            if (cancelled) return
+            setUpdateStatus(status)
+          },
+          onError: (message) => {
+            if (cancelled) return
+            setErrorMessage(message)
+          },
+          onReload: () => {
+            if (cancelled) return
+            window.location.reload()
+          },
+        })
+        if (!cancelled) {
+          updateTransitionRef.current = nextTransition
         }
       } catch {
-        // Ignore fetch errors during update.
+        // Ignore fetch errors while services are restarting.
       }
+    }
+
+    void pollUpdateStatus()
+    const interval = window.setInterval(() => {
+      void pollUpdateStatus()
     }, 2000)
 
     return () => {
+      cancelled = true
       window.clearInterval(interval)
     }
-  }, [updateStatus?.state])
+  }, [readUpdateStatus, updateInProgress])
 
   const runOperation = useCallback(async (
     operationName: string,
     endpoint: string,
     payload: Record<string, unknown>,
     fallbackMessage: string,
-  ) => {
+    options?: RunOperationOptions,
+  ): Promise<boolean> => {
     try {
       setActiveOperation(operationName)
       setErrorMessage(null)
@@ -367,13 +427,50 @@ export function App(): ReactElement {
 
       const message = extractMessage(body) ?? fallbackMessage
       setFeedbackMessage(message)
-      await Promise.all([loadDashboard(), loadSettings()])
+      if (options?.refreshAfterSuccess ?? true) {
+        await Promise.all([loadDashboard(), loadSettings()])
+      }
+      return true
     } catch (err) {
       setErrorMessage((err as Error).message)
+      return false
     } finally {
       setActiveOperation(null)
     }
   }, [loadDashboard, loadSettings, operationsEnabled, webMutationToken])
+
+  const submitUpdate = useCallback(async () => {
+    const accepted = await runOperation(
+      'update',
+      '/api/operations/update',
+      {},
+      'Update initiated - pulling and rebuilding...',
+      { refreshAfterSuccess: false },
+    )
+    if (!accepted) {
+      return
+    }
+
+    updateTransitionRef.current = createUpdateTransitionState(Date.now())
+    setUpdateStatus({ state: 'draining' })
+
+    try {
+      const status = await readUpdateStatus()
+      if (!status) {
+        return
+      }
+      const immediateStatus = resolveImmediateUpdateStatusAfterAccept(status)
+      if (immediateStatus) {
+        updateTransitionRef.current = {
+          startedAtMs: updateTransitionRef.current.startedAtMs,
+          sawActiveState: true,
+        }
+        setUpdateStatus(immediateStatus)
+      }
+    } catch {
+      // Ignore immediate read failures while update orchestration starts.
+    }
+  }, [readUpdateStatus, runOperation])
 
   const submitRetry = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -619,8 +716,7 @@ export function App(): ReactElement {
                   void submitDeleteEntry(event)
                 }}
                 onUpdate={() => {
-                  setUpdateStatus({ state: 'draining' })
-                  void runOperation('update', '/api/operations/update', {}, 'Update initiated - pulling and rebuilding...')
+                  void submitUpdate()
                 }}
               />
             </section>
@@ -662,6 +758,8 @@ export function App(): ReactElement {
           />
         )}
       </div>
+
+      {updateInProgress && updateStatus && <UpdateProgressModal status={updateStatus} />}
     </main>
   )
 }

--- a/web/src/components/UpdateProgressModal.tsx
+++ b/web/src/components/UpdateProgressModal.tsx
@@ -1,0 +1,99 @@
+import { type ReactElement } from 'react'
+
+import { type UpdateStatus } from '../types/dashboard.js'
+
+const UPDATE_STEPS = [
+  { id: 'draining', label: 'Draining running services' },
+  { id: 'pulling', label: 'Pulling latest code' },
+  { id: 'building', label: 'Installing and building' },
+  { id: 'restarting', label: 'Restarting supervisor children' },
+  { id: 'health-checking', label: 'Running health checks' },
+] as const
+
+type UpdateStepId = (typeof UPDATE_STEPS)[number]['id']
+
+function formatUpdateState(value: string): string {
+  return value
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function getStepStatus(
+  stepId: UpdateStepId,
+  currentState: string,
+): 'pending' | 'active' | 'done' {
+  const currentIndex = UPDATE_STEPS.findIndex((step) => step.id === currentState)
+  if (currentIndex < 0) {
+    return 'pending'
+  }
+
+  const stepIndex = UPDATE_STEPS.findIndex((step) => step.id === stepId)
+  if (stepIndex < currentIndex) {
+    return 'done'
+  }
+  if (stepIndex === currentIndex) {
+    return 'active'
+  }
+  return 'pending'
+}
+
+export function UpdateProgressModal({ status }: { status: UpdateStatus }): ReactElement {
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/78 px-4 backdrop-blur-sm">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="Self update in progress"
+        className="w-full max-w-xl rounded-box border border-base-300/80 bg-base-100/95 p-5 shadow-2xl"
+      >
+        <div className="flex items-center gap-3">
+          <span className="loading loading-spinner loading-md text-info" />
+          <div>
+            <h2 className="text-lg font-semibold">Applying self-update</h2>
+            <p className="text-sm text-base-content/75">
+              Current stage: {formatUpdateState(status.state)}
+            </p>
+          </div>
+        </div>
+
+        <ul className="mt-4 space-y-2">
+          {UPDATE_STEPS.map((step) => {
+            const stepStatus = getStepStatus(step.id, status.state)
+            const badgeTone =
+              stepStatus === 'active'
+                ? 'badge-info'
+                : stepStatus === 'done'
+                  ? 'badge-success'
+                  : 'badge-ghost'
+            const badgeLabel =
+              stepStatus === 'active'
+                ? 'live'
+                : stepStatus === 'done'
+                  ? 'done'
+                  : 'pending'
+
+            return (
+              <li key={step.id} className="flex items-center justify-between gap-3 text-sm">
+                <span className={stepStatus === 'pending' ? 'text-base-content/65' : undefined}>
+                  {step.label}
+                </span>
+                <span className={`badge badge-sm ${badgeTone}`}>{badgeLabel}</span>
+              </li>
+            )
+          })}
+        </ul>
+
+        {status.state === 'rolling-back' && (
+          <div className="mt-4 rounded border border-warning/35 bg-warning/10 p-2 text-xs text-warning-content">
+            Health checks failed. Rolling back to the previous known-good build.
+          </div>
+        )}
+
+        <p className="mt-4 text-xs text-base-content/70">
+          Dashboard controls are temporarily blocked. This page refreshes automatically after a
+          healthy restart.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/web/src/lib/update-status-flow.ts
+++ b/web/src/lib/update-status-flow.ts
@@ -1,0 +1,127 @@
+import { type UpdateStatus } from '../types/dashboard.js'
+
+export const UPDATE_STATUS_TERMINAL_GRACE_MS = 6_000
+
+export interface UpdateTransitionState {
+  startedAtMs: number | null
+  sawActiveState: boolean
+}
+
+export function createUpdateTransitionState(startedAtMs: number): UpdateTransitionState {
+  return { startedAtMs, sawActiveState: false }
+}
+
+export function clearUpdateTransitionState(): UpdateTransitionState {
+  return { startedAtMs: null, sawActiveState: false }
+}
+
+export function isUpdateInProgress(status: UpdateStatus | null): boolean {
+  return status != null && status.state !== 'idle' && status.state !== 'failed'
+}
+
+export function resolveImmediateUpdateStatusAfterAccept(status: UpdateStatus): UpdateStatus | null {
+  if (isUpdateInProgress(status)) {
+    return status
+  }
+  return null
+}
+
+function shouldAcceptTerminalStatus(
+  transition: UpdateTransitionState,
+  nowMs: number,
+  graceMs: number,
+): boolean {
+  if (transition.startedAtMs == null) {
+    return true
+  }
+  if (transition.sawActiveState) {
+    return true
+  }
+  return nowMs - transition.startedAtMs >= graceMs
+}
+
+interface UpdatePollDecision {
+  nextTransition: UpdateTransitionState
+  nextStatus: UpdateStatus | null
+  errorMessage: string | null
+  shouldReload: boolean
+}
+
+function decidePolledUpdateStatus(
+  status: UpdateStatus,
+  transition: UpdateTransitionState,
+  nowMs: number,
+  graceMs: number,
+): UpdatePollDecision {
+  if (isUpdateInProgress(status)) {
+    return {
+      nextTransition: { startedAtMs: transition.startedAtMs, sawActiveState: true },
+      nextStatus: status,
+      errorMessage: null,
+      shouldReload: false,
+    }
+  }
+
+  if (!shouldAcceptTerminalStatus(transition, nowMs, graceMs)) {
+    return {
+      nextTransition: transition,
+      nextStatus: null,
+      errorMessage: null,
+      shouldReload: false,
+    }
+  }
+
+  if (status.state === 'failed') {
+    return {
+      nextTransition: clearUpdateTransitionState(),
+      nextStatus: status,
+      errorMessage: `Update failed: ${status.error ?? 'unknown error'}`,
+      shouldReload: false,
+    }
+  }
+
+  return {
+    nextTransition: clearUpdateTransitionState(),
+    nextStatus: status,
+    errorMessage: null,
+    shouldReload: status.state === 'idle',
+  }
+}
+
+export interface PollAndApplyUpdateStatusOptions {
+  fetchUpdateStatus: () => Promise<UpdateStatus | null>
+  transition: UpdateTransitionState
+  onStatus: (status: UpdateStatus) => void
+  onError: (message: string) => void
+  onReload: () => void
+  nowMs?: () => number
+  graceMs?: number
+}
+
+export async function pollAndApplyUpdateStatus(
+  options: PollAndApplyUpdateStatusOptions,
+): Promise<UpdateTransitionState> {
+  const status = await options.fetchUpdateStatus()
+  if (!status) {
+    return options.transition
+  }
+
+  const decision = decidePolledUpdateStatus(
+    status,
+    options.transition,
+    options.nowMs ? options.nowMs() : Date.now(),
+    options.graceMs ?? UPDATE_STATUS_TERMINAL_GRACE_MS,
+  )
+
+  if (decision.nextStatus) {
+    options.onStatus(decision.nextStatus)
+  }
+  if (decision.errorMessage) {
+    options.onError(decision.errorMessage)
+  }
+  if (decision.shouldReload) {
+    options.onReload()
+  }
+
+  return decision.nextTransition
+}

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -206,8 +206,19 @@ export interface SettingsSnapshot {
   settings: RuntimeSettingSnapshot[]
 }
 
+export type UpdateState =
+  | 'idle'
+  | 'draining'
+  | 'pulling'
+  | 'building'
+  | 'restarting'
+  | 'health-checking'
+  | 'rolling-back'
+  | 'failed'
+  | (string & {})
+
 export interface UpdateStatus {
-  state: string
+  state: UpdateState
   error?: string
 }
 


### PR DESCRIPTION
Closes #88

## Plan
**Objective:** Add a blocking modal with live update status and auto-refresh on successful self-update

1. Create UpdateModal.tsx component: a DaisyUI modal (dialog element with modal-open class) that renders when updateStatus is non-null and not idle/failed. Shows: (a) a title like 'Updating Night-Orch', (b) a vertical stepper/progress list of phases (draining, pulling, building, restarting, health-checking) with checkmark for completed, spinner for active, dimmed for pending, (c) error state with retry option if failed. Modal uses backdrop that blocks all interaction. Use the DaisyUI 'steps' component or a custom ul with status indicators.
2. Update App.tsx update status polling effect (lines 307-333): On successful completion (state === 'idle' after being non-idle), instead of showing a feedback message, call window.location.reload() after a brief delay (e.g., 500ms) to let the user see the success state. Keep the modal visible during this transition.
3. Render the UpdateModal in App.tsx, passing updateStatus and an onDismiss callback (only available in failed state to close the modal). The modal should be rendered at the top level (outside the main content div) so it overlays everything. Also show the modal immediately when the update button is clicked (state = draining).
4. Update the UpdateStatus type in dashboard.ts to use a union of known states rather than bare string, so the modal can properly determine phase ordering and completion status.
5. Verify: run pnpm typecheck and pnpm lint from the web directory (or root) to ensure no type errors or lint issues.

## Implementation
Implemented the self-update UX flow with a blocking modal and safer live status handling in the web app. `submitUpdate` now always enters a non-terminal local `draining` state after acceptance, immediate stale terminal reads are ignored, and polling now uses a grace-aware transition tracker so stale `failed`/`idle` states do not prematurely end the flow. Successful completion (`idle`) triggers `window.location.reload()`, while true terminal `failed` states surface an error. Added tests for modal rendering plus update-flow behavior: active progression to reload, stale immediate failed handling, and terminal failed behavior without reload.

**Changed files:**
- `web/src/App.tsx`
- `web/src/lib/update-status-flow.ts`
- `web/src/components/UpdateProgressModal.tsx`
- `web/src/types/dashboard.ts`
- `test/web/update-progress-modal.test.ts`
- `test/web/app-update-flow.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files in full plus adjacent update endpoint/supervisor flow (`src/web/server.ts`, `src/supervisor/index.ts`, `src/supervisor/status.ts`, `src/supervisor/updater.ts`). The stale-terminal race is now mitigated via transition-state grace handling, the blocking modal + live stage updates are wired correctly, and successful update completion triggers reload from the polling path. Verification passed locally: `pnpm typecheck`, `pnpm lint`, and `pnpm test` (132 files, 1120 tests).

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex