### PR TITLE
[CHORE] Settings (night-orch / #96)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,33 @@ Recommended deployment uses a dedicated non-root user (for example `orch`) with:
 - code in `/home/orch/apps/night-orch`
 - target repos in `/home/orch/repos/*`
 
+## Runtime Settings Overrides (DB-backed)
+
+Night-orch supports a curated set of runtime overrides stored in SQLite (`settings_overrides` table).  
+Effective config precedence is:
+
+1. YAML value (or schema default when omitted)
+2. DB override (if present)
+
+Overrides are persisted in DB and survive process restarts. They are not written back to YAML.
+
+Curated runtime keys:
+
+| Key | Type | Accepted Range |
+| --- | --- | --- |
+| `github.pollIntervalSeconds` | integer | `5..3600` |
+| `security.maxDailyCostUsd` | number | `1..10000` |
+| `loop.maxReviewIterations` | integer | `1..20` |
+| `loop.maxTotalAgentPasses` | integer | `1..50` |
+| `observability.agentStreaming` | boolean | `true`/`false` |
+
+Update surfaces:
+
+- CLI: `night-orch settings list|set|unset`
+- MCP: `night-orch-list-settings`, `night-orch-set-setting`, `night-orch-clear-setting`
+- Web: Settings page (`/api/settings`, `/api/operations/settings/*`)
+- TUI: `settings` tab (hotkey `5`)
+
 ## YAML Conventions
 
 - `version` must be exactly `1`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -369,7 +369,7 @@ Options: `--config`, `--trust-workspace`, `--dry-run`, `--log-level`
 
 Start the embedded web control surface. Serves the React/Tailwind frontend, a REST API under `/api/*`, and a WebSocket stream endpoint at `/ws`.
 
-By default, `web` runs in attach mode: no poll loop, no metrics server, and no embedded MCP server are started in the web process. Manual web operations (`poll`, `sync`, `cleanup`, `retry`, `continue`, `rebase`, `delete entry`) remain available and execute in the web process.
+By default, `web` runs in attach mode: no poll loop, no metrics server, and no embedded MCP server are started in the web process. Manual web operations (`poll`, `sync`, `cleanup`, `retry`, `continue`, `rebase`, `delete entry`, runtime settings set/clear) remain available and execute in the web process.
 Use `--standalone` to run poller + metrics + embedded MCP in the same process as the web server.
 
 Default bind is `127.0.0.1:3200`. Use `--host` / `--port` to change this (for example when reverse-proxying through Caddy or nginx). Use `--allowed-host` (repeatable) to permit additional Host/Origin values when proxying.
@@ -396,7 +396,15 @@ Show current state: active runs, active leases, daily cost against budget, recen
 
 ### `night-orch tui`
 
-Live-updating terminal dashboard. Refreshes every 2 seconds. Shows active runs, merge queue, cost bar, recent history, and issue actions (`poll`, `sync`, `cleanup`, `retry`, `retry fresh`, `continue`, `rebase`, `delete entry`). Press Ctrl+C to exit.
+Live-updating terminal dashboard. Refreshes every 2 seconds. Shows active runs, merge queue, cost bar, recent history, issue actions (`poll`, `sync`, `cleanup`, `retry`, `retry fresh`, `continue`, `rebase`, `delete entry`), and a Settings tab (`5`) for curated runtime overrides. Press Ctrl+C to exit.
+
+### `night-orch settings`
+
+Manage DB-backed runtime overrides for curated config keys.
+
+- `night-orch settings list [--json]`
+- `night-orch settings set <key> <value>`
+- `night-orch settings unset <key>`
 
 ### `night-orch sync`
 
@@ -434,7 +442,7 @@ Send a test notification through all configured channels. Verifies webhook URLs,
 
 ### `night-orch mcp`
 
-Start the MCP server on stdio transport (for Claude Code integration). Exposes 15 tools and 3 resources for querying and controlling night-orch.
+Start the MCP server on stdio transport (for Claude Code integration). Exposes 18 tools and 3 resources for querying and controlling night-orch.
 
 ---
 
@@ -486,10 +494,13 @@ Key metrics:
 
 Night-orch exposes an MCP server for integration with Claude Code and other MCP clients.
 
-### Tools (15)
+### Tools (18)
 
 | Tool | Description |
 |------|-------------|
+| `night-orch-list-settings` | List curated runtime settings, overrides, and effective values |
+| `night-orch-set-setting` | Set one DB-backed runtime override |
+| `night-orch-clear-setting` | Clear one DB-backed runtime override |
 | `night-orch-status` | Operational snapshot |
 | `night-orch-run-detail` | Full run history and events |
 | `night-orch-list-runs` | Filtered run listing |

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -5,6 +5,7 @@ import { createForgeAdapter } from '../../forge/factory.js'
 import { createMetricsService } from '../../metrics/service.js'
 import { createLogger, logger } from '../../utils/logger.js'
 import type { ForgeAdapter } from '../../forge/types.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -22,12 +23,12 @@ export async function mcpCommand(globalOpts?: GlobalOpts): Promise<void> {
   // In stdio mode stdout is reserved for JSON-RPC frames.
   logger.level = 'silent'
 
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       // Write to stderr — stdout is reserved for MCP stdio transport
@@ -39,17 +40,18 @@ export async function mcpCommand(globalOpts?: GlobalOpts): Promise<void> {
     return
   }
 
-  const db = initDatabase(config.storage.dbPath)
-  const metrics = config.metrics.enabled ? createMetricsService(config.metrics) : null
+  const db = initDatabase(baseConfig.storage.dbPath)
+  const runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+  const metrics = runtimeConfig.metrics.enabled ? createMetricsService(runtimeConfig.metrics) : null
 
   if (metrics) {
     await metrics.start()
   }
 
   const forgeAdapters = new Map<string, ForgeAdapter>()
-  for (const repo of config.repos) {
+  for (const repo of runtimeConfig.repos) {
     try {
-      forgeAdapters.set(repo.repo, createForgeAdapter(repo, config))
+      forgeAdapters.set(repo.repo, createForgeAdapter(repo, runtimeConfig))
     } catch (err) {
       mcpLogger.warn({ repo: repo.repo, err }, 'Failed to create forge adapter — list-issues will be unavailable for this repo')
     }
@@ -58,5 +60,5 @@ export async function mcpCommand(globalOpts?: GlobalOpts): Promise<void> {
   // All logging goes to stderr when in MCP stdio mode
   mcpLogger.info('Starting MCP server')
 
-  await startMCPStdio({ db, config, forgeAdapters, poller: null, metrics })
+  await startMCPStdio({ db, config: baseConfig, forgeAdapters, poller: null, metrics })
 }

--- a/src/cli/commands/run-once.ts
+++ b/src/cli/commands/run-once.ts
@@ -3,6 +3,7 @@ import { initDatabase } from '../../state/db.js'
 import { pollOnce } from '../../runner/poller.js'
 import { SyncEngine } from '../../ops/sync.js'
 import { logger } from '../../utils/logger.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -14,12 +15,12 @@ interface GlobalOpts {
 export async function runOnceCommand(globalOpts?: GlobalOpts): Promise<void> {
   const dryRun = globalOpts?.dryRun ?? false
 
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`Config error: ${err.message}`)
@@ -31,7 +32,8 @@ export async function runOnceCommand(globalOpts?: GlobalOpts): Promise<void> {
     return
   }
 
-  const db = initDatabase(config.storage.dbPath)
+  const db = initDatabase(baseConfig.storage.dbPath)
+  const runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
 
   try {
     // Crash recovery: release orphaned leases and reconcile stale runs.
@@ -43,7 +45,7 @@ export async function runOnceCommand(globalOpts?: GlobalOpts): Promise<void> {
         logger.info({ releasedLeases }, 'Released orphaned leases from previous run')
       }
 
-      const syncEngine = new SyncEngine(db, config)
+      const syncEngine = new SyncEngine(db, runtimeConfig)
       const syncResult = await syncEngine.reconcile(dryRun)
       if (syncResult.reconciledRuns.length > 0 || syncResult.expiredLeases > 0) {
         logger.info(
@@ -55,7 +57,7 @@ export async function runOnceCommand(globalOpts?: GlobalOpts): Promise<void> {
       logger.warn({ err }, 'Startup sync failed — continuing')
     }
 
-    const result = await pollOnce(config, db, dryRun)
+    const result = await pollOnce(runtimeConfig, db, dryRun)
     logger.info({ processed: result.processed, errors: result.errors }, 'Run-once complete')
 
     if (result.errors > 0) {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -12,6 +12,7 @@ import { startMCPHttpServer } from '../../mcp/http.js'
 import type { Server } from 'node:http'
 import type { ForgeAdapter } from '../../forge/types.js'
 import { logger } from '../../utils/logger.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -34,12 +35,12 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
     return
   }
 
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`Config error: ${err.message}\n`)
@@ -51,13 +52,13 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
     return
   }
 
-  const db = initDatabase(config.storage.dbPath)
-  const intervalMs = config.github.pollIntervalSeconds * 1000
+  const db = initDatabase(baseConfig.storage.dbPath)
+  let runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
 
   // Start metrics service
   let metrics: MetricsService | undefined
-  if (config.metrics) {
-    metrics = createMetricsService(config.metrics)
+  if (runtimeConfig.metrics) {
+    metrics = createMetricsService(runtimeConfig.metrics)
     try {
       await metrics.start()
     } catch (err) {
@@ -76,7 +77,7 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
       logger.info({ releasedLeases }, 'Released orphaned leases from previous run')
     }
 
-    const syncEngine = new SyncEngine(db, config)
+    const syncEngine = new SyncEngine(db, runtimeConfig)
     const syncResult = await syncEngine.reconcile(dryRun)
     if (syncResult.reconciledRuns.length > 0 || syncResult.expiredLeases > 0) {
       logger.info(
@@ -91,27 +92,34 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
   // Start embedded MCP HTTP/SSE server
   let mcpServer: Server | undefined
   const pollerControl = new PollCycleController()
-  if (config.mcp.enabled) {
+  if (runtimeConfig.mcp.enabled) {
     const forgeAdapters = new Map<string, ForgeAdapter>()
-    for (const repo of config.repos) {
+    for (const repo of runtimeConfig.repos) {
       try {
-        forgeAdapters.set(repo.repo, createForgeAdapter(repo, config))
+        forgeAdapters.set(repo.repo, createForgeAdapter(repo, runtimeConfig))
       } catch (err) {
         logger.warn({ repo: repo.repo, err }, 'Failed to create forge adapter for MCP')
       }
     }
     try {
       mcpServer = await startMCPHttpServer(
-        { db, config, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
-        config.mcp.httpHost,
-        config.mcp.httpPort,
+        { db, config: baseConfig, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
+        runtimeConfig.mcp.httpHost,
+        runtimeConfig.mcp.httpPort,
       )
     } catch (err) {
       logger.warn({ err }, 'Failed to start MCP HTTP server — continuing without MCP')
     }
   }
 
-  logger.info({ intervalMs, dryRun, repos: config.repos.length }, 'Starting poller')
+  logger.info(
+    {
+      intervalMs: runtimeConfig.github.pollIntervalSeconds * 1000,
+      dryRun,
+      repos: runtimeConfig.repos.length,
+    },
+    'Starting poller',
+  )
 
   // Graceful shutdown
   const shutdown = new ShutdownHandler(db)
@@ -128,7 +136,8 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
   // Poll loop
   while (!shutdown.isShuttingDown) {
     try {
-      const runPromise = pollOnce(config, db, dryRun, metrics)
+      runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+      const runPromise = pollOnce(runtimeConfig, db, dryRun, metrics)
       shutdown.trackRun(runPromise.then(() => {}))
       const pollResult = await runPromise
       if (pollResult.immediateFollowupRepos.length > 0) {
@@ -144,7 +153,8 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
 
     if (shutdown.isShuttingDown) break
 
-    const waitResult = await pollerControl.waitForNextCycle(intervalMs)
+    runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+    const waitResult = await pollerControl.waitForNextCycle(runtimeConfig.github.pollIntervalSeconds * 1000)
     if (waitResult === 'manual') {
       logger.info('Manual poll trigger received — running next cycle immediately')
     }

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -1,0 +1,124 @@
+import { loadConfig, resolveConfigPath, ConfigError } from '../../config/loader.js'
+import { initDatabase } from '../../state/db.js'
+import {
+  clearRuntimeSettingOverride,
+  listRuntimeSettings,
+  setRuntimeSettingOverride,
+} from '../../settings/runtime.js'
+
+interface GlobalOpts {
+  config?: string
+  trustWorkspace?: boolean
+  logLevel?: string
+}
+
+export async function settingsListCommand(
+  globalOpts?: GlobalOpts,
+  json = false,
+): Promise<void> {
+  const resources = loadSettingsResources(globalOpts)
+  if (!resources) return
+
+  const { db, baseConfig } = resources
+  try {
+    const settings = listRuntimeSettings(baseConfig, db)
+    if (json) {
+      console.log(JSON.stringify({ settings }, null, 2))
+      return
+    }
+
+    console.log('\nRuntime Settings (base + DB override)\n')
+    for (const setting of settings) {
+      const bounds = setting.type === 'number'
+        ? `${setting.min ?? '-'}..${setting.max ?? '-'} step=${setting.step ?? '-'}`
+        : 'true|false'
+      const overrideDisplay = setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)
+      const updated = setting.updatedAt ?? '-'
+
+      console.log(`${setting.key}`)
+      console.log(`  label:      ${setting.label}`)
+      console.log(`  base:       ${formatSettingValue(setting.baseValue)}`)
+      console.log(`  override:   ${overrideDisplay}`)
+      console.log(`  effective:  ${formatSettingValue(setting.effectiveValue)} (${setting.source})`)
+      console.log(`  accepted:   ${bounds}`)
+      console.log(`  updated:    ${updated}`)
+    }
+    console.log('')
+  } finally {
+    db.close()
+  }
+}
+
+export async function settingsSetCommand(
+  key: string,
+  value: string,
+  globalOpts?: GlobalOpts,
+): Promise<void> {
+  const resources = loadSettingsResources(globalOpts)
+  if (!resources) return
+
+  const { db, baseConfig } = resources
+  try {
+    const result = setRuntimeSettingOverride(baseConfig, db, key, value, 'cli')
+    const changedMessage = result.changed ? 'updated' : 'unchanged'
+    console.log(
+      `${changedMessage}: ${result.setting.key} = ${formatSettingValue(result.setting.effectiveValue)} (source=${result.setting.source})`,
+    )
+  } catch (err) {
+    process.stderr.write(`Settings error: ${(err as Error).message}\n`)
+    process.exitCode = 1
+  } finally {
+    db.close()
+  }
+}
+
+export async function settingsUnsetCommand(
+  key: string,
+  globalOpts?: GlobalOpts,
+): Promise<void> {
+  const resources = loadSettingsResources(globalOpts)
+  if (!resources) return
+
+  const { db, baseConfig } = resources
+  try {
+    const result = clearRuntimeSettingOverride(baseConfig, db, key)
+    const changedMessage = result.changed ? 'cleared override' : 'no override to clear'
+    console.log(
+      `${changedMessage}: ${result.setting.key} => ${formatSettingValue(result.setting.effectiveValue)} (source=${result.setting.source})`,
+    )
+  } catch (err) {
+    process.stderr.write(`Settings error: ${(err as Error).message}\n`)
+    process.exitCode = 1
+  } finally {
+    db.close()
+  }
+}
+
+function loadSettingsResources(
+  globalOpts?: GlobalOpts,
+): { baseConfig: Awaited<ReturnType<typeof loadConfig>>; db: ReturnType<typeof initDatabase> } | null {
+  try {
+    const configPath = resolveConfigPath(globalOpts?.config, {
+      trustWorkspace: globalOpts?.trustWorkspace ?? false,
+    })
+    const baseConfig = loadConfig(configPath)
+    const db = initDatabase(baseConfig.storage.dbPath)
+    return { baseConfig, db }
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`Config error: ${err.message}\n`)
+      if (err.details) err.details.forEach((detail) => process.stderr.write(`${detail}\n`))
+    } else {
+      process.stderr.write(`${(err as Error).message}\n`)
+    }
+    process.exitCode = 1
+    return null
+  }
+}
+
+function formatSettingValue(value: string | number | boolean): string {
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  return String(value)
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -2,6 +2,7 @@ import { loadConfig, resolveConfigPath, ConfigError } from '../../config/loader.
 import { initDatabase } from '../../state/db.js'
 import { RunManager } from '../../state/runs.js'
 import { formatUtcDateTime, parseUtcTimestampMs } from '../../utils/time.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -10,12 +11,12 @@ interface GlobalOpts {
 }
 
 export async function statusCommand(globalOpts?: GlobalOpts): Promise<void> {
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`Config error: ${err.message}\n`)
@@ -25,7 +26,8 @@ export async function statusCommand(globalOpts?: GlobalOpts): Promise<void> {
     process.exit(1)
   }
 
-  const db = initDatabase(config.storage.dbPath)
+  const db = initDatabase(baseConfig.storage.dbPath)
+  const config = resolveConfigWithRuntimeSettings(baseConfig, db)
   const runs = new RunManager(db)
 
   const active = runs.getActive()

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,6 +1,7 @@
 import { loadConfig, resolveConfigPath, ConfigError } from '../../config/loader.js'
 import { initDatabase } from '../../state/db.js'
 import { SyncEngine } from '../../ops/sync.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -12,12 +13,12 @@ interface GlobalOpts {
 export async function syncCommand(globalOpts?: GlobalOpts): Promise<void> {
   const dryRun = globalOpts?.dryRun ?? false
 
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       console.error(`Config error: ${err.message}`)
@@ -28,7 +29,8 @@ export async function syncCommand(globalOpts?: GlobalOpts): Promise<void> {
     return
   }
 
-  const db = initDatabase(config.storage.dbPath)
+  const db = initDatabase(baseConfig.storage.dbPath)
+  const config = resolveConfigWithRuntimeSettings(baseConfig, db)
 
   try {
     const engine = new SyncEngine(db, config)

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -4,6 +4,7 @@ import { App } from '../tui/app.js'
 import { initDatabase } from '../../state/db.js'
 import { resolveConfigPath, loadConfig, ConfigError } from '../../config/loader.js'
 import { logger } from '../../utils/logger.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -13,12 +14,12 @@ interface GlobalOpts {
 }
 
 export async function runWatch(globalOpts?: GlobalOpts): Promise<void> {
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`Config error: ${err.message}\n`)
@@ -28,8 +29,9 @@ export async function runWatch(globalOpts?: GlobalOpts): Promise<void> {
     process.exit(1)
   }
 
-  const db = initDatabase(config.storage.dbPath)
-  const pollIntervalMs = config.github.pollIntervalSeconds * 1000
+  const db = initDatabase(baseConfig.storage.dbPath)
+  const runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+  const pollIntervalMs = runtimeConfig.github.pollIntervalSeconds * 1000
   const useAltScreen = Boolean(process.stdout.isTTY)
 
   if (useAltScreen) {
@@ -44,7 +46,7 @@ export async function runWatch(globalOpts?: GlobalOpts): Promise<void> {
     const { waitUntilExit } = render(
       React.createElement(App, {
         db,
-        config,
+        config: baseConfig,
         pollIntervalMs,
         dryRun: globalOpts?.dryRun ?? false,
         enableBackgroundPoller: true,

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -11,6 +11,7 @@ import type { ForgeAdapter } from '../../forge/types.js'
 import { startMCPHttpServer } from '../../mcp/http.js'
 import { startWebServer } from '../../web/server.js'
 import { logger } from '../../utils/logger.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface GlobalOpts {
   config?: string
@@ -33,12 +34,12 @@ export async function webCommand(
 ): Promise<void> {
   const dryRun = globalOpts?.dryRun ?? false
 
-  let config
+  let baseConfig
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    config = loadConfig(configPath)
+    baseConfig = loadConfig(configPath)
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`Config error: ${err.message}\n`)
@@ -56,13 +57,13 @@ export async function webCommand(
   const snapshotIntervalMs = normalizePort(commandOpts.snapshotIntervalMs, 3000)
   const standalone = commandOpts.standalone ?? false
 
-  const db = initDatabase(config.storage.dbPath)
-  const intervalMs = config.github.pollIntervalSeconds * 1000
+  const db = initDatabase(baseConfig.storage.dbPath)
+  let runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
 
   // Start metrics service (standalone mode only)
   let metrics: MetricsService | undefined
-  if (standalone && config.metrics) {
-    metrics = createMetricsService(config.metrics)
+  if (standalone && runtimeConfig.metrics) {
+    metrics = createMetricsService(runtimeConfig.metrics)
     try {
       await metrics.start()
     } catch (err) {
@@ -81,7 +82,7 @@ export async function webCommand(
         logger.info({ releasedLeases }, 'Released orphaned leases from previous run')
       }
 
-      const syncEngine = new SyncEngine(db, config)
+      const syncEngine = new SyncEngine(db, runtimeConfig)
       const syncResult = await syncEngine.reconcile(dryRun)
       if (syncResult.reconciledRuns.length > 0 || syncResult.expiredLeases > 0) {
         logger.info(
@@ -95,9 +96,9 @@ export async function webCommand(
   }
 
   const forgeAdapters = new Map<string, ForgeAdapter>()
-  for (const repo of config.repos) {
+  for (const repo of runtimeConfig.repos) {
     try {
-      forgeAdapters.set(repo.repo, createForgeAdapter(repo, config))
+      forgeAdapters.set(repo.repo, createForgeAdapter(repo, runtimeConfig))
     } catch (err) {
       logger.warn({ repo: repo.repo, err }, 'Failed to create forge adapter')
     }
@@ -106,12 +107,12 @@ export async function webCommand(
   // Start optional embedded MCP server (standalone mode only).
   const pollerControl = standalone ? new PollCycleController() : null
   let mcpServer: Server | undefined
-  if (standalone && config.mcp.enabled) {
+  if (standalone && runtimeConfig.mcp.enabled) {
     try {
       mcpServer = await startMCPHttpServer(
-        { db, config, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
-        config.mcp.httpHost,
-        config.mcp.httpPort,
+        { db, config: baseConfig, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
+        runtimeConfig.mcp.httpHost,
+        runtimeConfig.mcp.httpPort,
       )
     } catch (err) {
       logger.warn({ err }, 'Failed to start MCP HTTP server — continuing without MCP')
@@ -122,7 +123,7 @@ export async function webCommand(
   let webServer: Server | undefined
   try {
     webServer = await startWebServer(
-      { db, config, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
+      { db, config: baseConfig, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
       { host, allowedHosts, port, snapshotIntervalMs, operationsEnabled: true },
     )
   } catch (err) {
@@ -162,12 +163,22 @@ export async function webCommand(
     return
   }
 
-  logger.info({ intervalMs, dryRun, repos: config.repos.length, host, port }, 'Starting web poller')
+  logger.info(
+    {
+      intervalMs: runtimeConfig.github.pollIntervalSeconds * 1000,
+      dryRun,
+      repos: runtimeConfig.repos.length,
+      host,
+      port,
+    },
+    'Starting web poller',
+  )
 
   // Poll loop
   while (!shutdown.isShuttingDown) {
     try {
-      const runPromise = pollOnce(config, db, dryRun, metrics)
+      runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+      const runPromise = pollOnce(runtimeConfig, db, dryRun, metrics)
       shutdown.trackRun(runPromise.then(() => {}))
       const pollResult = await runPromise
       if (pollResult.immediateFollowupRepos.length > 0) {
@@ -183,7 +194,8 @@ export async function webCommand(
 
     if (shutdown.isShuttingDown) break
 
-    const waitResult = await pollerControl!.waitForNextCycle(intervalMs)
+    runtimeConfig = resolveConfigWithRuntimeSettings(baseConfig, db)
+    const waitResult = await pollerControl!.waitForNextCycle(runtimeConfig.github.pollIntervalSeconds * 1000)
     if (waitResult === 'manual') {
       logger.info('Manual poll trigger received — running next cycle immediately')
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,11 +17,27 @@ import { webCommand } from './commands/web.js'
 import { serveCommand } from './commands/serve.js'
 import { updateCommand } from './commands/update.js'
 import { continueCommand } from './commands/continue.js'
+import {
+  settingsListCommand,
+  settingsSetCommand,
+  settingsUnsetCommand,
+} from './commands/settings.js'
 
 const program = new Command()
 
 function collectOptionValue(value: string, previous: string[]): string[] {
   return [...previous, value]
+}
+
+interface GlobalCliOpts {
+  config?: string
+  trustWorkspace?: boolean
+  dryRun?: boolean
+  logLevel?: string
+}
+
+function resolveRootGlobalOpts(cmd: Command): GlobalCliOpts | undefined {
+  return cmd.parent?.parent?.opts<GlobalCliOpts>()
 }
 
 program
@@ -172,5 +188,37 @@ program
   .command('update')
   .description('Trigger self-update — pulls latest code, rebuilds, and restarts services')
   .action((_opts, cmd) => updateCommand(cmd.parent?.opts()))
+
+const settingsCommand = program
+  .command('settings')
+  .description('Manage DB-backed runtime settings overrides')
+
+settingsCommand
+  .command('list')
+  .description('List curated runtime settings and active overrides')
+  .option('--json', 'Output JSON')
+  .action((opts: { json?: boolean }, cmd) => {
+    const globalOpts = resolveRootGlobalOpts(cmd)
+    return settingsListCommand(globalOpts, opts.json ?? false)
+  })
+
+settingsCommand
+  .command('set')
+  .argument('<key>', 'Setting key')
+  .argument('<value>', 'Setting value')
+  .description('Set one runtime setting override')
+  .action((key: string, value: string, _opts, cmd) => {
+    const globalOpts = resolveRootGlobalOpts(cmd)
+    return settingsSetCommand(key, value, globalOpts)
+  })
+
+settingsCommand
+  .command('unset')
+  .argument('<key>', 'Setting key')
+  .description('Clear one runtime setting override')
+  .action((key: string, _opts, cmd) => {
+    const globalOpts = resolveRootGlobalOpts(cmd)
+    return settingsUnsetCommand(key, globalOpts)
+  })
 
 program.parse()

--- a/src/cli/tui/actions-bar.tsx
+++ b/src/cli/tui/actions-bar.tsx
@@ -25,18 +25,21 @@ function joinHintGroups(...groups: Array<string | null>): string {
 
 function navigationHints(activeTab: TabId, runFocused: boolean): string {
   if (activeTab === 'runs' && runFocused) {
-    return '[1-4]tabs [h/l]tabs [j/k]scroll run'
+    return '[1-5]tabs [h/l]tabs [j/k]scroll run'
   }
   if (activeTab === 'runs') {
-    return '[1-4]tabs [h/l]tabs [j/k]select issue [o/enter]open'
+    return '[1-5]tabs [h/l]tabs [j/k]select issue [o/enter]open'
   }
   if (activeTab === 'projects') {
-    return '[1-4]tabs [h/l]tabs [j/k]select project'
+    return '[1-5]tabs [h/l]tabs [j/k]select project'
   }
   if (activeTab === 'logs') {
-    return '[1-4]tabs [h/l]tabs [j/k]select log [J/K]scroll raw'
+    return '[1-5]tabs [h/l]tabs [j/k]select log [J/K]scroll raw'
   }
-  return '[1-4]tabs [h/l]tabs'
+  if (activeTab === 'settings') {
+    return '[1-5]tabs [h/l]tabs [j/k]select setting'
+  }
+  return '[1-5]tabs [h/l]tabs'
 }
 
 function globalHints(options: {
@@ -61,6 +64,9 @@ function issueHints(options: {
   runFocused: boolean
 }): string {
   const { activeTab, busy, runFocused } = options
+  if (activeTab === 'settings') {
+    return '[+/-]adjust number [space]toggle bool [u]unset override'
+  }
   if (activeTab !== 'runs') {
     return 'n/a (issue actions on runs tab)'
   }

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -18,12 +18,19 @@ import { Header } from './header.js'
 import { LogsView } from './logs-view.js'
 import { ProjectsView } from './projects-view.js'
 import { RunsView } from './runs-view.js'
+import { SettingsView } from './settings-view.js'
 import { StatsView } from './stats-view.js'
 import { collectMissingTitleTargets, hasReadableTitle, type TitleLookup } from './titles.js'
 import { TABS } from './constants.js'
 import type { RunsViewMode, TabId, TuiLogLine } from './types.js'
 import { formatUtcClock, nowUtcIso } from '../../utils/time.js'
 import { getBuildInfo } from '../../utils/build-info.js'
+import {
+  clearRuntimeSettingOverride,
+  listRuntimeSettings,
+  resolveConfigWithRuntimeSettings,
+  setRuntimeSettingOverride,
+} from '../../settings/runtime.js'
 
 interface AppProps {
   db: Database.Database
@@ -46,11 +53,17 @@ const EXIT_GRACE_TIMEOUT_MS = 15_000
 const CLEANUP_CONFIRM_TIMEOUT_MS = 5_000
 const BUILD_INFO = getBuildInfo()
 
+function formatSettingValue(value: string | number | boolean): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}
+
 export function resolveTabHotkey(input: string): TabId | null {
   if (input === '1') return 'runs'
   if (input === '2') return 'projects'
   if (input === '3') return 'stats'
   if (input === '4') return 'logs'
+  if (input === '5') return 'settings'
   return null
 }
 
@@ -223,6 +236,7 @@ export function App({
   const [activeTab, setActiveTab] = useState<TabId>('runs')
   const [runsViewMode, setRunsViewMode] = useState<RunsViewMode>('list')
   const [selectedProjectIndex, setSelectedProjectIndex] = useState(0)
+  const [selectedSettingIndex, setSelectedSettingIndex] = useState(0)
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [cleanupConfirmPending, setCleanupConfirmPending] = useState(false)
   const [lastRefreshAt, setLastRefreshAt] = useState(nowUtcIso())
@@ -268,6 +282,18 @@ export function App({
     })
   }, [])
 
+  const runtimeConfig = useMemo(
+    () => resolveConfigWithRuntimeSettings(config, db),
+    [config, db, tick],
+  )
+  const effectivePollIntervalMs = runtimeConfig.github.pollIntervalSeconds > 0
+    ? runtimeConfig.github.pollIntervalSeconds * 1000
+    : pollIntervalMs
+  const runtimeSettings = useMemo(
+    () => listRuntimeSettings(config, db),
+    [config, db, tick],
+  )
+
   const forgeByRepo = useMemo(() => {
     const map = new Map<string, ReturnType<typeof createForgeAdapter>>()
     for (const repoConfig of config.repos) {
@@ -280,9 +306,9 @@ export function App({
     if (!autoRefresh) return
     const timer = setInterval(() => {
       setTick((t) => t + 1)
-    }, pollIntervalMs)
+    }, effectivePollIntervalMs)
     return () => clearInterval(timer)
-  }, [autoRefresh, pollIntervalMs])
+  }, [autoRefresh, effectivePollIntervalMs])
 
   useEffect(() => {
     setLastRefreshAt(nowUtcIso())
@@ -306,7 +332,8 @@ export function App({
       }
 
       try {
-        const syncEngine = new SyncEngine(db, config)
+        const startupConfig = resolveConfigWithRuntimeSettings(config, db)
+        const syncEngine = new SyncEngine(db, startupConfig)
         const syncResult = await syncEngine.reconcile(dryRun)
         appendLog(
           'info',
@@ -375,6 +402,11 @@ export function App({
     const maxIndex = Math.max(0, config.repos.length - 1)
     setSelectedProjectIndex((current) => Math.max(0, Math.min(current, maxIndex)))
   }, [config.repos])
+
+  useEffect(() => {
+    const maxIndex = Math.max(0, runtimeSettings.length - 1)
+    setSelectedSettingIndex((current) => Math.max(0, Math.min(current, maxIndex)))
+  }, [runtimeSettings.length])
 
   useEffect(() => {
     const now = Date.now()
@@ -492,7 +524,8 @@ export function App({
       const target = trigger === 'manual' && targetIssue
         ? { repo: targetIssue.repo, issueNumber: targetIssue.issue_number }
         : undefined
-      const result = await pollOnce(config, db, dryRun, undefined, target)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const result = await pollOnce(currentRuntimeConfig, db, dryRun, undefined, target)
       const targetSuffix = target ? ` for ${target.repo}#${target.issueNumber}` : ''
       const summary = `${result.processed} processed, ${result.errors} error(s)${targetSuffix}${dryRun ? ' (dry-run)' : ''}`
       appendLog('info', `${trigger} poll: ${summary}`)
@@ -528,13 +561,13 @@ export function App({
     void cycle()
     const timer = setInterval(() => {
       void cycle()
-    }, pollIntervalMs)
+    }, effectivePollIntervalMs)
 
     return () => {
       stopped = true
       clearInterval(timer)
     }
-  }, [autoRefresh, enableBackgroundPoller, pollIntervalMs, runPollCycle, startupReady])
+  }, [autoRefresh, effectivePollIntervalMs, enableBackgroundPoller, runPollCycle, startupReady])
 
   const moveSelection = useCallback((direction: -1 | 1) => {
     if (issues.length === 0) return
@@ -556,6 +589,11 @@ export function App({
     const next = TABS[nextIndex]
     if (next) setActiveTab(next.id)
   }, [activeTab])
+
+  const moveSettingSelection = useCallback((direction: -1 | 1) => {
+    const maxIndex = Math.max(0, runtimeSettings.length - 1)
+    setSelectedSettingIndex((current) => Math.max(0, Math.min(maxIndex, current + direction)))
+  }, [runtimeSettings.length])
 
   const forceRefresh = useCallback(() => {
     setTick((t) => t + 1)
@@ -593,7 +631,8 @@ export function App({
     const label = fresh ? 'retry-fresh' : 'retry'
     await runAction(label, async () => {
       if (!selectedIssue) throw new Error('No issue selected')
-      const engine = new RetryEngine(db, config)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const engine = new RetryEngine(db, currentRuntimeConfig)
       await engine.retry(selectedIssue.repo, selectedIssue.issue_number, {
         immediate: false,
         resetPlan: fresh,
@@ -607,7 +646,8 @@ export function App({
 
   const runSync = useCallback(async () => {
     await runAction('sync', async () => {
-      const engine = new SyncEngine(db, config)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const engine = new SyncEngine(db, currentRuntimeConfig)
       const result = await engine.reconcile(dryRun)
       return `${result.reconciledRuns.length} reconciled, ${result.labelCorrections.length} label fixes, ${result.expiredLeases} expired lease(s), ${result.orphanedWorktrees.length} orphaned worktree(s)${dryRun ? ' (dry-run)' : ''}`
     })
@@ -615,7 +655,8 @@ export function App({
 
   const runCleanup = useCallback(async () => {
     await runAction('cleanup', async () => {
-      const engine = new CleanupEngine(db, config)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const engine = new CleanupEngine(db, currentRuntimeConfig)
       const result = await engine.run({
         completedWorktrees: true,
         errorWorktreeAgeDays: 7,
@@ -630,15 +671,16 @@ export function App({
 
   const runLabelsInit = useCallback(async () => {
     await runAction('labels-init', async () => {
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
       const targetRepo = activeTab === 'projects'
-        ? config.repos[selectedProjectIndex]?.repo
-        : selectedIssue?.repo ?? config.repos[0]?.repo
+        ? currentRuntimeConfig.repos[selectedProjectIndex]?.repo
+        : selectedIssue?.repo ?? currentRuntimeConfig.repos[0]?.repo
 
       if (!targetRepo) {
         throw new Error('No repositories configured')
       }
 
-      const engine = new LabelsInitEngine(config)
+      const engine = new LabelsInitEngine(currentRuntimeConfig)
       const result = await engine.run({
         targetRepo,
         dryRun,
@@ -663,9 +705,10 @@ export function App({
     await runAction('rebase', async () => {
       const target = selectedIssue ?? issues.find((issue) => issue.status === 'review_ready')
       if (!target) throw new Error('No issue selected')
-      const repoConfig = config.repos.find((r) => r.repo === target.repo)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const repoConfig = currentRuntimeConfig.repos.find((r) => r.repo === target.repo)
       if (!repoConfig) throw new Error(`Repo not found in config: ${target.repo}`)
-      const forge = createForgeAdapter(repoConfig, config)
+      const forge = createForgeAdapter(repoConfig, currentRuntimeConfig)
       let botUser = ''
       try {
         const auth = await forge.validateAuth()
@@ -682,9 +725,10 @@ export function App({
     await runAction('continue', async () => {
       const target = selectedIssue ?? issues.find((issue) => issue.status === 'blocked' || issue.status === 'review_ready' || issue.status === 'error')
       if (!target) throw new Error('No issue selected')
-      const repoConfig = config.repos.find((r) => r.repo === target.repo)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const repoConfig = currentRuntimeConfig.repos.find((r) => r.repo === target.repo)
       if (!repoConfig) throw new Error(`Repo not found in config: ${target.repo}`)
-      const forge = createForgeAdapter(repoConfig, config)
+      const forge = createForgeAdapter(repoConfig, currentRuntimeConfig)
       let botUser = ''
       try {
         const auth = await forge.validateAuth()
@@ -700,7 +744,8 @@ export function App({
   const runDeleteEntry = useCallback(async () => {
     await runAction('delete-entry', async () => {
       if (!selectedIssue) throw new Error('No issue selected')
-      const engine = new DeleteIssueEntryEngine(db, config)
+      const currentRuntimeConfig = resolveConfigWithRuntimeSettings(config, db)
+      const engine = new DeleteIssueEntryEngine(db, currentRuntimeConfig)
       const result = await engine.deleteEntry(selectedIssue.repo, selectedIssue.issue_number, {
         dryRun,
         force: false,
@@ -714,6 +759,80 @@ export function App({
       return `${selectedIssue.repo}#${selectedIssue.issue_number}: ${result.runsDeleted} run(s), ${result.issuesDeleted} issue row(s), ${result.worktreesRemoved.length} worktree(s)${warningSuffix}${dryRun ? ' (dry-run)' : ''}`
     })
   }, [config, db, dryRun, runAction, selectedIssue])
+
+  const runSetSetting = useCallback(async (nextValue: string | number | boolean) => {
+    const target = runtimeSettings[selectedSettingIndex]
+    if (!target) {
+      setStatusLine('No setting selected')
+      return
+    }
+
+    await runAction('setting-set', async () => {
+      const result = setRuntimeSettingOverride(config, db, target.key, nextValue, 'tui')
+      return `${result.setting.key} => ${formatSettingValue(result.setting.effectiveValue)}`
+    })
+  }, [config, db, runAction, runtimeSettings, selectedSettingIndex])
+
+  const runClearSetting = useCallback(async () => {
+    const target = runtimeSettings[selectedSettingIndex]
+    if (!target) {
+      setStatusLine('No setting selected')
+      return
+    }
+
+    await runAction('setting-unset', async () => {
+      const result = clearRuntimeSettingOverride(config, db, target.key)
+      return `${result.setting.key} => ${formatSettingValue(result.setting.effectiveValue)} (${result.setting.source})`
+    })
+  }, [config, db, runAction, runtimeSettings, selectedSettingIndex])
+
+  const runAdjustSelectedSetting = useCallback(async (direction: -1 | 1) => {
+    const target = runtimeSettings[selectedSettingIndex]
+    if (!target) {
+      setStatusLine('No setting selected')
+      return
+    }
+    if (target.type !== 'number') {
+      setStatusLine(`"${target.key}" is boolean. Use space to toggle.`)
+      return
+    }
+
+    const current = target.effectiveValue
+    if (typeof current !== 'number') {
+      setStatusLine(`"${target.key}" has non-numeric effective value`)
+      return
+    }
+    const step = target.step ?? 1
+    const min = target.min ?? Number.NEGATIVE_INFINITY
+    const max = target.max ?? Number.POSITIVE_INFINITY
+    const next = Math.max(min, Math.min(max, current + direction * step))
+    if (next === current) {
+      setStatusLine(`"${target.key}" already at bound`)
+      return
+    }
+
+    await runSetSetting(next)
+  }, [runSetSetting, runtimeSettings, selectedSettingIndex])
+
+  const runToggleSelectedSetting = useCallback(async () => {
+    const target = runtimeSettings[selectedSettingIndex]
+    if (!target) {
+      setStatusLine('No setting selected')
+      return
+    }
+    if (target.type !== 'boolean') {
+      setStatusLine(`"${target.key}" is numeric. Use +/- to adjust.`)
+      return
+    }
+
+    const current = target.effectiveValue
+    if (typeof current !== 'boolean') {
+      setStatusLine(`"${target.key}" has non-boolean effective value`)
+      return
+    }
+
+    await runSetSetting(!current)
+  }, [runSetSetting, runtimeSettings, selectedSettingIndex])
 
   const gracefulExit = useCallback(() => {
     if (shuttingDown.current) {
@@ -833,11 +952,11 @@ export function App({
 
     if (activeTab === 'projects') {
       if (key.downArrow || input === 'j') {
-        setSelectedProjectIndex((current) => moveProjectSelection(current, 1, config.repos.length))
+        setSelectedProjectIndex((current) => moveProjectSelection(current, 1, runtimeConfig.repos.length))
         return
       }
       if (key.upArrow || input === 'k') {
-        setSelectedProjectIndex((current) => moveProjectSelection(current, -1, config.repos.length))
+        setSelectedProjectIndex((current) => moveProjectSelection(current, -1, runtimeConfig.repos.length))
         return
       }
     }
@@ -861,6 +980,33 @@ export function App({
       }
       if (input === 'K') {
         setLogDetailScrollOffset((current) => Math.max(0, current - 1))
+        return
+      }
+    }
+
+    if (activeTab === 'settings') {
+      if (key.downArrow || input === 'j') {
+        moveSettingSelection(1)
+        return
+      }
+      if (key.upArrow || input === 'k') {
+        moveSettingSelection(-1)
+        return
+      }
+      if (input === '+' || input === '=') {
+        void runAdjustSelectedSetting(1)
+        return
+      }
+      if (input === '-') {
+        void runAdjustSelectedSetting(-1)
+        return
+      }
+      if (input === 'u') {
+        void runClearSetting()
+        return
+      }
+      if (input === ' ') {
+        void runToggleSelectedSetting()
         return
       }
     }
@@ -963,7 +1109,7 @@ export function App({
     <Box flexDirection="column" height={termRows}>
       <Header
         activeTab={activeTab}
-        pollIntervalMs={pollIntervalMs}
+        pollIntervalMs={effectivePollIntervalMs}
         dryRun={dryRun}
         status={stats}
         autoRefresh={autoRefresh}
@@ -997,17 +1143,17 @@ export function App({
         <StatsView
           stats={stats}
           autoRefresh={autoRefresh}
-          pollIntervalMs={pollIntervalMs}
+          pollIntervalMs={effectivePollIntervalMs}
           lastRefreshAt={lastRefreshAt}
         />
       )}
       {activeTab === 'projects' && (
         <ProjectsView
-          repos={config.repos}
+          repos={runtimeConfig.repos}
           selectedIndex={selectedProjectIndex}
-          workerProfiles={config.workerProfiles}
-          globalGithubTokenEnv={config.github.tokenEnv}
-          globalGithubApiBaseUrl={config.github.apiBaseUrl}
+          workerProfiles={runtimeConfig.workerProfiles}
+          globalGithubTokenEnv={runtimeConfig.github.tokenEnv}
+          globalGithubApiBaseUrl={runtimeConfig.github.apiBaseUrl}
         />
       )}
       {activeTab === 'logs' && (
@@ -1019,6 +1165,12 @@ export function App({
             detailScrollOffset={logDetailScrollOffset}
           />
         </Box>
+      )}
+      {activeTab === 'settings' && (
+        <SettingsView
+          settings={runtimeSettings}
+          selectedIndex={selectedSettingIndex}
+        />
       )}
 
       <ActionsBar

--- a/src/cli/tui/constants.ts
+++ b/src/cli/tui/constants.ts
@@ -5,6 +5,7 @@ export const TABS: Array<{ id: TabId; hotkey: string; label: string }> = [
   { id: 'projects', hotkey: '2', label: 'Projects' },
   { id: 'stats', hotkey: '3', label: 'Stats' },
   { id: 'logs', hotkey: '4', label: 'Logs' },
+  { id: 'settings', hotkey: '5', label: 'Settings' },
 ]
 
 export type TuiColor = 'white' | 'gray' | 'yellow' | 'cyan' | 'magenta' | 'green' | 'red'

--- a/src/cli/tui/settings-view.tsx
+++ b/src/cli/tui/settings-view.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import type { RuntimeSettingSnapshot } from '../../settings/runtime.js'
+
+interface SettingsViewProps {
+  settings: RuntimeSettingSnapshot[]
+  selectedIndex: number
+}
+
+export function SettingsView({
+  settings,
+  selectedIndex,
+}: SettingsViewProps): React.ReactElement {
+  if (settings.length === 0) {
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor="blue" paddingX={1}>
+        <Text bold color="cyan">Settings</Text>
+        <Text dimColor>No curated runtime settings available.</Text>
+      </Box>
+    )
+  }
+
+  const clampedIndex = Math.max(0, Math.min(settings.length - 1, selectedIndex))
+  const selected = settings[clampedIndex]!
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="blue" paddingX={1}>
+      <Text bold color="cyan">Runtime Settings</Text>
+      <Text dimColor>Use j/k to select, +/- to adjust numeric values, space to toggle booleans, u to clear override.</Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {settings.map((setting, index) => {
+          const selectedRow = index === clampedIndex
+          const override = setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)
+          const line = `${setting.key} | effective=${formatSettingValue(setting.effectiveValue)} | override=${override} | source=${setting.source}`
+          return (
+            <Text key={setting.key} color={selectedRow ? 'white' : 'gray'} inverse={selectedRow}>
+              {selectedRow ? '▸ ' : '  '}
+              {line}
+            </Text>
+          )
+        })}
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color="white">Selected</Text>
+        <Text>{selected.label}</Text>
+        <Text dimColor>{selected.description}</Text>
+        <Text>
+          base={formatSettingValue(selected.baseValue)} override={
+            selected.overrideValue === null ? '-' : formatSettingValue(selected.overrideValue)
+          } effective={formatSettingValue(selected.effectiveValue)}
+        </Text>
+      </Box>
+    </Box>
+  )
+}
+
+function formatSettingValue(value: string | number | boolean): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}

--- a/src/cli/tui/types.ts
+++ b/src/cli/tui/types.ts
@@ -1,4 +1,4 @@
-export type TabId = 'runs' | 'projects' | 'stats' | 'logs'
+export type TabId = 'runs' | 'projects' | 'stats' | 'logs' | 'settings'
 
 export type RunsViewMode = 'list' | 'focus'
 

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -1,6 +1,7 @@
 import type { MCPDependencies } from '../server.js'
 import { RunManager } from '../../state/runs.js'
 import { CostTracker } from '../../loop/cost.js'
+import { resolveConfigWithRuntimeSettings } from '../../settings/runtime.js'
 
 interface ResourceDefinition {
   uri: string
@@ -36,24 +37,29 @@ export async function handleResourceRead(
   uri: string,
   deps: MCPDependencies,
 ): Promise<unknown> {
+  const runtimeDeps: MCPDependencies = {
+    ...deps,
+    config: resolveConfigWithRuntimeSettings(deps.config, deps.db),
+  }
+
   // Handle parameterized URIs
   const runsMatch = uri.match(/^night-orch:\/\/runs\/(.+)$/)
   if (runsMatch) {
-    return readRunResource(runsMatch[1]!, deps)
+    return readRunResource(runsMatch[1]!, runtimeDeps)
   }
 
   const logsMatch = uri.match(/^night-orch:\/\/logs\/(.+)$/)
   if (logsMatch) {
-    return readLogsResource(logsMatch[1]!, deps)
+    return readLogsResource(logsMatch[1]!, runtimeDeps)
   }
 
   switch (uri) {
     case 'night-orch://status':
-      return readStatusResource(deps)
+      return readStatusResource(runtimeDeps)
     case 'night-orch://config':
-      return readConfigResource(deps)
+      return readConfigResource(runtimeDeps)
     case 'night-orch://metrics':
-      return readMetricsResource(deps)
+      return readMetricsResource(runtimeDeps)
     default:
       throw new Error(`Unknown resource: ${uri}`)
   }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -18,6 +18,12 @@ import { flushActiveAgentObservability } from '../../events/observability.js'
 import { createForgeAdapter } from '../../forge/factory.js'
 import { nowUtcIso } from '../../utils/time.js'
 import { loadRuns } from '../../cli/tui/data.js'
+import {
+  clearRuntimeSettingOverride,
+  listRuntimeSettings,
+  resolveConfigWithRuntimeSettings,
+  setRuntimeSettingOverride,
+} from '../../settings/runtime.js'
 
 interface ToolDefinition {
   name: string
@@ -31,6 +37,39 @@ interface ToolDefinition {
 
 export function registerTools(): ToolDefinition[] {
   return [
+    {
+      name: 'night-orch-list-settings',
+      description: 'List runtime-configurable settings with base values, DB overrides, and effective values.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    {
+      name: 'night-orch-set-setting',
+      description: 'Set one runtime setting override in DB.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Setting key (for example github.pollIntervalSeconds)' },
+          value: { type: 'string', description: 'Setting value as text (for booleans use true/false)' },
+          authToken: { type: 'string', description: 'Required when mcp.authTokenEnv is configured' },
+        },
+        required: ['key', 'value'],
+      },
+    },
+    {
+      name: 'night-orch-clear-setting',
+      description: 'Clear one runtime setting override (revert to YAML/default).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Setting key' },
+          authToken: { type: 'string', description: 'Required when mcp.authTokenEnv is configured' },
+        },
+        required: ['key'],
+      },
+    },
     {
       name: 'night-orch-status',
       description: 'Get current night-orch operational status including active runs, eligible issues, and recent activity.',
@@ -220,39 +259,103 @@ export async function handleToolCall(
   args: Record<string, unknown>,
   deps: MCPDependencies,
 ): Promise<unknown> {
+  const runtimeDeps: MCPDependencies = {
+    ...deps,
+    config: resolveConfigWithRuntimeSettings(deps.config, deps.db),
+  }
+
   switch (name) {
+    case 'night-orch-list-settings':
+      return handleListSettings(deps)
+    case 'night-orch-set-setting':
+      return handleSetSetting(args as { key: string; value: unknown; authToken?: string }, deps)
+    case 'night-orch-clear-setting':
+      return handleClearSetting(args as { key: string; authToken?: string }, deps)
     case 'night-orch-status':
-      return handleStatus(args as { repo?: string }, deps)
+      return handleStatus(args as { repo?: string }, runtimeDeps)
     case 'night-orch-run-detail':
-      return handleRunDetail(args as { runId: string }, deps)
+      return handleRunDetail(args as { runId: string }, runtimeDeps)
     case 'night-orch-list-runs':
-      return handleListRuns(args as { repo?: string; status?: string; limit?: number }, deps)
+      return handleListRuns(args as { repo?: string; status?: string; limit?: number }, runtimeDeps)
     case 'night-orch-cost-report':
-      return handleCostReport(args as { days?: number }, deps)
+      return handleCostReport(args as { days?: number }, runtimeDeps)
     case 'night-orch-retry':
-      return handleRetry(args as { repo: string; issueNumber: number; resetPlan?: boolean; fresh?: boolean; authToken?: string }, deps)
+      return handleRetry(args as { repo: string; issueNumber: number; resetPlan?: boolean; fresh?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-sync':
-      return handleSync(args as { dryRun?: boolean; authToken?: string }, deps)
+      return handleSync(args as { dryRun?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-cleanup':
-      return handleCleanup(args as { dryRun?: boolean; authToken?: string }, deps)
+      return handleCleanup(args as { dryRun?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-labels-init':
-      return handleLabelsInit(args as { repo: string; dryRun?: boolean; authToken?: string }, deps)
+      return handleLabelsInit(args as { repo: string; dryRun?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-delete-entry':
-      return handleDeleteEntry(args as { repo: string; issueNumber: number; force?: boolean; dryRun?: boolean; authToken?: string }, deps)
+      return handleDeleteEntry(args as { repo: string; issueNumber: number; force?: boolean; dryRun?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-poll':
-      return handlePoll(args as { dryRun?: boolean; authToken?: string }, deps)
+      return handlePoll(args as { dryRun?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-list-issues':
-      return handleListIssues(args as { repo: string; filter?: string }, deps)
+      return handleListIssues(args as { repo: string; filter?: string }, runtimeDeps)
     case 'night-orch-stream-events':
-      return handleStreamEvents(args as { runId: string; since?: number; limit?: number }, deps)
+      return handleStreamEvents(args as { runId: string; since?: number; limit?: number }, runtimeDeps)
     case 'night-orch-rebase':
-      return handleRebase(args as { repo: string; issueNumber: number; check?: boolean; authToken?: string }, deps)
+      return handleRebase(args as { repo: string; issueNumber: number; check?: boolean; authToken?: string }, runtimeDeps)
     case 'night-orch-continue':
-      return handleContinue(args as { repo: string; issueNumber: number; authToken?: string }, deps)
+      return handleContinue(args as { repo: string; issueNumber: number; authToken?: string }, runtimeDeps)
     case 'night-orch-update':
-      return handleUpdate(args as { authToken?: string }, deps)
+      return handleUpdate(args as { authToken?: string }, runtimeDeps)
     default:
       throw new Error(`Unknown tool: ${name}`)
+  }
+}
+
+async function handleListSettings(deps: MCPDependencies): Promise<unknown> {
+  return {
+    settings: listRuntimeSettings(deps.config, deps.db),
+  }
+}
+
+async function handleSetSetting(
+  args: { key: string; value: unknown; authToken?: string },
+  deps: MCPDependencies,
+): Promise<unknown> {
+  assertMcpMutationAuth(args.authToken, deps)
+
+  if (typeof args.key !== 'string' || args.key.trim().length === 0) {
+    throw new Error('key is required')
+  }
+
+  const result = setRuntimeSettingOverride(
+    deps.config,
+    deps.db,
+    args.key.trim(),
+    args.value,
+    'mcp',
+  )
+
+  return {
+    changed: result.changed,
+    setting: result.setting,
+    message: result.changed
+      ? `Updated ${result.setting.key} to ${String(result.setting.effectiveValue)}`
+      : `${result.setting.key} unchanged`,
+  }
+}
+
+async function handleClearSetting(
+  args: { key: string; authToken?: string },
+  deps: MCPDependencies,
+): Promise<unknown> {
+  assertMcpMutationAuth(args.authToken, deps)
+
+  if (typeof args.key !== 'string' || args.key.trim().length === 0) {
+    throw new Error('key is required')
+  }
+
+  const result = clearRuntimeSettingOverride(deps.config, deps.db, args.key.trim())
+  return {
+    changed: result.changed,
+    setting: result.setting,
+    message: result.changed
+      ? `Cleared override for ${result.setting.key}`
+      : `No override found for ${result.setting.key}`,
   }
 }
 

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -1,0 +1,288 @@
+import type { Config } from '../config/schema.js'
+
+export type SettingKey =
+  | 'github.pollIntervalSeconds'
+  | 'security.maxDailyCostUsd'
+  | 'loop.maxReviewIterations'
+  | 'loop.maxTotalAgentPasses'
+  | 'observability.agentStreaming'
+
+export type SettingValue = number | boolean
+export type SettingType = 'number' | 'boolean'
+
+interface SettingDefinitionBase<K extends SettingKey, V extends SettingValue> {
+  key: K
+  label: string
+  description: string
+  type: SettingType
+  read: (config: Config) => V
+  apply: (config: Config, value: V) => Config
+  parseInput: (raw: unknown) => V
+  parseStored: (raw: string) => V
+  serialize: (value: V) => string
+}
+
+export interface NumberSettingDefinition<K extends SettingKey = SettingKey>
+  extends SettingDefinitionBase<K, number> {
+  type: 'number'
+  min?: number
+  max?: number
+  step?: number
+}
+
+export interface BooleanSettingDefinition<K extends SettingKey = SettingKey>
+  extends SettingDefinitionBase<K, boolean> {
+  type: 'boolean'
+}
+
+export type SettingDefinition = NumberSettingDefinition | BooleanSettingDefinition
+
+const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
+  'github.pollIntervalSeconds': {
+    key: 'github.pollIntervalSeconds',
+    label: 'Poll Interval (seconds)',
+    description: 'Delay between automatic poll cycles.',
+    type: 'number',
+    min: 5,
+    max: 3600,
+    step: 5,
+    read: (config) => config.github.pollIntervalSeconds,
+    apply: (config, value) => ({
+      ...config,
+      github: {
+        ...config.github,
+        pollIntervalSeconds: value,
+      },
+    }),
+    parseInput: (raw) => parseNumberInput(raw, {
+      key: 'github.pollIntervalSeconds',
+      integer: true,
+      min: 5,
+      max: 3600,
+    }),
+    parseStored: (raw) => parseStoredNumber(raw, {
+      key: 'github.pollIntervalSeconds',
+      integer: true,
+      min: 5,
+      max: 3600,
+    }),
+    serialize: (value) => JSON.stringify(value),
+  },
+  'security.maxDailyCostUsd': {
+    key: 'security.maxDailyCostUsd',
+    label: 'Daily Cost Budget (USD)',
+    description: 'Maximum allowed spend per UTC day before new runs are blocked.',
+    type: 'number',
+    min: 1,
+    max: 10000,
+    step: 1,
+    read: (config) => config.security.maxDailyCostUsd,
+    apply: (config, value) => ({
+      ...config,
+      security: {
+        ...config.security,
+        maxDailyCostUsd: value,
+      },
+    }),
+    parseInput: (raw) => parseNumberInput(raw, {
+      key: 'security.maxDailyCostUsd',
+      integer: false,
+      min: 1,
+      max: 10000,
+    }),
+    parseStored: (raw) => parseStoredNumber(raw, {
+      key: 'security.maxDailyCostUsd',
+      integer: false,
+      min: 1,
+      max: 10000,
+    }),
+    serialize: (value) => JSON.stringify(value),
+  },
+  'loop.maxReviewIterations': {
+    key: 'loop.maxReviewIterations',
+    label: 'Max Review Iterations',
+    description: 'Maximum review correction loops per run.',
+    type: 'number',
+    min: 1,
+    max: 20,
+    step: 1,
+    read: (config) => config.loop.maxReviewIterations,
+    apply: (config, value) => ({
+      ...config,
+      loop: {
+        ...config.loop,
+        maxReviewIterations: value,
+      },
+    }),
+    parseInput: (raw) => parseNumberInput(raw, {
+      key: 'loop.maxReviewIterations',
+      integer: true,
+      min: 1,
+      max: 20,
+    }),
+    parseStored: (raw) => parseStoredNumber(raw, {
+      key: 'loop.maxReviewIterations',
+      integer: true,
+      min: 1,
+      max: 20,
+    }),
+    serialize: (value) => JSON.stringify(value),
+  },
+  'loop.maxTotalAgentPasses': {
+    key: 'loop.maxTotalAgentPasses',
+    label: 'Max Total Agent Passes',
+    description: 'Hard cap on planner/coder/reviewer passes in one run.',
+    type: 'number',
+    min: 1,
+    max: 50,
+    step: 1,
+    read: (config) => config.loop.maxTotalAgentPasses,
+    apply: (config, value) => ({
+      ...config,
+      loop: {
+        ...config.loop,
+        maxTotalAgentPasses: value,
+      },
+    }),
+    parseInput: (raw) => parseNumberInput(raw, {
+      key: 'loop.maxTotalAgentPasses',
+      integer: true,
+      min: 1,
+      max: 50,
+    }),
+    parseStored: (raw) => parseStoredNumber(raw, {
+      key: 'loop.maxTotalAgentPasses',
+      integer: true,
+      min: 1,
+      max: 50,
+    }),
+    serialize: (value) => JSON.stringify(value),
+  },
+  'observability.agentStreaming': {
+    key: 'observability.agentStreaming',
+    label: 'Agent Streaming',
+    description: 'Enable in-flight agent event streaming to TUI/Web.',
+    type: 'boolean',
+    read: (config) => config.observability?.agentStreaming ?? true,
+    apply: (config, value) => ({
+      ...config,
+      observability: {
+        ...buildDefaultObservability(config),
+        agentStreaming: value,
+      },
+    }),
+    parseInput: (raw) => parseBooleanInput(raw, 'observability.agentStreaming'),
+    parseStored: (raw) => parseStoredBoolean(raw, 'observability.agentStreaming'),
+    serialize: (value) => JSON.stringify(value),
+  },
+}
+
+const SETTING_KEYS = Object.keys(SETTING_DEFINITIONS) as SettingKey[]
+
+export function listSettingDefinitions(): SettingDefinition[] {
+  return SETTING_KEYS.map((key) => SETTING_DEFINITIONS[key])
+}
+
+export function getSettingDefinition(key: string): SettingDefinition | null {
+  return SETTING_DEFINITIONS[key as SettingKey] ?? null
+}
+
+function parseNumberInput(
+  raw: unknown,
+  options: { key: SettingKey; integer: boolean; min: number; max: number },
+): number {
+  const parsed = typeof raw === 'number'
+    ? raw
+    : typeof raw === 'string'
+      ? parseStrictNumberString(raw)
+      : Number.NaN
+
+  return validateNumber(parsed, options)
+}
+
+function parseStoredNumber(
+  raw: string,
+  options: { key: SettingKey; integer: boolean; min: number; max: number },
+): number {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'number') {
+      throw new Error(`Stored value for ${options.key} is not numeric`)
+    }
+    return validateNumber(parsed, options)
+  } catch (err) {
+    throw new Error(`Invalid stored value for ${options.key}: ${(err as Error).message}`)
+  }
+}
+
+function validateNumber(
+  value: number,
+  options: { key: SettingKey; integer: boolean; min: number; max: number },
+): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${options.key} must be a finite number`)
+  }
+
+  if (options.integer && !Number.isInteger(value)) {
+    throw new Error(`${options.key} must be an integer`)
+  }
+
+  if (value < options.min || value > options.max) {
+    throw new Error(`${options.key} must be between ${options.min} and ${options.max}`)
+  }
+
+  return value
+}
+
+function parseStrictNumberString(raw: string): number {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) {
+    return Number.NaN
+  }
+
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed)) {
+    return Number.NaN
+  }
+
+  return parsed
+}
+
+function parseBooleanInput(raw: unknown, key: SettingKey): boolean {
+  if (typeof raw === 'boolean') {
+    return raw
+  }
+  if (typeof raw !== 'string') {
+    throw new Error(`${key} must be true/false`)
+  }
+
+  const normalized = raw.trim().toLowerCase()
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
+    return true
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'off') {
+    return false
+  }
+  throw new Error(`${key} must be true/false`)
+}
+
+function parseStoredBoolean(raw: string, key: SettingKey): boolean {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'boolean') {
+      throw new Error(`Stored value for ${key} is not boolean`)
+    }
+    return parsed
+  } catch (err) {
+    throw new Error(`Invalid stored value for ${key}: ${(err as Error).message}`)
+  }
+}
+
+function buildDefaultObservability(config: Config): Config['observability'] {
+  return {
+    agentStreaming: config.observability?.agentStreaming ?? true,
+    eventRetention: config.observability?.eventRetention ?? 1000,
+    sessionLogs: config.observability?.sessionLogs ?? true,
+    sessionLogRetention: config.observability?.sessionLogRetention ?? 7,
+  }
+}

--- a/src/settings/runtime.ts
+++ b/src/settings/runtime.ts
@@ -1,0 +1,214 @@
+import type Database from 'better-sqlite3'
+import type { Config } from '../config/schema.js'
+import { logger } from '../utils/logger.js'
+import {
+  getSettingDefinition,
+  listSettingDefinitions,
+  type SettingDefinition,
+  type SettingKey,
+  type SettingType,
+  type SettingValue,
+} from './registry.js'
+import { SettingOverrideStore, type SettingOverrideRow } from '../state/settings.js'
+
+export interface RuntimeSettingSnapshot {
+  key: SettingKey
+  label: string
+  description: string
+  type: SettingType
+  min?: number
+  max?: number
+  step?: number
+  baseValue: SettingValue
+  overrideValue: SettingValue | null
+  effectiveValue: SettingValue
+  source: 'base' | 'override'
+  updatedBy: string | null
+  updatedAt: string | null
+}
+
+export interface RuntimeSettingMutationResult {
+  changed: boolean
+  setting: RuntimeSettingSnapshot
+  effectiveConfig: Config
+}
+
+export class RuntimeSettingInputError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RuntimeSettingInputError'
+  }
+}
+
+interface ParsedOverride {
+  row: SettingOverrideRow
+  definition: SettingDefinition
+  value: SettingValue
+}
+
+export function listRuntimeSettings(
+  baseConfig: Config,
+  db: Database.Database,
+): RuntimeSettingSnapshot[] {
+  const parsedOverrides = parseSettingOverrides(db)
+
+  return listSettingDefinitions().map((definition) => {
+    const override = parsedOverrides.get(definition.key)
+    const baseValue = definition.read(baseConfig)
+    const overrideValue = override?.value ?? null
+    const effectiveValue = overrideValue ?? baseValue
+
+    return {
+      key: definition.key,
+      label: definition.label,
+      description: definition.description,
+      type: definition.type,
+      ...(definition.type === 'number'
+        ? {
+            ...(definition.min !== undefined ? { min: definition.min } : {}),
+            ...(definition.max !== undefined ? { max: definition.max } : {}),
+            ...(definition.step !== undefined ? { step: definition.step } : {}),
+          }
+        : {}),
+      baseValue,
+      overrideValue,
+      effectiveValue,
+      source: overrideValue === null ? 'base' : 'override',
+      updatedBy: override?.row.updatedBy ?? null,
+      updatedAt: override?.row.updatedAt ?? null,
+    }
+  })
+}
+
+export function resolveConfigWithRuntimeSettings(
+  baseConfig: Config,
+  db: Database.Database,
+): Config {
+  const parsedOverrides = parseSettingOverrides(db)
+  let effectiveConfig = baseConfig
+
+  for (const definition of listSettingDefinitions()) {
+    const override = parsedOverrides.get(definition.key)
+    if (!override) continue
+    if (definition.type === 'number') {
+      if (typeof override.value !== 'number') continue
+      effectiveConfig = definition.apply(effectiveConfig, override.value)
+      continue
+    }
+    if (typeof override.value !== 'boolean') continue
+    effectiveConfig = definition.apply(effectiveConfig, override.value)
+  }
+
+  return effectiveConfig
+}
+
+export function setRuntimeSettingOverride(
+  baseConfig: Config,
+  db: Database.Database,
+  key: string,
+  rawValue: unknown,
+  updatedBy: string | null = null,
+): RuntimeSettingMutationResult {
+  const definition = requireSettingDefinition(key)
+  let serialized: string
+  try {
+    if (definition.type === 'number') {
+      const parsedValue = definition.parseInput(rawValue)
+      serialized = definition.serialize(parsedValue)
+    } else {
+      const parsedValue = definition.parseInput(rawValue)
+      serialized = definition.serialize(parsedValue)
+    }
+  } catch (err) {
+    throw new RuntimeSettingInputError((err as Error).message)
+  }
+  const store = new SettingOverrideStore(db)
+  const existing = store.get(definition.key)
+  const changed = !existing || existing.value !== serialized
+
+  if (changed) {
+    store.upsert(definition.key, serialized, updatedBy)
+  }
+
+  const setting = listRuntimeSettings(baseConfig, db).find((entry) => entry.key === definition.key)
+  if (!setting) {
+    throw new Error(`Failed to resolve setting after update: ${definition.key}`)
+  }
+
+  return {
+    changed,
+    setting,
+    effectiveConfig: resolveConfigWithRuntimeSettings(baseConfig, db),
+  }
+}
+
+export function clearRuntimeSettingOverride(
+  baseConfig: Config,
+  db: Database.Database,
+  key: string,
+): RuntimeSettingMutationResult {
+  const definition = requireSettingDefinition(key)
+  const store = new SettingOverrideStore(db)
+  const changed = store.delete(definition.key)
+
+  const setting = listRuntimeSettings(baseConfig, db).find((entry) => entry.key === definition.key)
+  if (!setting) {
+    throw new Error(`Failed to resolve setting after clear: ${definition.key}`)
+  }
+
+  return {
+    changed,
+    setting,
+    effectiveConfig: resolveConfigWithRuntimeSettings(baseConfig, db),
+  }
+}
+
+function requireSettingDefinition(key: string): SettingDefinition {
+  const definition = getSettingDefinition(key)
+  if (!definition) {
+    const available = listSettingDefinitions().map((entry) => entry.key).join(', ')
+    throw new RuntimeSettingInputError(`Unknown setting key "${key}". Supported keys: ${available}`)
+  }
+  return definition
+}
+
+function parseSettingOverrides(db: Database.Database): Map<SettingKey, ParsedOverride> {
+  const maybeDb = db as unknown as { prepare?: unknown }
+  if (typeof maybeDb.prepare !== 'function') {
+    return new Map()
+  }
+
+  const store = new SettingOverrideStore(db)
+  let rows: SettingOverrideRow[]
+  try {
+    rows = store.list()
+  } catch (err) {
+    logger.warn({ err: (err as Error).message }, 'Failed to load runtime settings overrides')
+    return new Map()
+  }
+  const parsed = new Map<SettingKey, ParsedOverride>()
+
+  for (const row of rows) {
+    const definition = getSettingDefinition(row.key)
+    if (!definition) {
+      logger.warn({ key: row.key }, 'Ignoring unknown runtime setting override key')
+      continue
+    }
+
+    try {
+      const value = definition.parseStored(row.value)
+      parsed.set(definition.key, {
+        row,
+        definition,
+        value,
+      })
+    } catch (err) {
+      logger.warn(
+        { key: row.key, err: (err as Error).message },
+        'Ignoring invalid runtime setting override value',
+      )
+    }
+  }
+
+  return parsed
+}

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -13,6 +13,7 @@ import { up as migration008 } from './migrations/008-agent-events.js'
 import { up as migration009 } from './migrations/009-run-titles.js'
 import { up as migration010 } from './migrations/010-issues.js'
 import { up as migration011 } from './migrations/011-rebuild-issues-from-latest-run.js'
+import { up as migration012 } from './migrations/012-settings-overrides.js'
 
 const MIGRATIONS = [
   { version: 1, name: '001-initial', up: migration001 },
@@ -26,6 +27,7 @@ const MIGRATIONS = [
   { version: 9, name: '009-run-titles', up: migration009 },
   { version: 10, name: '010-issues', up: migration010 },
   { version: 11, name: '011-rebuild-issues-from-latest-run', up: migration011 },
+  { version: 12, name: '012-settings-overrides', up: migration012 },
 ]
 
 export function initDatabase(dbPath: string): Database.Database {

--- a/src/state/migrations/012-settings-overrides.ts
+++ b/src/state/migrations/012-settings-overrides.ts
@@ -1,0 +1,15 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS settings_overrides (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_by TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_settings_overrides_updated_at
+      ON settings_overrides(updated_at);
+  `)
+}

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,0 +1,79 @@
+import type Database from 'better-sqlite3'
+import { nowUtcIso } from '../utils/time.js'
+
+export interface SettingOverrideRow {
+  key: string
+  value: string
+  updatedBy: string | null
+  updatedAt: string
+}
+
+interface RawSettingOverrideRow {
+  key: string
+  value: string
+  updated_by: string | null
+  updated_at: string
+}
+
+export class SettingOverrideStore {
+  constructor(private db: Database.Database) {}
+
+  list(): SettingOverrideRow[] {
+    const rows = this.db
+      .prepare(
+        `SELECT key, value, updated_by, updated_at
+         FROM settings_overrides
+         ORDER BY key`,
+      )
+      .all() as RawSettingOverrideRow[]
+    return rows.map(mapSettingOverrideRow)
+  }
+
+  get(key: string): SettingOverrideRow | null {
+    const row = this.db
+      .prepare(
+        `SELECT key, value, updated_by, updated_at
+         FROM settings_overrides
+         WHERE key = ?`,
+      )
+      .get(key) as RawSettingOverrideRow | undefined
+    return row ? mapSettingOverrideRow(row) : null
+  }
+
+  upsert(key: string, value: string, updatedBy: string | null): SettingOverrideRow {
+    const updatedAt = nowUtcIso()
+    this.db
+      .prepare(
+        `INSERT INTO settings_overrides (key, value, updated_by, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET
+           value = excluded.value,
+           updated_by = excluded.updated_by,
+           updated_at = excluded.updated_at`,
+      )
+      .run(key, value, updatedBy, updatedAt)
+
+    return this.get(key) ?? {
+      key,
+      value,
+      updatedBy,
+      updatedAt,
+    }
+  }
+
+  delete(key: string): boolean {
+    const result = this.db
+      .prepare('DELETE FROM settings_overrides WHERE key = ?')
+      .run(key)
+    return result.changes > 0
+  }
+}
+
+function mapSettingOverrideRow(row: RawSettingOverrideRow): SettingOverrideRow {
+  return {
+    key: row.key,
+    value: row.value,
+    updatedBy: row.updated_by,
+    updatedAt: row.updated_at,
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -14,6 +14,11 @@ import { loadTuiStats } from '../state/stats.js'
 import { getBuildInfo } from '../utils/build-info.js'
 import { logger } from '../utils/logger.js'
 import { nowUtcIso } from '../utils/time.js'
+import {
+  listRuntimeSettings,
+  resolveConfigWithRuntimeSettings,
+  RuntimeSettingInputError,
+} from '../settings/runtime.js'
 
 export interface WebServerOptions {
   host: string
@@ -42,6 +47,11 @@ interface DashboardSnapshot {
     pollIntervalSeconds: number
   }
   stats: ReturnType<typeof loadTuiStats>
+}
+
+interface SettingsSnapshot {
+  generatedAt: string
+  settings: ReturnType<typeof listRuntimeSettings>
 }
 
 type CommandSpec = string | string[]
@@ -369,6 +379,10 @@ async function handleApiRequest(
 ): Promise<void> {
   const method = req.method ?? 'GET'
   const { pathname, searchParams } = requestUrl
+  const runtimeDeps: MCPDependencies = {
+    ...deps,
+    config: resolveConfigWithRuntimeSettings(deps.config, deps.db),
+  }
 
   if (method === 'POST' && pathname.startsWith('/api/operations/')) {
     // Update is a supervisor operation — always allowed regardless of attach/standalone mode
@@ -390,13 +404,19 @@ async function handleApiRequest(
   }
 
   if (method === 'GET' && pathname === '/api/dashboard') {
-    const snapshot = await buildDashboardSnapshot(deps)
+    const snapshot = await buildDashboardSnapshot(runtimeDeps)
     writeJson(res, 200, snapshot)
     return
   }
 
   if (method === 'GET' && pathname === '/api/projects') {
-    const snapshot = buildProjectsSnapshot(deps)
+    const snapshot = buildProjectsSnapshot(runtimeDeps)
+    writeJson(res, 200, snapshot)
+    return
+  }
+
+  if (method === 'GET' && pathname === '/api/settings') {
+    const snapshot = buildSettingsSnapshot(deps)
     writeJson(res, 200, snapshot)
     return
   }
@@ -411,7 +431,7 @@ async function handleApiRequest(
 
   if (method === 'GET' && pathname === '/api/status') {
     const repo = searchParams.get('repo') ?? undefined
-    const result = await handleToolCall('night-orch-status', { repo }, deps)
+    const result = await handleToolCall('night-orch-status', { repo }, runtimeDeps)
     writeJson(res, 200, result)
     return
   }
@@ -420,25 +440,25 @@ async function handleApiRequest(
     const repo = searchParams.get('repo') ?? undefined
     const status = searchParams.get('status') ?? undefined
     const limit = toBoundedInt(searchParams.get('limit'), 50, 1, 500)
-    const result = await handleToolCall('night-orch-list-runs', { repo, status, limit }, deps)
+    const result = await handleToolCall('night-orch-list-runs', { repo, status, limit }, runtimeDeps)
     writeJson(res, 200, result)
     return
   }
 
   if (method === 'GET' && pathname === '/api/cost') {
     const days = toBoundedInt(searchParams.get('days'), 7, 1, 30)
-    const result = await handleToolCall('night-orch-cost-report', { days }, deps)
+    const result = await handleToolCall('night-orch-cost-report', { days }, runtimeDeps)
     writeJson(res, 200, result)
     return
   }
 
   if (method === 'GET' && pathname === '/api/stats') {
-    writeJson(res, 200, loadTuiStats(deps.db))
+    writeJson(res, 200, loadTuiStats(runtimeDeps.db))
     return
   }
 
   if (method === 'GET' && pathname === '/api/config') {
-    const result = await handleResourceRead('night-orch://config', deps)
+    const result = await handleResourceRead('night-orch://config', runtimeDeps)
     writeJson(res, 200, result)
     return
   }
@@ -447,7 +467,7 @@ async function handleApiRequest(
     const runDetailMatch = pathname.match(/^\/api\/runs\/([^/]+)$/)
     if (runDetailMatch) {
       const runId = decodeURIComponent(runDetailMatch[1] ?? '')
-      const result = await handleToolCall('night-orch-run-detail', { runId }, deps)
+      const result = await handleToolCall('night-orch-run-detail', { runId }, runtimeDeps)
       writeJson(res, 200, result)
       return
     }
@@ -457,7 +477,7 @@ async function handleApiRequest(
       const runId = decodeURIComponent(runEventsMatch[1] ?? '')
       const since = toBoundedInt(searchParams.get('since'), 0, 0, Number.MAX_SAFE_INTEGER)
       const limit = toBoundedInt(searchParams.get('limit'), 100, 1, 200)
-      const result = await handleToolCall('night-orch-stream-events', { runId, since, limit }, deps)
+      const result = await handleToolCall('night-orch-stream-events', { runId, since, limit }, runtimeDeps)
       writeJson(res, 200, result)
       return
     }
@@ -466,7 +486,7 @@ async function handleApiRequest(
     if (repoIssuesMatch) {
       const repo = decodeURIComponent(repoIssuesMatch[1] ?? '')
       const filter = searchParams.get('filter') ?? 'all'
-      const result = await handleToolCall('night-orch-list-issues', { repo, filter }, deps)
+      const result = await handleToolCall('night-orch-list-issues', { repo, filter }, runtimeDeps)
       writeJson(res, 200, result)
       return
     }
@@ -477,7 +497,7 @@ async function handleApiRequest(
     const result = await handleToolCall(
       'night-orch-poll',
       withMcpMutationAuth({ dryRun: Boolean(body['dryRun']) }, security),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -488,7 +508,7 @@ async function handleApiRequest(
     const result = await handleToolCall(
       'night-orch-sync',
       withMcpMutationAuth({ dryRun: Boolean(body['dryRun']) }, security),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -499,7 +519,7 @@ async function handleApiRequest(
     const result = await handleToolCall(
       'night-orch-cleanup',
       withMcpMutationAuth({ dryRun: Boolean(body['dryRun']) }, security),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -523,7 +543,7 @@ async function handleApiRequest(
         },
         security,
       ),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -550,7 +570,7 @@ async function handleApiRequest(
         },
         security,
       ),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -576,7 +596,7 @@ async function handleApiRequest(
         },
         security,
       ),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -601,7 +621,7 @@ async function handleApiRequest(
         },
         security,
       ),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
     return
@@ -628,9 +648,62 @@ async function handleApiRequest(
         },
         security,
       ),
-      deps,
+      runtimeDeps,
     )
     writeJson(res, 200, result)
+    return
+  }
+
+  if (method === 'POST' && pathname === '/api/operations/settings/set') {
+    const body = await readJsonBody(req)
+    const key = toNonEmptyString(body['key'])
+    const value = body['value']
+
+    if (!key || value === undefined) {
+      writeJson(res, 400, { error: 'key and value are required' })
+      return
+    }
+
+    try {
+      const result = await handleToolCall(
+        'night-orch-set-setting',
+        withMcpMutationAuth({ key, value }, security),
+        deps,
+      )
+      writeJson(res, 200, result)
+    } catch (err) {
+      if (isRuntimeSettingInputError(err)) {
+        writeJson(res, 400, { error: (err as Error).message })
+        return
+      }
+      throw err
+    }
+    return
+  }
+
+  if (method === 'POST' && pathname === '/api/operations/settings/clear') {
+    const body = await readJsonBody(req)
+    const key = toNonEmptyString(body['key'])
+
+    if (!key) {
+      writeJson(res, 400, { error: 'key is required' })
+      return
+    }
+
+    try {
+      const result = await handleToolCall(
+        'night-orch-clear-setting',
+        withMcpMutationAuth({ key }, security),
+        deps,
+      )
+      writeJson(res, 200, result)
+    } catch (err) {
+      if (isRuntimeSettingInputError(err)) {
+        writeJson(res, 400, { error: (err as Error).message })
+        return
+      }
+      throw err
+    }
     return
   }
 
@@ -1015,10 +1088,15 @@ function toNonEmptyString(value: unknown): string | null {
 }
 
 async function buildDashboardSnapshot(deps: MCPDependencies): Promise<DashboardSnapshot> {
+  const runtimeConfig = resolveConfigWithRuntimeSettings(deps.config, deps.db)
+  const runtimeDeps: MCPDependencies = {
+    ...deps,
+    config: runtimeConfig,
+  }
   const [status, runs, cost] = await Promise.all([
-    handleToolCall('night-orch-status', {}, deps),
-    handleToolCall('night-orch-list-runs', { limit: 100 }, deps),
-    handleToolCall('night-orch-cost-report', { days: 7 }, deps),
+    handleToolCall('night-orch-status', {}, runtimeDeps),
+    handleToolCall('night-orch-list-runs', { limit: 100 }, runtimeDeps),
+    handleToolCall('night-orch-cost-report', { days: 7 }, runtimeDeps),
   ])
 
   return {
@@ -1028,10 +1106,10 @@ async function buildDashboardSnapshot(deps: MCPDependencies): Promise<DashboardS
     cost,
     build: BUILD_INFO,
     config: {
-      repos: deps.config.repos.map((repo) => repo.repo),
-      pollIntervalSeconds: deps.config.github.pollIntervalSeconds,
+      repos: runtimeConfig.repos.map((repo) => repo.repo),
+      pollIntervalSeconds: runtimeConfig.github.pollIntervalSeconds,
     },
-    stats: loadTuiStats(deps.db),
+    stats: loadTuiStats(runtimeDeps.db),
   }
 }
 
@@ -1049,6 +1127,13 @@ function buildProjectsSnapshot(deps: MCPDependencies): ProjectsSnapshot {
       ]),
     ),
     repos: deps.config.repos.map((repo) => sanitizeProjectRepo(repo)),
+  }
+}
+
+function buildSettingsSnapshot(deps: MCPDependencies): SettingsSnapshot {
+  return {
+    generatedAt: nowUtcIso(),
+    settings: listRuntimeSettings(deps.config, deps.db),
   }
 }
 
@@ -1319,6 +1404,13 @@ function isClientRequestError(message: string): boolean {
 
 function isAuthorizationError(message: string): boolean {
   return message.startsWith('Unauthorized:')
+}
+
+function isRuntimeSettingInputError(err: unknown): err is RuntimeSettingInputError {
+  if (err instanceof RuntimeSettingInputError) {
+    return true
+  }
+  return err instanceof Error && err.name === 'RuntimeSettingInputError'
 }
 
 function decodeWsMessage(raw: unknown): string | null {

--- a/test/cli/tui/actions-bar.test.ts
+++ b/test/cli/tui/actions-bar.test.ts
@@ -14,7 +14,7 @@ describe('buildActionHints', () => {
       autoRefresh: true,
     }))
 
-    expect(sections.navigation).toContain('[1-4]tabs [h/l]tabs [j/k]select issue [o/enter]open')
+    expect(sections.navigation).toContain('[1-5]tabs [h/l]tabs [j/k]select issue [o/enter]open')
     expect(sections.global).toContain('[q]quit [r]refresh [p]poll [s]sync [L]labels-init [D]cleanup(confirm)')
     expect(sections.issue).toContain('[t]retry [T]retry fresh [c]continue [_]rebase [X]delete entry')
   })
@@ -40,7 +40,7 @@ describe('buildActionHints', () => {
       autoRefresh: true,
     }))
 
-    expect(sections.navigation).toContain('[1-4]tabs [h/l]tabs [j/k]scroll run')
+    expect(sections.navigation).toContain('[1-5]tabs [h/l]tabs [j/k]scroll run')
     expect(sections.global).toContain('[q/esc]close [r]refresh')
     expect(sections.issue).toContain('focused run detail')
   })
@@ -53,7 +53,7 @@ describe('buildActionHints', () => {
       autoRefresh: false,
     }))
 
-    expect(sections.navigation).toBe('[1-4]tabs [h/l]tabs')
+    expect(sections.navigation).toBe('[1-5]tabs [h/l]tabs')
     expect(sections.global).toContain('[q]quit [r]refresh [a]toggle auto-refresh')
     expect(sections.issue).not.toContain('retry')
     expect(sections.issue).not.toContain('rebase')
@@ -95,5 +95,17 @@ describe('buildActionHints', () => {
     expect(sections.navigation).toContain('[j/k]select log [J/K]scroll raw')
     expect(sections.global).toContain('[q]quit [r]refresh')
     expect(sections.issue).toContain('runs tab')
+  })
+
+  it('shows settings controls on settings tab', () => {
+    const sections = sectionMap(buildActionHints({
+      activeTab: 'settings',
+      busy: false,
+      runFocused: false,
+      autoRefresh: true,
+    }))
+
+    expect(sections.navigation).toContain('[1-5]tabs [h/l]tabs [j/k]select setting')
+    expect(sections.issue).toContain('[+/-]adjust number [space]toggle bool [u]unset override')
   })
 })

--- a/test/cli/tui/app-input.test.ts
+++ b/test/cli/tui/app-input.test.ts
@@ -17,6 +17,7 @@ describe('tui app input helpers', () => {
     expect(resolveTabHotkey('2')).toBe('projects')
     expect(resolveTabHotkey('3')).toBe('stats')
     expect(resolveTabHotkey('4')).toBe('logs')
+    expect(resolveTabHotkey('5')).toBe('settings')
     expect(resolveTabHotkey('x')).toBeNull()
   })
 

--- a/test/mcp/integration.test.ts
+++ b/test/mcp/integration.test.ts
@@ -52,10 +52,13 @@ describe('MCP Integration', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('lists all 15 tools', async () => {
+  it('lists all 18 tools', async () => {
     const result = await client.listTools()
-    expect(result.tools.length).toBe(15)
+    expect(result.tools.length).toBe(18)
     const names = result.tools.map((t) => t.name)
+    expect(names).toContain('night-orch-list-settings')
+    expect(names).toContain('night-orch-set-setting')
+    expect(names).toContain('night-orch-clear-setting')
     expect(names).toContain('night-orch-status')
     expect(names).toContain('night-orch-poll')
     expect(names).toContain('night-orch-list-issues')

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -44,6 +44,9 @@ describe('MCP Tools', () => {
   it('registers all expected tools', () => {
     const tools = registerTools()
     const names = tools.map((t) => t.name)
+    expect(names).toContain('night-orch-list-settings')
+    expect(names).toContain('night-orch-set-setting')
+    expect(names).toContain('night-orch-clear-setting')
     expect(names).toContain('night-orch-status')
     expect(names).toContain('night-orch-run-detail')
     expect(names).toContain('night-orch-list-runs')
@@ -58,7 +61,43 @@ describe('MCP Tools', () => {
     expect(names).toContain('night-orch-stream-events')
     expect(names).toContain('night-orch-rebase')
     expect(names).toContain('night-orch-continue')
-    expect(tools.length).toBe(15)
+    expect(tools.length).toBe(18)
+  })
+
+  it('settings tools list/set/clear runtime overrides', async () => {
+    const listedBefore = await handleToolCall('night-orch-list-settings', {}, deps) as {
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+    }
+    const pollSettingBefore = listedBefore.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(pollSettingBefore).toBeDefined()
+    expect(pollSettingBefore?.source).toBe('base')
+
+    const setResult = await handleToolCall(
+      'night-orch-set-setting',
+      { key: 'github.pollIntervalSeconds', value: '120' },
+      deps,
+    ) as { changed: boolean; setting: { key: string; effectiveValue: number; source: string } }
+    expect(setResult.changed).toBe(true)
+    expect(setResult.setting.key).toBe('github.pollIntervalSeconds')
+    expect(setResult.setting.effectiveValue).toBe(120)
+    expect(setResult.setting.source).toBe('override')
+
+    const listedAfter = await handleToolCall('night-orch-list-settings', {}, deps) as {
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+    }
+    const pollSettingAfter = listedAfter.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(pollSettingAfter?.effectiveValue).toBe(120)
+    expect(pollSettingAfter?.source).toBe('override')
+
+    const clearResult = await handleToolCall(
+      'night-orch-clear-setting',
+      { key: 'github.pollIntervalSeconds' },
+      deps,
+    ) as { changed: boolean; setting: { key: string; effectiveValue: number; source: string } }
+    expect(clearResult.changed).toBe(true)
+    expect(clearResult.setting.key).toBe('github.pollIntervalSeconds')
+    expect(clearResult.setting.effectiveValue).toBe(300)
+    expect(clearResult.setting.source).toBe('base')
   })
 
   it('status tool returns summary', async () => {

--- a/test/settings/runtime.test.ts
+++ b/test/settings/runtime.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type Database from 'better-sqlite3'
+import type { Config } from '../../src/config/schema.js'
+import { initDatabase } from '../../src/state/db.js'
+import {
+  clearRuntimeSettingOverride,
+  listRuntimeSettings,
+  resolveConfigWithRuntimeSettings,
+  setRuntimeSettingOverride,
+} from '../../src/settings/runtime.js'
+
+function makeMinimalConfig(): Config {
+  return {
+    version: 1,
+    github: {
+      tokenEnv: 'GITHUB_TOKEN',
+      apiBaseUrl: 'https://api.github.com',
+      pollIntervalSeconds: 300,
+      appMentions: {},
+    },
+    storage: {
+      dbPath: '/tmp/state.db',
+      worktreeRoot: '/tmp/worktrees',
+      logsRoot: '/tmp/logs',
+      autoCleanup: {
+        enabled: true,
+        intervalMinutes: 60,
+      },
+      retention: {
+        worktreeAgeDays: 7,
+        detailDays: 30,
+        archiveDays: 90,
+      },
+    },
+    notifications: {
+      channels: [{ type: 'console' }],
+      events: {
+        onRunStarted: false,
+        onBlocked: true,
+        onPrReady: true,
+        onError: true,
+        onRetryExhausted: true,
+      },
+    },
+    loop: {
+      maxReviewIterations: 4,
+      maxTotalAgentPasses: 10,
+      stopOnPlannerFailure: true,
+      requireVerificationPass: true,
+      reviewApprovalKeyword: 'APPROVED',
+      reviewNeedsChangesKeyword: 'CHANGES_REQUIRED',
+      blockOnAmbiguousReview: true,
+      maxAutoRetries: 3,
+      decompose: false,
+      maxSubtasks: 5,
+      maxConcurrentSubtasks: 3,
+    },
+    security: {
+      maxChangedFiles: 50,
+      maxChangedLines: 5000,
+      maxDailyCostUsd: 50,
+      maxCostPerRunUsd: 10,
+    },
+    workerProfiles: {},
+    metrics: {
+      enabled: false,
+      port: 9090,
+      host: '127.0.0.1',
+    },
+    observability: {
+      agentStreaming: true,
+      eventRetention: 1000,
+      sessionLogs: true,
+      sessionLogRetention: 7,
+    },
+    mcp: {
+      enabled: true,
+      transport: 'stdio',
+      authTokenEnv: null,
+      httpHost: '127.0.0.1',
+      httpPort: 3100,
+    },
+    commentCommands: {
+      enabled: true,
+      requireCollaborator: false,
+    },
+    repos: [{
+      repo: 'org/repo',
+      forge: 'github',
+      linkedProjects: [],
+      localPath: '/tmp/repo',
+      maxConcurrentRuns: 1,
+      baseBranch: 'main',
+      branchPrefix: 'orch',
+      labels: {
+        ready: ['orch:ready'],
+        running: 'orch:running',
+        blocked: 'orch:blocked',
+        needsHuman: 'orch:needs-human',
+        reviewReady: 'orch:review-ready',
+        error: 'orch:error',
+        retry: 'orch:retry',
+        planning: 'orch:planning',
+        mergeQueued: 'orch:merge-queued',
+        merging: 'orch:merging',
+        mergeFailed: 'orch:merge-failed',
+      },
+      labelConfig: {},
+      defaults: {
+        planner: 'claude',
+        coder: 'claude',
+        reviewer: 'claude',
+        doneMode: 'pr-ready',
+        notifyPriority: 'normal',
+        prMentions: [],
+      },
+      verify: [],
+      planning: {
+        prdDirectory: 'docs/prd',
+      },
+      selectors: {
+        includeLabelsAny: ['orch:ready'],
+        excludeLabelsAny: ['orch:blocked'],
+      },
+      agents: {},
+      mergeQueue: {
+        enabled: false,
+        batchSize: 5,
+        mergeMethod: 'merge',
+        retryFlakyOnce: true,
+        requireApproval: true,
+        stagingBranchPrefix: 'orch/staging',
+      },
+    }],
+    workflows: {},
+  }
+}
+
+describe('runtime settings', () => {
+  let tmpDir: string
+  let db: Database.Database
+  let baseConfig: Config
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'night-orch-settings-test-'))
+    db = initDatabase(join(tmpDir, 'test.db'))
+    baseConfig = makeMinimalConfig()
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('lists curated settings with base values by default', () => {
+    const settings = listRuntimeSettings(baseConfig, db)
+    expect(settings).toHaveLength(5)
+
+    const poll = settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(poll).toMatchObject({
+      source: 'base',
+      baseValue: 300,
+      effectiveValue: 300,
+      overrideValue: null,
+    })
+  })
+
+  it('applies set and clear override mutations', () => {
+    const setResult = setRuntimeSettingOverride(
+      baseConfig,
+      db,
+      'github.pollIntervalSeconds',
+      '120',
+      'test',
+    )
+    expect(setResult.changed).toBe(true)
+    expect(setResult.setting.source).toBe('override')
+    expect(setResult.setting.effectiveValue).toBe(120)
+
+    const effective = resolveConfigWithRuntimeSettings(baseConfig, db)
+    expect(effective.github.pollIntervalSeconds).toBe(120)
+
+    const clearResult = clearRuntimeSettingOverride(baseConfig, db, 'github.pollIntervalSeconds')
+    expect(clearResult.changed).toBe(true)
+    expect(clearResult.setting.source).toBe('base')
+    expect(clearResult.setting.effectiveValue).toBe(300)
+  })
+
+  it('ignores invalid stored rows and falls back to base values', () => {
+    db.prepare(
+      `INSERT INTO settings_overrides (key, value, updated_by, updated_at)
+       VALUES (?, ?, ?, datetime('now'))`,
+    ).run('github.pollIntervalSeconds', '"oops"', 'test')
+
+    const settings = listRuntimeSettings(baseConfig, db)
+    const poll = settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(poll?.source).toBe('base')
+    expect(poll?.effectiveValue).toBe(300)
+  })
+
+  it('rejects malformed numeric override input strings', () => {
+    expect(() => {
+      setRuntimeSettingOverride(
+        baseConfig,
+        db,
+        'github.pollIntervalSeconds',
+        '120abc',
+        'test',
+      )
+    }).toThrow('github.pollIntervalSeconds must be a finite number')
+
+    expect(() => {
+      setRuntimeSettingOverride(
+        baseConfig,
+        db,
+        'security.maxDailyCostUsd',
+        '12.5usd',
+        'test',
+      )
+    }).toThrow('security.maxDailyCostUsd must be a finite number')
+  })
+})

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -233,6 +233,152 @@ describe('startWebServer', () => {
     await expect(index.text()).resolves.toContain('<!doctype html>')
   })
 
+  it('reads and mutates runtime settings through web APIs', async () => {
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+    const mutationToken = await getMutationToken(baseUrl)
+
+    const initial = await fetch(`${baseUrl}/api/settings`)
+    expect(initial.status).toBe(200)
+    const initialPayload = await initial.json() as {
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+    }
+    const pollBefore = initialPayload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(pollBefore?.source).toBe('base')
+    expect(pollBefore?.effectiveValue).toBe(300)
+
+    const setResponse = await fetch(`${baseUrl}/api/operations/settings/set`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'github.pollIntervalSeconds',
+        value: '120',
+      }),
+    })
+    expect(setResponse.status).toBe(200)
+    await expect(setResponse.json()).resolves.toMatchObject({
+      changed: true,
+      setting: {
+        key: 'github.pollIntervalSeconds',
+        effectiveValue: 120,
+        source: 'override',
+      },
+    })
+
+    const afterSet = await fetch(`${baseUrl}/api/settings`)
+    const afterSetPayload = await afterSet.json() as {
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+    }
+    const pollAfterSet = afterSetPayload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(pollAfterSet?.source).toBe('override')
+    expect(pollAfterSet?.effectiveValue).toBe(120)
+
+    const clearResponse = await fetch(`${baseUrl}/api/operations/settings/clear`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'github.pollIntervalSeconds',
+      }),
+    })
+    expect(clearResponse.status).toBe(200)
+    await expect(clearResponse.json()).resolves.toMatchObject({
+      changed: true,
+      setting: {
+        key: 'github.pollIntervalSeconds',
+        effectiveValue: 300,
+        source: 'base',
+      },
+    })
+  })
+
+  it('returns 400 for invalid runtime settings mutations', async () => {
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+    const mutationToken = await getMutationToken(baseUrl)
+
+    const invalidKeySet = await fetch(`${baseUrl}/api/operations/settings/set`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'github.notASetting',
+        value: '120',
+      }),
+    })
+    expect(invalidKeySet.status).toBe(400)
+    await expect(invalidKeySet.json()).resolves.toMatchObject({
+      error: expect.stringContaining('Unknown setting key'),
+    })
+
+    const invalidValueSet = await fetch(`${baseUrl}/api/operations/settings/set`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'github.pollIntervalSeconds',
+        value: '120abc',
+      }),
+    })
+    expect(invalidValueSet.status).toBe(400)
+    await expect(invalidValueSet.json()).resolves.toMatchObject({
+      error: 'github.pollIntervalSeconds must be a finite number',
+    })
+
+    const invalidKeyClear = await fetch(`${baseUrl}/api/operations/settings/clear`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'github.notASetting',
+      }),
+    })
+    expect(invalidKeyClear.status).toBe(400)
+    await expect(invalidKeyClear.json()).resolves.toMatchObject({
+      error: expect.stringContaining('Unknown setting key'),
+    })
+  })
+
   it('dashboard includes tracked issues that do not have run rows yet', async () => {
     db.prepare(
       `INSERT INTO issues (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { OperationsPanel } from './components/OperationsPanel.js'
 import { ProjectsPage } from './components/ProjectsPage.js'
 import { RunEventStream } from './components/RunEventStream.js'
 import { RunsPanel } from './components/RunsPanel.js'
+import { SettingsPage } from './components/SettingsPage.js'
 import { StatsPage } from './components/StatsPage.js'
 import { extractMessage, formatTimestamp } from './lib/format.js'
 import { STATUS_BADGE_TONE } from './lib/run-tone.js'
@@ -15,6 +16,7 @@ import {
   type DashboardSnapshot,
   type ProjectsSnapshot,
   type RunEvent,
+  type SettingsSnapshot,
   type SessionResponse,
   type UpdateStatus,
   type WsEnvelope,
@@ -26,32 +28,13 @@ const WEB_AUTH_TOKEN_HEADER = 'x-night-orch-web-token'
 const FRONTEND_BUILD_VERSION = import.meta.env.VITE_BUILD_VERSION ?? 'unknown'
 const FRONTEND_BUILD_GIT_SHA = import.meta.env.VITE_BUILD_GIT_SHA ?? 'unknown'
 
-interface PlaceholderPageProps {
-  title: string
-  description: string
-  detail: string
-}
-
-function PlaceholderPage({ title, description, detail }: PlaceholderPageProps): ReactElement {
-  return (
-    <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
-      <div className="card-body p-6 sm:p-8">
-        <h2 className="card-title text-2xl font-semibold capitalize text-base-content">{title}</h2>
-        <p className="max-w-3xl text-sm text-base-content/75">{description}</p>
-        <div className="mt-3 rounded-box border border-dashed border-base-300/70 bg-base-100/50 p-4">
-          <p className="text-xs uppercase tracking-[0.18em] text-base-content/60">Placeholder</p>
-          <p className="mt-1 text-sm text-base-content/80">{detail}</p>
-        </div>
-      </div>
-    </section>
-  )
-}
-
 export function App(): ReactElement {
   const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null)
   const [projectsSnapshot, setProjectsSnapshot] = useState<ProjectsSnapshot | null>(null)
+  const [settingsSnapshot, setSettingsSnapshot] = useState<SettingsSnapshot | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isProjectsLoading, setIsProjectsLoading] = useState(true)
+  const [isSettingsLoading, setIsSettingsLoading] = useState(true)
   const [socketConnected, setSocketConnected] = useState(false)
   const [activePage, setActivePage] = useState<DashboardPage>('issues')
   const [selectedRepo, setSelectedRepo] = useState('all')
@@ -63,6 +46,7 @@ export function App(): ReactElement {
   const [activeOperation, setActiveOperation] = useState<string | null>(null)
   const [webMutationToken, setWebMutationToken] = useState<string | null>(null)
   const [operationsEnabled, setOperationsEnabled] = useState(true)
+  const [settingsDrafts, setSettingsDrafts] = useState<Record<string, string>>({})
 
   const [retryRepo, setRetryRepo] = useState('')
   const [retryIssueNumber, setRetryIssueNumber] = useState('')
@@ -169,20 +153,36 @@ export function App(): ReactElement {
     setProjectsSnapshot(payload)
   }, [])
 
+  const loadSettings = useCallback(async () => {
+    const response = await fetch('/api/settings')
+    if (!response.ok) {
+      throw new Error(`Failed to load settings (${response.status})`)
+    }
+    const payload = await response.json() as SettingsSnapshot
+    setSettingsSnapshot(payload)
+    setSettingsDrafts(
+      Object.fromEntries(
+        payload.settings.map((setting) => [setting.key, String(setting.effectiveValue)]),
+      ),
+    )
+  }, [])
+
   useEffect(() => {
     void (async () => {
       try {
         setIsLoading(true)
         setIsProjectsLoading(true)
-        await Promise.all([loadDashboard(), loadSessionToken(), loadProjects()])
+        setIsSettingsLoading(true)
+        await Promise.all([loadDashboard(), loadSessionToken(), loadProjects(), loadSettings()])
       } catch (err) {
         setErrorMessage((err as Error).message)
       } finally {
         setIsLoading(false)
         setIsProjectsLoading(false)
+        setIsSettingsLoading(false)
       }
     })()
-  }, [loadDashboard, loadProjects, loadSessionToken])
+  }, [loadDashboard, loadProjects, loadSessionToken, loadSettings])
 
   useEffect(() => {
     if (repos.length === 0) {
@@ -367,13 +367,13 @@ export function App(): ReactElement {
 
       const message = extractMessage(body) ?? fallbackMessage
       setFeedbackMessage(message)
-      await loadDashboard()
+      await Promise.all([loadDashboard(), loadSettings()])
     } catch (err) {
       setErrorMessage((err as Error).message)
     } finally {
       setActiveOperation(null)
     }
-  }, [loadDashboard, operationsEnabled, webMutationToken])
+  }, [loadDashboard, loadSettings, operationsEnabled, webMutationToken])
 
   const submitRetry = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -470,6 +470,30 @@ export function App(): ReactElement {
       `Continue pass queued for ${continueRepo}#${issueNumber}`,
     )
   }, [continueIssueNumber, continueRepo, runOperation])
+
+  const applySetting = useCallback(async (key: string) => {
+    const value = settingsDrafts[key]
+    if (value === undefined) {
+      setErrorMessage(`No draft value found for ${key}`)
+      return
+    }
+
+    await runOperation(
+      `setting:set:${key}`,
+      '/api/operations/settings/set',
+      { key, value },
+      `Updated ${key}`,
+    )
+  }, [runOperation, settingsDrafts])
+
+  const clearSetting = useCallback(async (key: string) => {
+    await runOperation(
+      `setting:clear:${key}`,
+      '/api/operations/settings/clear',
+      { key },
+      `Cleared override for ${key}`,
+    )
+  }, [runOperation])
 
   return (
     <main data-theme="black" className="min-h-screen bg-orch-admin">
@@ -617,10 +641,24 @@ export function App(): ReactElement {
         )}
 
         {activePage === 'settings' && (
-          <PlaceholderPage
-            title="settings"
-            description="Environment-level dashboard settings and web preferences will appear here."
-            detail="Settings UI is a placeholder for now."
+          <SettingsPage
+            settings={settingsSnapshot?.settings ?? []}
+            generatedAt={settingsSnapshot?.generatedAt ?? null}
+            isLoading={isSettingsLoading}
+            activeOperation={activeOperation}
+            drafts={settingsDrafts}
+            onDraftChange={(key, value) => {
+              setSettingsDrafts((current) => ({
+                ...current,
+                [key]: value,
+              }))
+            }}
+            onApply={(key) => {
+              void applySetting(key)
+            }}
+            onClear={(key) => {
+              void clearSetting(key)
+            }}
           />
         )}
       </div>

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -1,0 +1,138 @@
+import { type ReactElement } from 'react'
+import type { RuntimeSettingSnapshot } from '../types/dashboard.js'
+
+interface SettingsPageProps {
+  settings: RuntimeSettingSnapshot[]
+  generatedAt: string | null
+  isLoading: boolean
+  activeOperation: string | null
+  drafts: Record<string, string>
+  onDraftChange: (key: string, value: string) => void
+  onApply: (key: string) => void
+  onClear: (key: string) => void
+}
+
+export function SettingsPage({
+  settings,
+  generatedAt,
+  isLoading,
+  activeOperation,
+  drafts,
+  onDraftChange,
+  onApply,
+  onClear,
+}: SettingsPageProps): ReactElement {
+  return (
+    <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+      <div className="card-body p-6 sm:p-8">
+        <h2 className="card-title text-2xl font-semibold capitalize text-base-content">settings</h2>
+        <p className="max-w-3xl text-sm text-base-content/75">
+          Runtime overrides are stored in SQLite and applied on top of YAML/default values.
+        </p>
+        <p className="text-xs text-base-content/60">
+          Last refresh: {generatedAt ?? '-'}
+        </p>
+
+        {isLoading ? (
+          <p className="text-sm text-base-content/70">Loading settings…</p>
+        ) : settings.length === 0 ? (
+          <p className="text-sm text-base-content/70">No curated settings available.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="table table-zebra table-sm">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Base</th>
+                  <th>Override</th>
+                  <th>Effective</th>
+                  <th>Value</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {settings.map((setting) => {
+                  const draft = drafts[setting.key] ?? formatSettingValue(setting.effectiveValue)
+                  const rowBusy = activeOperation === `setting:set:${setting.key}` || activeOperation === `setting:clear:${setting.key}`
+
+                  return (
+                    <tr key={setting.key}>
+                      <td>
+                        <div className="flex flex-col">
+                          <span className="font-mono text-xs">{setting.key}</span>
+                          <span className="text-xs text-base-content/60">{setting.label}</span>
+                        </div>
+                      </td>
+                      <td className="font-mono text-xs">{formatSettingValue(setting.baseValue)}</td>
+                      <td className="font-mono text-xs">
+                        {setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)}
+                      </td>
+                      <td className="font-mono text-xs">
+                        {formatSettingValue(setting.effectiveValue)}
+                        <span className="ml-2 badge badge-ghost badge-xs">{setting.source}</span>
+                      </td>
+                      <td>
+                        {setting.type === 'boolean' ? (
+                          <select
+                            className="select select-bordered select-xs w-28"
+                            value={normalizeBooleanDraft(draft)}
+                            onChange={(event) => onDraftChange(setting.key, event.target.value)}
+                            disabled={rowBusy}
+                          >
+                            <option value="true">true</option>
+                            <option value="false">false</option>
+                          </select>
+                        ) : (
+                          <input
+                            className="input input-bordered input-xs w-32 font-mono"
+                            type="number"
+                            value={draft}
+                            min={setting.min}
+                            max={setting.max}
+                            step={setting.step}
+                            onChange={(event) => onDraftChange(setting.key, event.target.value)}
+                            disabled={rowBusy}
+                          />
+                        )}
+                      </td>
+                      <td>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-info"
+                            onClick={() => onApply(setting.key)}
+                            disabled={rowBusy}
+                          >
+                            apply
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-ghost"
+                            onClick={() => onClear(setting.key)}
+                            disabled={rowBusy}
+                          >
+                            clear
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function formatSettingValue(value: string | number | boolean): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}
+
+function normalizeBooleanDraft(value: string): string {
+  const normalized = value.trim().toLowerCase()
+  return normalized === 'false' ? 'false' : 'true'
+}

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -183,6 +183,29 @@ export interface SessionResponse {
   operationsEnabled?: boolean
 }
 
+export type RuntimeSettingType = 'number' | 'boolean'
+
+export interface RuntimeSettingSnapshot {
+  key: string
+  label: string
+  description: string
+  type: RuntimeSettingType
+  min?: number
+  max?: number
+  step?: number
+  baseValue: number | boolean
+  overrideValue: number | boolean | null
+  effectiveValue: number | boolean
+  source: 'base' | 'override'
+  updatedBy: string | null
+  updatedAt: string | null
+}
+
+export interface SettingsSnapshot {
+  generatedAt: string
+  settings: RuntimeSettingSnapshot[]
+}
+
 export interface UpdateStatus {
   state: string
   error?: string


### PR DESCRIPTION
Closes #96

## Plan
**Objective:** Add DB-backed settings overrides that let users change curated config values at runtime via CLI, MCP, TUI, and Web UI, with server reload on change

1. Create migration 012-settings.ts: CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT DEFAULT datetime('now')). Register in db.ts MIGRATIONS array.
2. Create src/state/settings.ts — SettingsManager class with methods: get(key), getAll(), set(key, value), remove(key), getAllAsRecord(). Uses parameterized queries. Validates keys against an OVERRIDABLE_KEYS allowlist. The allowlist is a Record<string, {type, description, validate}> defining which dot-path config keys can be overridden.
3. Create src/config/settings-overlay.ts — applySettingsOverrides(config: Config, overrides: Record<string,string>): Config function. Takes dot-notation keys (e.g., 'github.pollIntervalSeconds') and deeply merges parsed values onto the config object. Export OVERRIDABLE_SETTINGS constant defining the allowlist with key, type (number/boolean/string), description, and Zod-based validation for each. Initial allowlist: github.pollIntervalSeconds, security.maxDailyCostUsd, security.maxCostPerRunUsd, security.maxChangedFiles, security.maxChangedLines, loop.maxReviewIterations, loop.maxTotalAgentPasses, loop.maxAutoRetries, loop.stopOnPlannerFailure, loop.requireVerificationPass, loop.blockOnAmbiguousReview, loop.decompose, observability.agentStreaming, observability.sessionLogs.
4. Modify src/config/loader.ts — add loadConfigWithOverrides(configPath, db) that calls loadConfig() then reads settings from DB via SettingsManager and calls applySettingsOverrides(). Existing loadConfig() stays unchanged for backward compat. Update CLI commands that load config to use loadConfigWithOverrides when a DB is available.
5. Create src/cli/commands/settings.ts — CLI command with subcommands: 'settings list' (show all overrides + defaults), 'settings set <key> <value>', 'settings get <key>', 'settings reset <key>' (remove override). After set/reset, write trigger file to signal reload (same mechanism as update command).
6. Register the settings CLI command in src/cli/index.ts.
7. Add MCP tools: 'night-orch-settings-list' (list all settings with current values and sources), 'night-orch-settings-set' (set a key to a value, triggers reload), 'night-orch-settings-reset' (remove an override). Add to registerTools() and handleToolCall() in src/mcp/tools/index.ts.
8. Add TUI settings view: Update types.ts to add 'settings' to TabId union. Update constants.ts to add tab entry with hotkey '5'. Create settings-view.tsx showing overridable keys with current value (yaml default vs override) and allowing set/reset via inline editing. Update app.tsx to route to settings view and handle hotkey.
9. Add web API endpoints: GET /api/settings (list all settings with defaults and overrides), POST /api/operations/settings-set (set key/value), POST /api/operations/settings-reset (remove override). POST endpoints trigger reload via IPC/trigger-file. Wire through handleToolCall to MCP tools.
10. Create web/src/components/SettingsPage.tsx — Replace the placeholder settings page. Display a table/card layout of all overridable settings grouped by section (github, security, loop, observability). Each row shows: key, description, YAML default, current override (if any), input to change. Save button calls POST /api/operations/settings-set. Reset button calls POST /api/operations/settings-reset. Update web/src/types/dashboard.ts with SettingsEntry type. Update App.tsx to use SettingsPage instead of PlaceholderPage.
11. Add reload signaling in settings mutation paths: After writing to DB, create trigger file at ~/.config/night-orch/settings-changed (or reuse update-requested). If running under supervisor (process.send available), send IPC message. Supervisor restarts children, which re-read config+overrides on boot.
12. Write tests: test/state/settings.test.ts (SettingsManager CRUD, validation, allowlist enforcement), test/config/settings-overlay.test.ts (overlay merging, type coercion, invalid key rejection). Update test/config/loader.test.ts if loadConfigWithOverrides added.
13. Update docs/CONFIGURATION.md with a new 'Runtime Settings Overrides' section explaining the settings system, which fields are overridable, CLI/web/MCP usage, and reload behavior.

## Implementation
Addressed the two review findings on top of the runtime-settings implementation: web settings mutation endpoints now map settings validation/key errors to HTTP 400 instead of bubbling to HTTP 500, and numeric parsing for runtime setting inputs is now strict so malformed values like "120abc" are rejected. Added regression tests for invalid web settings key/value cases and malformed numeric override strings. Verification passed with `pnpm typecheck`, `pnpm lint`, targeted tests (`test/settings/runtime.test.ts`, `test/web/server.test.ts`), and full `pnpm test` (130 files, 1107 tests).

**Changed files:**
- `src/web/server.ts`
- `src/settings/runtime.ts`
- `src/settings/registry.ts`
- `test/web/server.test.ts`
- `test/settings/runtime.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files in full (runtime settings core, DB migration/store, CLI/TUI/MCP/Web integrations, frontend, docs, and related tests). The previously reported issues are addressed: web settings validation errors now return HTTP 400, and numeric parsing now rejects malformed partial strings. I also ran targeted verification for touched areas: all selected tests passed (72/72). No blocking findings remain; residual risk is limited to light direct coverage of the new `night-orch settings` CLI command formatting paths.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex