### PR TITLE
[CHORE] Better workflow system (night-orch / #85)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -260,7 +260,10 @@ Supported commands (posted as issue comments):
 
 ## `workflows`
 
-Named workflow definitions for custom execution pipelines. When no workflow is configured, the default Plan→Code→Verify→Review→Decide pipeline is used.
+Named workflow definitions for custom execution pipelines.
+When no workflow is configured:
+- `standard` issues use Plan→Code→Verify→Review→Decide
+- `trivial` issues use a lightweight Code→Verify→Decide flow (review gate disabled)
 
 ```yaml
 workflows:
@@ -270,6 +273,17 @@ workflows:
       - { type: verify, id: verify }
       - { type: worker, id: review, role: reviewer }
       - { type: decide, id: decide, onIterate: code }
+
+  fast-trivial:
+    roles:
+      coder: codex
+      reviewer: codex
+    agents:
+      codex: codex-fast
+    steps:
+      - { type: worker, id: code, role: coder }
+      - { type: verify, id: verify }
+      - { type: decide, id: decide, onIterate: code, requireReview: false }
 
   with-security:
     steps:
@@ -287,11 +301,17 @@ workflows:
 | --- | --- | --- |
 | `worker` | `id`, `role`, `skipWhen?`, `continueFrom?`, `prompt?` | Invoke a worker adapter. Built-in roles: `planner`, `coder`, `reviewer`. |
 | `verify` | `id`, `skipWhen?` | Run configured verify commands. |
-| `decide` | `id`, `onIterate` | Evaluate review/verify results and route to publish, iterate (jump to `onIterate` step), or block. |
+| `decide` | `id`, `onIterate`, `requireReview?` | Evaluate review/verify results and route to publish, iterate (jump to `onIterate` step), or block. |
 
 - `skipWhen` — skip the step when the triage level matches (e.g., `trivial`)
 - `continueFrom` — continue the AI session from a prior step (e.g., coder continues planner's session). Session reuse is agent-specific; cross-agent handoffs (for example `planner=claude`, `coder=codex`) start a fresh session.
 - `prompt` — path to a custom system prompt template (overrides the default)
+- `requireReview` — default `true`; set to `false` for no-review workflows (for example lightweight triage paths)
+
+### Workflow-Level Overrides
+
+- `roles` — optional role defaults (`planner`/`coder`/`reviewer`) for runs using this workflow
+- `agents` — optional per-agent worker profile overrides (same shape as `repos[].agents`)
 
 Reference a workflow in `repos[].workflow` by name.
 
@@ -319,11 +339,33 @@ Reference a workflow in `repos[].workflow` by name.
 | `selectors` | object | no | object with defaults | Issue label inclusion/exclusion filters. |
 | `agents` | record | no | `{}` | Maps agent names to worker profile names. |
 | `workflow` | string | no | none | Name of a workflow from `workflows` section. Uses default pipeline if omitted. |
+| `workflowByTriage` | object | no | none | Per-triage workflow selection (`trivial`/`standard`). |
 | `mergeQueue` | object | no | object with defaults | Merge queue configuration. |
 
 Poll execution model:
 - Repos are polled in parallel.
 - Each repo runs up to `maxConcurrentRuns` issues at once (default `1`).
+
+### `repos[].workflowByTriage`
+
+Route triage levels to different named workflows:
+
+```yaml
+repos:
+  - repo: myorg/myrepo
+    workflow: full
+    workflowByTriage:
+      trivial: fast-trivial
+      standard: full
+```
+
+Resolution order:
+1. Planning-label workflow override (planning-only mode)
+2. `workflowByTriage[triageLevel]`
+3. `workflow`
+4. Built-in defaults (`trivial` -> lightweight, others -> full)
+
+Note: `architectural` issues are intentionally handled outside workflow execution and are labeled for human guidance.
 
 ### `repos[].labels`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -101,7 +101,7 @@ Repos are polled in parallel. By default, each repo runs one issue at a time; ra
 1. **Discovery** — the daemon polls each repo for open issues with configured labels (default: `orch:ready`)
 2. **Triage** — issues are classified as trivial, standard, or architectural based on labels and body length
 3. **Decomposition** (optional) — complex issues are split into independent sub-tasks
-4. **Pipeline execution** — each issue runs through the configured workflow (default: Plan → Code → Verify → Review → Decide) in an isolated git worktree
+4. **Pipeline execution** — each issue runs through the configured workflow in an isolated git worktree (defaults: `standard` = Plan → Code → Verify → Review → Decide, `trivial` = Code → Verify → Decide)
 5. **Publishing** — approved changes are committed, pushed, and a PR is created on the remote
 6. **Merge queue** (optional) — approved PRs are batched, tested, and merged automatically
 
@@ -127,10 +127,11 @@ night-orch retry owner/repo 42
 
 ## Workflows
 
-By default, night-orch uses this pipeline:
+By default, night-orch uses:
 
 ```
-Plan → Code → Verify → Review → Decide
+Standard:    Plan → Code → Verify → Review → Decide
+Trivial:           Code → Verify → Decide
                  ↑                  │
                  └──── iterate ─────┘
 ```
@@ -151,6 +152,8 @@ workflows:
 repos:
   - repo: org/simple-repo
     workflow: minimal    # skips planning entirely
+    workflowByTriage:
+      trivial: minimal   # optional triage-specific routing
 ```
 
 ### Adding custom steps
@@ -175,13 +178,16 @@ workflows:
 |------|---------|
 | `worker` | Invoke an AI agent (planner, coder, reviewer, or custom role) |
 | `verify` | Run configured test/lint/typecheck commands |
-| `decide` | Evaluate results and route to publish, iterate, or block |
+| `decide` | Evaluate results and route to publish, iterate, or block (`requireReview: false` supports no-review flows) |
 
 ### Step options
 
 - `skipWhen: trivial` — skip this step for trivially-triaged issues
 - `continueFrom: plan` — continue the AI session from a prior step when both steps use the same agent (reduces token usage, improves context)
 - `prompt: path/to/template.md` — use a custom system prompt instead of the default
+- `requireReview: false` — allow verification-only decisioning for lightweight workflows
+- `roles` (workflow-level) — per-workflow default role assignment (`planner`/`coder`/`reviewer`)
+- `agents` (workflow-level) — per-workflow worker profile overrides (same shape as `repos[].agents`)
 
 ---
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -101,6 +101,16 @@ commentCommands:
 #       - { type: verify, id: verify }
 #       - { type: worker, id: review, role: reviewer }
 #       - { type: decide, id: decide, onIterate: code }
+#   fast-trivial:
+#     roles:
+#       coder: codex
+#       reviewer: codex
+#     agents:
+#       codex: codex-fast
+#     steps:
+#       - { type: worker, id: code, role: coder }
+#       - { type: verify, id: verify }
+#       - { type: decide, id: decide, onIterate: code, requireReview: false }
 #   with-security-review:
 #     steps:
 #       - { type: worker, id: plan, role: planner, skipWhen: trivial }
@@ -208,6 +218,9 @@ repos:
       claude: claude-default
       codex: codex-default
     # workflow: minimal           # Reference a named workflow
+    # workflowByTriage:
+    #   trivial: fast-trivial
+    #   standard: minimal
     # mergeQueue:
     #   enabled: true
     #   batchSize: 5

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -88,6 +88,16 @@ function validateWorkerProfileRefs(config: Config): void {
       }
     }
   }
+
+  for (const [workflowName, workflow] of Object.entries(config.workflows)) {
+    for (const [agentName, profileRef] of Object.entries(workflow.agents ?? {})) {
+      if (!profileNames.has(profileRef)) {
+        throw new ConfigError(
+          `Workflow ${workflowName}: agent "${agentName}" references unknown worker profile "${profileRef}". Available: ${[...profileNames].join(', ')}`,
+        )
+      }
+    }
+  }
 }
 
 /**

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -176,6 +176,7 @@ const WorkflowDecideStepSchema = z.object({
   type: z.literal('decide'),
   id: z.string(),
   onIterate: z.string(),
+  requireReview: z.boolean().optional(),
 })
 
 const WorkflowStepSchema = z.discriminatedUnion('type', [
@@ -184,9 +185,22 @@ const WorkflowStepSchema = z.discriminatedUnion('type', [
   WorkflowDecideStepSchema,
 ])
 
+const WorkflowRoleOverridesSchema = z.object({
+  planner: z.enum(['claude', 'codex']).optional(),
+  coder: z.enum(['claude', 'codex']).optional(),
+  reviewer: z.enum(['claude', 'codex']).optional(),
+})
+
 const WorkflowSchema = z.object({
   steps: z.array(WorkflowStepSchema).min(1),
+  roles: WorkflowRoleOverridesSchema.optional(),
+  agents: z.record(z.string()).optional(),
 })
+
+const WorkflowByTriageSchema = z.object({
+  trivial: z.string().optional(),
+  standard: z.string().optional(),
+}).strict()
 
 // --- Merge queue schema ---
 
@@ -222,6 +236,7 @@ const RepoConfigSchema = z.object({
   selectors: SelectorsSchema.default({}),
   agents: z.record(z.string()).default({}),
   workflow: z.string().optional(),
+  workflowByTriage: WorkflowByTriageSchema.optional(),
   mergeQueue: MergeQueueSchema.default({}),
 })
 

--- a/src/loop/decision.ts
+++ b/src/loop/decision.ts
@@ -21,9 +21,11 @@ export function decide(
   ctx: RunContext,
   loopConfig: Config['loop'],
   securityConfig: Config['security'],
+  options: { requireReview?: boolean } = {},
 ): LoopDecision {
   const maxReviewIter = ctx.adjustedLimits.maxReviewIterations
   const maxTotalPasses = ctx.adjustedLimits.maxTotalAgentPasses
+  const requireReview = options.requireReview ?? true
 
   // Rule 1: Cost limit
   // (Caller should check before invoking, but double-check here)
@@ -55,6 +57,27 @@ export function decide(
 
   // No review result = parse failure
   if (!review) {
+    // Lightweight workflows may intentionally omit reviewer phases.
+    if (!requireReview) {
+      if (loopConfig.requireVerificationPass && !verifyCommandsConfigured) {
+        return { action: 'block', reason: 'Verification required but no verify commands are configured', blockReason: 'verify_config' }
+      }
+      if (loopConfig.requireVerificationPass && !verifyResultsAvailable) {
+        return { action: 'block', reason: 'Verification required but no verify results are available', blockReason: 'verify_config' }
+      }
+      if (verificationSatisfied) {
+        return { action: 'publish', reason: 'Verification passed in no-review workflow' }
+      }
+      if (ctx.iteration >= maxReviewIter) {
+        return { action: 'block', reason: `Max review iterations reached: ${ctx.iteration}/${maxReviewIter}`, blockReason: 'iteration_limit' }
+      }
+      return {
+        action: 'iterate',
+        reason: 'Verification failed in no-review workflow — retrying',
+        findings: [],
+      }
+    }
+
     // Rules 8, 9
     if (loopConfig.blockOnAmbiguousReview) {
       return { action: 'block', reason: 'Review output not parseable and blockOnAmbiguousReview is true', blockReason: 'ambiguous_review' }

--- a/src/loop/step-executor.ts
+++ b/src/loop/step-executor.ts
@@ -169,10 +169,12 @@ export async function executeVerifyStep(
  */
 export async function executeDecideStep(
   ctx: RunContext,
-  _step: DecideStep,
+  step: DecideStep,
   deps: StepDependencies,
 ): Promise<StepResult> {
-  const decision = decide(ctx, deps.config.loop, deps.config.security)
+  const decision = decide(ctx, deps.config.loop, deps.config.security, {
+    requireReview: step.requireReview,
+  })
   return { ctx, decision }
 }
 

--- a/src/loop/workflow.ts
+++ b/src/loop/workflow.ts
@@ -2,6 +2,9 @@ import type { Config, RepoConfig } from '../config/schema.js'
 import type { TriageLevel } from '../discovery/triage.js'
 import { isPlanningIssue } from '../planning/mode.js'
 
+export type WorkflowRoleName = 'planner' | 'coder' | 'reviewer'
+export type WorkflowAgentName = 'claude' | 'codex'
+
 export type WorkerStep = {
   type: 'worker'
   id: string
@@ -21,12 +24,15 @@ export type DecideStep = {
   type: 'decide'
   id: string
   onIterate: string
+  requireReview?: boolean
 }
 
 export type WorkflowStep = WorkerStep | VerifyStep | DecideStep
 
 export interface ResolvedWorkflow {
   steps: WorkflowStep[]
+  roles?: Partial<Record<WorkflowRoleName, WorkflowAgentName>>
+  agents?: Record<string, string>
 }
 
 export const DEFAULT_WORKFLOW: ResolvedWorkflow = {
@@ -37,6 +43,18 @@ export const DEFAULT_WORKFLOW: ResolvedWorkflow = {
     { type: 'worker', id: 'review', role: 'reviewer' },
     { type: 'decide', id: 'decide', onIterate: 'code' },
   ],
+}
+
+export const LIGHTWEIGHT_WORKFLOW: ResolvedWorkflow = {
+  steps: [
+    { type: 'worker', id: 'code', role: 'coder' },
+    { type: 'verify', id: 'verify' },
+    { type: 'decide', id: 'decide', onIterate: 'code', requireReview: false },
+  ],
+  roles: {
+    coder: 'codex',
+    reviewer: 'codex',
+  },
 }
 
 export const PLANNING_ONLY_WORKFLOW: ResolvedWorkflow = {
@@ -55,15 +73,35 @@ export function resolveWorkflow(
   repoConfig: RepoConfig,
   config: Config,
   issueLabels: string[],
-  _triageLevel: TriageLevel,
+  triageLevel: TriageLevel,
 ): ResolvedWorkflow {
   if (isPlanningIssue(issueLabels, repoConfig)) return PLANNING_ONLY_WORKFLOW
 
+  const triageWorkflow = triageLevel === 'trivial' || triageLevel === 'standard'
+    ? repoConfig.workflowByTriage?.[triageLevel]
+    : undefined
+  if (triageWorkflow) {
+    const resolved = resolveConfiguredWorkflow(config, triageWorkflow)
+    if (resolved) return resolved
+  }
+
   const workflowName = repoConfig.workflow
-  if (!workflowName) return DEFAULT_WORKFLOW
+  if (workflowName) {
+    const resolved = resolveConfiguredWorkflow(config, workflowName)
+    if (resolved) return resolved
+  }
 
+  if (triageLevel === 'trivial') return LIGHTWEIGHT_WORKFLOW
+  return DEFAULT_WORKFLOW
+}
+
+function resolveConfiguredWorkflow(config: Config, workflowName: string): ResolvedWorkflow | null {
   const workflow = config.workflows[workflowName]
-  if (!workflow) return DEFAULT_WORKFLOW
+  if (!workflow) return null
 
-  return { steps: workflow.steps as WorkflowStep[] }
+  return {
+    steps: workflow.steps as WorkflowStep[],
+    ...(workflow.roles ? { roles: workflow.roles } : {}),
+    ...(workflow.agents ? { agents: workflow.agents } : {}),
+  }
 }

--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -18,7 +18,7 @@ import {
 } from '../environment/manager.js'
 import { createWorkerAdapter } from '../workers/factory.js'
 import { executeLoop } from '../loop/engine.js'
-import { resolveWorkflow } from '../loop/workflow.js'
+import { resolveWorkflow, type ResolvedWorkflow } from '../loop/workflow.js'
 import { publishPR } from '../publishing/publisher.js'
 import { MergeConflictError } from '../publishing/push.js'
 import { transitionLabels } from '../labels/manager.js'
@@ -225,92 +225,105 @@ export async function pollOnce(
                 let activeWorktreePath: string | null = null
 
                 try {
-                const resolvedRoles = resolveRoles(discoveredIssue.issue.labels, repoConfig.defaults)
-                const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, discoveredIssue.issue.number)
-                const replayableRun = queuedRun
-                  ? null
-                  : selectReplayableRun(runManager.getByRepoAndIssue(repoConfig.repo, discoveredIssue.issue.number))
-                const activeRun = queuedRun ?? replayableRun
-                const roles = activeRun
-                  ? {
-                      planner: coerceAgentName(activeRun.planner, resolvedRoles.planner),
-                      coder: coerceAgentName(activeRun.coder, resolvedRoles.coder),
-                      reviewer: coerceAgentName(activeRun.reviewer, resolvedRoles.reviewer),
-                    }
-                  : resolvedRoles
-                const slug = getOrPinSlug(db, repoConfig.repo, discoveredIssue.issue.number, discoveredIssue.issue.title)
-                const branch = branchName(repoConfig.branchPrefix, discoveredIssue.issue.number, slug)
-                const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, discoveredIssue.issue.number)
-                activeWorktreePath = worktreePath
-
-                const run = activeRun ?? runManager.create({
-                  repo: repoConfig.repo,
-                  issueNumber: discoveredIssue.issue.number,
-                  issueTitle: discoveredIssue.issue.title,
-                  issueNodeId: discoveredIssue.issue.nodeId,
-                  planner: roles.planner,
-                  coder: roles.coder,
-                  reviewer: roles.reviewer,
-                })
-                const previousRunStatus = run.status
-                if (replayableRun) {
-                  logger.info(
-                    { repo: repoConfig.repo, issue: discoveredIssue.issue.number, runId: run.id, status: replayableRun.status },
-                    'Re-queuing active run for rediscovered ready issue',
+                  const workflow = resolveWorkflow(
+                    repoConfig,
+                    config,
+                    discoveredIssue.issue.labels,
+                    discoveredIssue.triage.level,
                   )
-                }
-                runId = run.id
-                runManager.update(run.id, {
-                  status: 'running',
-                  issueTitle: discoveredIssue.issue.title,
-                  branchName: branch,
-                  branchSlug: slug,
-                  worktreePath,
-                  phaseData: {
-                    ...(run.phaseData ?? {}),
+                  const repoConfigForRun = applyWorkflowAgentOverrides(repoConfig, workflow)
+                  const roleDefaults = applyWorkflowRoleDefaults(
+                    repoConfigForRun.defaults,
+                    workflow,
+                    repoConfigForRun,
+                    config,
+                  )
+                  const resolvedRoles = resolveRoles(discoveredIssue.issue.labels, roleDefaults)
+                  const queuedRun = runManager.getLatestQueuedByIssue(repoConfig.repo, discoveredIssue.issue.number)
+                  const replayableRun = queuedRun
+                    ? null
+                    : selectReplayableRun(runManager.getByRepoAndIssue(repoConfig.repo, discoveredIssue.issue.number))
+                  const activeRun = queuedRun ?? replayableRun
+                  const roles = activeRun
+                    ? {
+                        planner: coerceAgentName(activeRun.planner, resolvedRoles.planner),
+                        coder: coerceAgentName(activeRun.coder, resolvedRoles.coder),
+                        reviewer: coerceAgentName(activeRun.reviewer, resolvedRoles.reviewer),
+                      }
+                    : resolvedRoles
+                  const slug = getOrPinSlug(db, repoConfig.repo, discoveredIssue.issue.number, discoveredIssue.issue.title)
+                  const branch = branchName(repoConfig.branchPrefix, discoveredIssue.issue.number, slug)
+                  const worktreePath = buildWorktreePath(config.storage.worktreeRoot, repoConfig.repo, discoveredIssue.issue.number)
+                  activeWorktreePath = worktreePath
+
+                  const run = activeRun ?? runManager.create({
+                    repo: repoConfig.repo,
+                    issueNumber: discoveredIssue.issue.number,
+                    issueTitle: discoveredIssue.issue.title,
+                    issueNodeId: discoveredIssue.issue.nodeId,
+                    planner: roles.planner,
+                    coder: roles.coder,
+                    reviewer: roles.reviewer,
+                  })
+                  const previousRunStatus = run.status
+                  if (replayableRun) {
+                    logger.info(
+                      { repo: repoConfig.repo, issue: discoveredIssue.issue.number, runId: run.id, status: replayableRun.status },
+                      'Re-queuing active run for rediscovered ready issue',
+                    )
+                  }
+                  runId = run.id
+                  runManager.update(run.id, {
+                    status: 'running',
+                    issueTitle: discoveredIssue.issue.title,
+                    branchName: branch,
+                    branchSlug: slug,
+                    worktreePath,
+                    phaseData: {
+                      ...(run.phaseData ?? {}),
+                      issueRepo,
+                    },
+                    endedAt: null,
+                    lastError: null,
+                    blockReason: null,
+                  })
+
+                  // Label transition
+                  await transitionLabels(
+                    forge,
                     issueRepo,
-                  },
-                  endedAt: null,
-                  lastError: null,
-                  blockReason: null,
-                })
+                    discoveredIssue.issue.number,
+                    discoveredIssue.issue.labels,
+                    previousRunStatus,
+                    'running',
+                    buildLabelConfig(repoConfig, discoveredIssue.issue.labels),
+                  )
 
-                // Label transition
-                await transitionLabels(
-                  forge,
-                  issueRepo,
-                  discoveredIssue.issue.number,
-                  discoveredIssue.issue.labels,
-                  previousRunStatus,
-                  'running',
-                  buildLabelConfig(repoConfig, discoveredIssue.issue.labels),
-                )
+                  // Notify
+                  await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
 
-                // Notify
-                await notifier.dispatch(makePayload('run_started', repoConfig.repo, discoveredIssue.issue))
+                  // Detect if this queued run needs a forced branch reset (e.g., after merge conflict)
+                  const forceReset = activeRun?.blockReason === 'merge_conflict'
 
-                // Detect if this queued run needs a forced branch reset (e.g., after merge conflict)
-                const forceReset = activeRun?.blockReason === 'merge_conflict'
+                  // Detect rebase mode from queued run's phaseData
+                  // If force-resetting, ignore stale rebase context — we're starting fresh
+                  const reactionType = activeRun?.phaseData?.reactionType
+                  const isRebaseRun = !forceReset && (reactionType === 'rebase' || reactionType === 'merge_conflict')
+                  const followupPromptFeedback = extractFollowupPromptFeedback(activeRun?.phaseData)
 
-                // Detect rebase mode from queued run's phaseData
-                // If force-resetting, ignore stale rebase context — we're starting fresh
-                const reactionType = activeRun?.phaseData?.reactionType
-                const isRebaseRun = !forceReset && (reactionType === 'rebase' || reactionType === 'merge_conflict')
-                const followupPromptFeedback = extractFollowupPromptFeedback(activeRun?.phaseData)
+                  // Check if prior run left tainted work that should be discarded
+                  // Never reset to base for rebase runs — we need the existing branch
+                  const planningMode = isPlanningIssue(discoveredIssue.issue.labels, repoConfigForRun)
+                  const resetToBase = forceReset || (!isRebaseRun && (planningMode || shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)))
 
-                // Check if prior run left tainted work that should be discarded
-                // Never reset to base for rebase runs — we need the existing branch
-                const planningMode = isPlanningIssue(discoveredIssue.issue.labels, repoConfig)
-                const resetToBase = forceReset || (!isRebaseRun && (planningMode || shouldResetBranch(runManager, repoConfig.repo, discoveredIssue.issue.number, run.id)))
-
-                // Create worktree
-                await worktreeManager.ensure({
-                  repoLocalPath: repoConfig.localPath,
-                  baseBranch: repoConfig.baseBranch,
-                  branchName: branch,
-                  worktreePath,
-                  resetToBase,
-                })
+                  // Create worktree
+                  await worktreeManager.ensure({
+                    repoLocalPath: repoConfig.localPath,
+                    baseBranch: repoConfig.baseBranch,
+                    branchName: branch,
+                    worktreePath,
+                    resetToBase,
+                  })
 
                 // Execute rebase if this is a rebase-queued run
                 if (isRebaseRun) {
@@ -419,27 +432,39 @@ export async function pollOnce(
                   logger.info({ repo: repoConfig.repo, issue: discoveredIssue.issue.number }, 'Rebase done but verify failed — entering code loop to fix')
                 }
 
-                if (repoConfig.environment) {
-                  const mode = resolveEnvironmentMode(discoveredIssue.issue.labels, repoConfig)
+                if (repoConfigForRun.environment) {
+                  const mode = resolveEnvironmentMode(discoveredIssue.issue.labels, repoConfigForRun)
                   envSetup = await setupEnvironment({
                     worktreePath,
                     issueNumber: discoveredIssue.issue.number,
-                    repoConfig,
+                    repoConfig: repoConfigForRun,
                     mode,
                     usedPorts: usedPortsInPass,
                   })
                 }
 
                 // Get worker adapters
-                const adjustedLimits = adjustLimitsForTriage(
-                  config.loop,
-                  config.workerProfiles[repoConfig.agents[roles.planner] ?? '']?.workerTimeoutSeconds ?? 1800,
-                  discoveredIssue.triage,
+                const plannerProfile = resolveWorkerProfileForAgent(
+                  roles.planner,
+                  repoConfigForRun,
+                  config,
+                )
+                const coderProfile = resolveWorkerProfileForAgent(
+                  roles.coder,
+                  repoConfigForRun,
+                  config,
+                )
+                const reviewerProfile = resolveWorkerProfileForAgent(
+                  roles.reviewer,
+                  repoConfigForRun,
+                  config,
                 )
 
-                const plannerProfile = config.workerProfiles[repoConfig.agents[roles.planner] ?? '']
-                const coderProfile = config.workerProfiles[repoConfig.agents[roles.coder] ?? '']
-                const reviewerProfile = config.workerProfiles[repoConfig.agents[roles.reviewer] ?? '']
+                const adjustedLimits = adjustLimitsForTriage(
+                  config.loop,
+                  plannerProfile?.workerTimeoutSeconds ?? 1800,
+                  discoveredIssue.triage,
+                )
 
                 if (!plannerProfile || !coderProfile || !reviewerProfile) {
                   throw new Error('Missing worker profiles for resolved roles')
@@ -451,7 +476,7 @@ export async function pollOnce(
                   issueRepo,
                   issueNumber: discoveredIssue.issue.number,
                   issue: discoveredIssue.issue,
-                  repoConfig,
+                  repoConfig: repoConfigForRun,
                   roles,
                   triageResult: discoveredIssue.triage,
                   adjustedLimits,
@@ -466,7 +491,7 @@ export async function pollOnce(
                   iteration: 1,
                   totalAgentPasses: 0,
                   estimatedCostUsd: 0,
-                  currentPhase: 'plan',
+                  currentPhase: workflow.steps[0]?.id ?? 'plan',
                   terminalStatus: 'running',
                   phaseHistory: [],
                   dryRun: false,
@@ -507,7 +532,7 @@ export async function pollOnce(
                         coder: createWorkerAdapter(coderProfile),
                         reviewer: createWorkerAdapter(reviewerProfile),
                       },
-                      workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
+                      workflow,
                       envOverrides: envSetup?.envOverrides ?? {},
                       metrics,
                       onAgentEvent: (event: AgentEvent) => observability.record(event),
@@ -570,7 +595,7 @@ export async function pollOnce(
                     coder: createWorkerAdapter(coderProfile),
                     reviewer: createWorkerAdapter(reviewerProfile),
                   },
-                  workflow: resolveWorkflow(repoConfig, config, discoveredIssue.issue.labels, discoveredIssue.triage.level),
+                  workflow,
                   envOverrides: envSetup?.envOverrides ?? {},
                   metrics,
                   onAgentEvent: (event) => observability.record(event),
@@ -1020,6 +1045,69 @@ function coerceAgentName(
     return value
   }
   return fallback
+}
+
+function applyWorkflowAgentOverrides(
+  repoConfig: Config['repos'][number],
+  workflow: ResolvedWorkflow,
+): Config['repos'][number] {
+  if (!workflow.agents || Object.keys(workflow.agents).length === 0) {
+    return repoConfig
+  }
+
+  return {
+    ...repoConfig,
+    agents: {
+      ...repoConfig.agents,
+      ...workflow.agents,
+    },
+  }
+}
+
+function applyWorkflowRoleDefaults(
+  repoDefaults: Config['repos'][number]['defaults'],
+  workflow: ResolvedWorkflow,
+  repoConfig: Config['repos'][number],
+  config: Config,
+): Config['repos'][number]['defaults'] {
+  if (!workflow.roles) {
+    return repoDefaults
+  }
+
+  const merged: Config['repos'][number]['defaults'] = {
+    ...repoDefaults,
+    ...workflow.roles,
+  }
+
+  for (const role of ['planner', 'coder', 'reviewer'] as const) {
+    const preferredAgent = merged[role]
+    if (canResolveAgent(preferredAgent, repoConfig, config)) continue
+    merged[role] = repoDefaults[role]
+  }
+
+  return merged
+}
+
+function canResolveAgent(
+  agent: Config['repos'][number]['defaults']['planner'],
+  repoConfig: Config['repos'][number],
+  config: Config,
+): boolean {
+  return resolveWorkerProfileForAgent(agent, repoConfig, config) !== null
+}
+
+function resolveWorkerProfileForAgent(
+  agent: Config['repos'][number]['defaults']['planner'],
+  repoConfig: Config['repos'][number],
+  config: Config,
+): Config['workerProfiles'][string] | null {
+  const mappedProfileName = repoConfig.agents[agent]
+  if (mappedProfileName) {
+    const mappedProfile = config.workerProfiles[mappedProfileName]
+    if (mappedProfile) return mappedProfile
+  }
+
+  return Object.values(config.workerProfiles).find((profile) => profile.type === agent) ?? null
 }
 
 function buildBlockReason(ctx: RunContext): string {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -143,6 +143,10 @@ interface ProjectRepoSummary {
   }
   agents: Record<string, string>
   workflow?: string
+  workflowByTriage?: {
+    trivial?: string
+    standard?: string
+  }
   mergeQueue: {
     enabled: boolean
     batchSize: number
@@ -1113,6 +1117,7 @@ function sanitizeProjectRepo(repo: RepoConfig): ProjectRepoSummary {
     },
     agents: { ...repo.agents },
     ...(repo.workflow ? { workflow: repo.workflow } : {}),
+    ...(repo.workflowByTriage ? { workflowByTriage: { ...repo.workflowByTriage } } : {}),
     mergeQueue: {
       enabled: repo.mergeQueue.enabled,
       batchSize: repo.mergeQueue.batchSize,

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resolveConfigPath } from '../../src/config/loader.js'
+import { loadConfig, resolveConfigPath } from '../../src/config/loader.js'
 
 describe('resolveConfigPath', () => {
   const originalCwd = process.cwd()
@@ -71,5 +71,65 @@ describe('resolveConfigPath', () => {
     const expected = join(tmpDir, '.night-orch.yaml')
     writeFileSync(expected, 'version: 1\nrepos: []\n')
     expect(resolveConfigPath(undefined, { trustWorkspace: true })).toBe(expected)
+  })
+
+  it('loadConfig rejects unknown workflow agent profile references', () => {
+    const configPath = join(tmpDir, 'config.yaml')
+    writeFileSync(configPath, `version: 1
+github:
+  tokenEnv: GITHUB_TOKEN
+workerProfiles:
+  claude-default:
+    type: claude
+    command: claude
+repos:
+  - repo: org/repo
+    localPath: /tmp/repo
+workflows:
+  fast-trivial:
+    agents:
+      codex: codex-fast
+    steps:
+      - type: worker
+        id: code
+        role: coder
+      - type: decide
+        id: decide
+        onIterate: code
+`)
+
+    expect(() => loadConfig(configPath)).toThrow('Workflow fast-trivial: agent "codex" references unknown worker profile "codex-fast"')
+  })
+
+  it('loadConfig accepts workflow agent profile references when profiles exist', () => {
+    const configPath = join(tmpDir, 'config.yaml')
+    writeFileSync(configPath, `version: 1
+github:
+  tokenEnv: GITHUB_TOKEN
+workerProfiles:
+  claude-default:
+    type: claude
+    command: claude
+  codex-fast:
+    type: codex
+    command: codex
+repos:
+  - repo: org/repo
+    localPath: /tmp/repo
+workflows:
+  fast-trivial:
+    agents:
+      codex: codex-fast
+    steps:
+      - type: worker
+        id: code
+        role: coder
+      - type: decide
+        id: decide
+        onIterate: code
+`)
+
+    const loaded = loadConfig(configPath)
+    expect(loaded.workflows['fast-trivial']?.agents?.['codex']).toBe('codex-fast')
   })
 })

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -226,4 +226,48 @@ describe('ConfigSchema', () => {
     const result = ConfigSchema.safeParse(raw)
     expect(result.success).toBe(false)
   })
+
+  it('accepts triage workflow routing with workflow role/profile overrides', () => {
+    const raw = loadExampleConfig()
+    raw.workflows = {
+      'fast-trivial': {
+        roles: {
+          coder: 'codex',
+          reviewer: 'codex',
+        },
+        agents: {
+          codex: 'codex-default',
+        },
+        steps: [
+          { type: 'worker', id: 'code', role: 'coder' },
+          { type: 'verify', id: 'verify' },
+          { type: 'decide', id: 'decide', onIterate: 'code', requireReview: false },
+        ],
+      },
+    }
+    raw.repos[0].workflowByTriage = { trivial: 'fast-trivial' }
+
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.repos[0]?.workflowByTriage?.trivial).toBe('fast-trivial')
+      expect(result.data.workflows['fast-trivial']?.roles?.coder).toBe('codex')
+      expect(result.data.workflows['fast-trivial']?.agents?.['codex']).toBe('codex-default')
+      const decideStep = result.data.workflows['fast-trivial']?.steps[2]
+      if (decideStep && decideStep.type === 'decide') {
+        expect(decideStep.requireReview).toBe(false)
+      }
+    }
+  })
+
+  it('rejects unsupported workflowByTriage keys', () => {
+    const raw = loadExampleConfig()
+    raw.repos[0].workflowByTriage = {
+      trivial: 'fast-trivial',
+      architectural: 'full',
+    }
+
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(false)
+  })
 })

--- a/test/loop/decision.test.ts
+++ b/test/loop/decision.test.ts
@@ -170,6 +170,24 @@ describe('decide', () => {
     expect(d.action).toBe('iterate')
   })
 
+  it('no-review workflow + verify pass → publish', () => {
+    const ctx = makeCtx({
+      reviewResult: null,
+      verifyResults: [{ command: 'test', exitCode: 0, stdout: '', stderr: '', durationMs: 100, passed: true }],
+    })
+    const d = decide(ctx, loopConfig, securityConfig, { requireReview: false })
+    expect(d.action).toBe('publish')
+  })
+
+  it('no-review workflow + verify fail → iterate', () => {
+    const ctx = makeCtx({
+      reviewResult: null,
+      verifyResults: [{ command: 'test', exitCode: 1, stdout: '', stderr: 'FAIL', durationMs: 100, passed: false }],
+    })
+    const d = decide(ctx, loopConfig, securityConfig, { requireReview: false })
+    expect(d.action).toBe('iterate')
+  })
+
   it('cost over budget → block', () => {
     const ctx = makeCtx({
       estimatedCostUsd: 15,

--- a/test/loop/workflow.test.ts
+++ b/test/loop/workflow.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { resolveWorkflow, DEFAULT_WORKFLOW, PLANNING_ONLY_WORKFLOW } from '../../src/loop/workflow.js'
+import {
+  resolveWorkflow,
+  DEFAULT_WORKFLOW,
+  LIGHTWEIGHT_WORKFLOW,
+  PLANNING_ONLY_WORKFLOW,
+} from '../../src/loop/workflow.js'
 import type { Config, RepoConfig } from '../../src/config/schema.js'
 
 function makeRepoConfig(overrides: Partial<RepoConfig> = {}): RepoConfig {
@@ -37,9 +42,14 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 }
 
 describe('resolveWorkflow', () => {
-  it('returns DEFAULT_WORKFLOW when no workflow configured', () => {
+  it('returns DEFAULT_WORKFLOW for standard issues when no workflow configured', () => {
     const result = resolveWorkflow(makeRepoConfig(), makeConfig(), [], 'standard')
     expect(result).toBe(DEFAULT_WORKFLOW)
+  })
+
+  it('returns LIGHTWEIGHT_WORKFLOW for trivial issues when no workflow configured', () => {
+    const result = resolveWorkflow(makeRepoConfig(), makeConfig(), [], 'trivial')
+    expect(result).toBe(LIGHTWEIGHT_WORKFLOW)
   })
 
   it('returns DEFAULT_WORKFLOW when named workflow not found', () => {
@@ -68,6 +78,26 @@ describe('resolveWorkflow', () => {
     )
     expect(result.steps).toHaveLength(3)
     expect(result.steps[0]!.id).toBe('code')
+  })
+
+  it('returns triage-mapped workflow when configured', () => {
+    const fastWorkflow = {
+      steps: [
+        { type: 'worker' as const, id: 'code', role: 'coder' },
+        { type: 'decide' as const, id: 'decide', onIterate: 'code', requireReview: false },
+      ],
+      roles: { coder: 'codex' as const },
+      agents: { codex: 'codex-fast' },
+    }
+    const result = resolveWorkflow(
+      makeRepoConfig({ workflowByTriage: { trivial: 'fast-trivial' } }),
+      makeConfig({ workflows: { 'fast-trivial': fastWorkflow } }),
+      [],
+      'trivial',
+    )
+    expect(result.steps).toHaveLength(2)
+    expect(result.roles?.coder).toBe('codex')
+    expect(result.agents?.['codex']).toBe('codex-fast')
   })
 
   it('returns PLANNING_ONLY_WORKFLOW when planning label is present', () => {

--- a/test/poller/poller.test.ts
+++ b/test/poller/poller.test.ts
@@ -214,6 +214,101 @@ describe('pollOnce', () => {
     expect(typeof result.errors).toBe('number')
   })
 
+  it('trivial issues use lightweight workflow and fallback codex profile-by-type when agent mapping is missing', async () => {
+    mockDiscoverEligibleIssues.mockResolvedValue([{
+      issue: { number: 1, nodeId: '', title: 'Tiny fix', body: 'Fix typo', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+      triage: { level: 'trivial', reason: 'Short body with trivial label' },
+    }])
+    mockExecuteLoop.mockResolvedValue({
+      currentPhase: 'publish',
+      terminalStatus: 'blocked',
+    })
+
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    config.workerProfiles['codex-fast'] = {
+      type: 'codex',
+      command: 'codex',
+      args: ['exec'],
+      workerTimeoutSeconds: 1200,
+      minimalEnv: true,
+      runtimeWrapper: null,
+      env: {},
+    }
+    config.repos[0]!.agents = { claude: 'claude' }
+
+    const result = await pollOnce(config, db, false)
+
+    expect(result.errors).toBe(0)
+    expect(mockExecuteLoop).toHaveBeenCalledTimes(1)
+    const initialCtx = mockExecuteLoop.mock.calls[0]?.[0] as {
+      roles: { coder: string }
+      repoConfig: { agents: Record<string, string> }
+    }
+    const loopDeps = mockExecuteLoop.mock.calls[0]?.[1] as {
+      workflow: { steps: Array<{ id: string }>; }
+    }
+    expect(initialCtx.roles.coder).toBe('codex')
+    expect(initialCtx.repoConfig.agents['codex']).toBeUndefined()
+    expect(loopDeps.workflow.steps.map((step) => step.id)).toEqual(['code', 'verify', 'decide'])
+  })
+
+  it('applies workflowByTriage role and agent overrides during run setup', async () => {
+    mockDiscoverEligibleIssues.mockResolvedValue([{
+      issue: { number: 1, nodeId: '', title: 'Tiny fix', body: 'Fix typo', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+      triage: { level: 'trivial', reason: 'Short body with trivial label' },
+    }])
+    mockExecuteLoop.mockResolvedValue({
+      currentPhase: 'publish',
+      terminalStatus: 'blocked',
+    })
+
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    config.workerProfiles['codex-fast'] = {
+      type: 'codex',
+      command: 'codex',
+      args: ['exec'],
+      workerTimeoutSeconds: 900,
+      minimalEnv: true,
+      runtimeWrapper: null,
+      env: {},
+    }
+    config.workflows = {
+      'fast-trivial': {
+        roles: {
+          coder: 'codex',
+          reviewer: 'codex',
+        },
+        agents: {
+          codex: 'codex-fast',
+        },
+        steps: [
+          { type: 'worker', id: 'code', role: 'coder' },
+          { type: 'verify', id: 'verify' },
+          { type: 'decide', id: 'decide', onIterate: 'code', requireReview: false },
+        ],
+      },
+    }
+    config.repos[0]!.workflowByTriage = { trivial: 'fast-trivial' }
+
+    const result = await pollOnce(config, db, false)
+
+    expect(result.errors).toBe(0)
+    expect(mockExecuteLoop).toHaveBeenCalledTimes(1)
+    const initialCtx = mockExecuteLoop.mock.calls[0]?.[0] as {
+      roles: { coder: string; reviewer: string }
+      repoConfig: { agents: Record<string, string> }
+    }
+    const loopDeps = mockExecuteLoop.mock.calls[0]?.[1] as {
+      workflow: { agents?: Record<string, string>; roles?: Record<string, string>; steps: Array<{ id: string }> }
+    }
+    expect(initialCtx.roles.coder).toBe('codex')
+    expect(initialCtx.roles.reviewer).toBe('codex')
+    expect(initialCtx.repoConfig.agents['codex']).toBe('codex-fast')
+    expect(loopDeps.workflow.agents?.['codex']).toBe('codex-fast')
+    expect(loopDeps.workflow.roles?.['coder']).toBe('codex')
+    expect(loopDeps.workflow.steps.map((step) => step.id)).toEqual(['code', 'verify', 'decide'])
+  })
+
   it('uses terminalStatus for blocked runs even when currentPhase is publish', async () => {
     mockDiscoverEligibleIssues.mockResolvedValue([{
       issue: { number: 1, nodeId: '', title: 'Test', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },


### PR DESCRIPTION
Closes #85

## Plan
**Objective:** Implement triage-driven workflow selection so trivial issues use lightweight workflows (fewer phases, faster models) while complex issues retain the full pipeline

1. Add QUICK_WORKFLOW (a lightweight built-in workflow: code → verify → decide, no planning or review step) and THOROUGH_WORKFLOW (plan → code → verify → review → decide with no skipWhen, for complex issues). Export these alongside DEFAULT_WORKFLOW and PLANNING_ONLY_WORKFLOW.
2. Extend the config schema to support per-triage-level workflow overrides on repos: add an optional 'workflowByTriage' field (Record<TriageLevel, string>) to RepoConfigSchema. Also add optional 'defaultsByTriage' field (Record<TriageLevel, Partial<DefaultsSchema>>) for per-triage agent overrides. This allows config like workflowByTriage: { trivial: 'quick', architectural: 'thorough' } and defaultsByTriage: { trivial: { coder: 'codex' } }.
3. Update resolveWorkflow to use the triageLevel parameter: check repoConfig.workflowByTriage[triageLevel] first, then fall back to repoConfig.workflow, then DEFAULT_WORKFLOW. Also add built-in workflow name resolution: 'quick' → QUICK_WORKFLOW, 'default' → DEFAULT_WORKFLOW, 'thorough' → THOROUGH_WORKFLOW, before looking in config.workflows.
4. Update resolveRoles in src/discovery/roles.ts to accept triageLevel and check repoConfig.defaultsByTriage[triageLevel] for agent overrides before falling back to repoConfig.defaults. This allows trivial issues to use faster/cheaper models.
5. Update the poller in src/runner/poller.ts to pass triageLevel when calling resolveRoles and resolveWorkflow. The triageLevel is already available from discoveredIssue.triage.level.
6. Add the built-in workflow definitions ('quick', 'default', 'thorough') to config.example.yaml and document the new workflowByTriage and defaultsByTriage fields in docs/CONFIGURATION.md.
7. Update workflow tests: test resolveWorkflow with triageLevel-based selection, built-in workflow name resolution, priority order (workflowByTriage > workflow > DEFAULT_WORKFLOW). Add tests for QUICK_WORKFLOW and THOROUGH_WORKFLOW step structures.
8. Update triage and roles tests: add tests for defaultsByTriage in resolveRoles, verifying triage-level overrides take precedence over base defaults.
9. Run pnpm typecheck && pnpm lint && pnpm test to verify everything compiles and passes.

## Implementation
Completed the retry and addressed all review findings. I unified poller agent/profile resolution with a single fallback-aware path (`resolveWorkerProfileForAgent`) so lightweight trivial runs can safely use codex-by-type even without `repos[].agents.codex`, and reused that same path for role-resolvability checks. I extended config-load validation to verify `workflows[*].agents` references against `workerProfiles`, preventing deferred runtime failures. I added poller integration tests for (a) trivial lightweight routing with missing codex mapping fallback and (b) `workflowByTriage` role/agent overrides, plus loader tests for invalid/valid workflow agent refs. For the architectural-routing mismatch, I made `workflowByTriage` explicitly support only `trivial` and `standard`, made the schema strict (unsupported keys now fail validation), updated docs accordingly, and removed `architectural` from the web snapshot type to avoid advertising a no-op key. All targeted tests, typecheck, and lint pass.

**Changed files:**
- `docs/CONFIGURATION.md`
- `docs/USAGE.md`
- `examples/config.example.yaml`
- `src/config/loader.ts`
- `src/config/schema.ts`
- `src/loop/decision.ts`
- `src/loop/step-executor.ts`
- `src/loop/workflow.ts`
- `src/runner/poller.ts`
- `src/web/server.ts`
- `test/config/loader.test.ts`
- `test/config/schema.test.ts`
- `test/loop/decision.test.ts`
- `test/loop/workflow.test.ts`
- `test/poller/poller.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all modified files in full plus adjacent workflow/loop code paths, and verified the new tests and runtime flow. The prior major concerns are addressed: workflow-level agent profile refs are now validated at config load, role/profile resolvability now uses a consistent fallback-by-type path in poller setup, workflowByTriage is constrained to supported keys (trivial/standard), and poller integration tests now cover trivial lightweight routing and workflowByTriage role/agent overrides. I also re-ran verification (`pnpm typecheck`, `pnpm lint`, `pnpm test`) and all passed.

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex