### PR TITLE
[CHORE] Runs - directly start next (night-orch / #92)

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -128,9 +128,16 @@ export async function runCommand(globalOpts?: GlobalOpts): Promise<void> {
   // Poll loop
   while (!shutdown.isShuttingDown) {
     try {
-      const runPromise = pollOnce(config, db, dryRun, metrics).then(() => {})
-      shutdown.trackRun(runPromise)
-      await runPromise
+      const runPromise = pollOnce(config, db, dryRun, metrics)
+      shutdown.trackRun(runPromise.then(() => {}))
+      const pollResult = await runPromise
+      if (pollResult.immediateFollowupRepos.length > 0) {
+        const trigger = pollerControl.triggerPollCycle()
+        logger.info(
+          { repos: pollResult.immediateFollowupRepos, triggerState: trigger.state },
+          'Run reached terminal state — scheduling immediate follow-up poll cycle',
+        )
+      }
     } catch (err) {
       logger.error({ err }, 'Poll cycle failed')
     }

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -167,9 +167,16 @@ export async function webCommand(
   // Poll loop
   while (!shutdown.isShuttingDown) {
     try {
-      const runPromise = pollOnce(config, db, dryRun, metrics).then(() => {})
-      shutdown.trackRun(runPromise)
-      await runPromise
+      const runPromise = pollOnce(config, db, dryRun, metrics)
+      shutdown.trackRun(runPromise.then(() => {}))
+      const pollResult = await runPromise
+      if (pollResult.immediateFollowupRepos.length > 0) {
+        const trigger = pollerControl!.triggerPollCycle()
+        logger.info(
+          { repos: pollResult.immediateFollowupRepos, triggerState: trigger.state },
+          'Run reached terminal state — scheduling immediate follow-up poll cycle',
+        )
+      }
     } catch (err) {
       logger.error({ err }, 'Poll cycle failed')
     }

--- a/src/runner/poller.ts
+++ b/src/runner/poller.ts
@@ -63,6 +63,7 @@ const STATUS_MARKER = markerTag('status')
 export interface PollResult {
   processed: number
   errors: number
+  immediateFollowupRepos: string[]
 }
 
 export interface PollTargetIssue {
@@ -90,6 +91,7 @@ export async function pollOnce(
 
   let processed = 0
   let errors = 0
+  const immediateFollowupRepos = new Set<string>()
   const observability = new AgentObservability(db, config)
   setActiveAgentObservability(observability)
 
@@ -116,6 +118,7 @@ export async function pollOnce(
       reposToProcess.map(async (repoConfig): Promise<PollResult> => {
         let repoProcessed = 0
         let repoErrors = 0
+        const repoImmediateFollowupRepos = new Set<string>()
         try {
           const forge = createForgeAdapter(repoConfig, config)
           const channels = createChannels(config.notifications, forge)
@@ -181,14 +184,22 @@ export async function pollOnce(
 
           if (discovered.length === 0) {
             logger.info({ repo: repoConfig.repo }, 'No eligible issues')
-            return { processed: repoProcessed, errors: repoErrors }
+            return {
+              processed: repoProcessed,
+              errors: repoErrors,
+              immediateFollowupRepos: [],
+            }
           }
 
           if (dryRun) {
             for (const d of discovered) {
               logger.info({ issue: d.issue.number, triage: d.triage.level, title: d.issue.title }, '[dry-run] Discovered issue')
             }
-            return { processed: repoProcessed, errors: repoErrors }
+            return {
+              processed: repoProcessed,
+              errors: repoErrors,
+              immediateFollowupRepos: [],
+            }
           }
 
           const maxConcurrentRuns = targetIssue ? 1 : (repoConfig.maxConcurrentRuns ?? 1)
@@ -714,6 +725,13 @@ export async function pollOnce(
                   }
                   repoErrors++
                 } finally {
+                  if (runId) {
+                    const finalRun = runManager.getById(runId)
+                    if (finalRun && isImmediateFollowupStatus(finalRun.status)) {
+                      repoImmediateFollowupRepos.add(finalRun.repo)
+                    }
+                  }
+
                   if (envSetup && activeWorktreePath) {
                     try {
                       await teardownEnvironment({
@@ -733,10 +751,18 @@ export async function pollOnce(
             }),
           )
 
-          return { processed: repoProcessed, errors: repoErrors }
+          return {
+            processed: repoProcessed,
+            errors: repoErrors,
+            immediateFollowupRepos: [...repoImmediateFollowupRepos],
+          }
         } catch (err) {
           logger.error({ repo: repoConfig.repo, err }, 'Repository poll failed')
-          return { processed: repoProcessed, errors: repoErrors + 1 }
+          return {
+            processed: repoProcessed,
+            errors: repoErrors + 1,
+            immediateFollowupRepos: [...repoImmediateFollowupRepos],
+          }
         }
       }),
     )
@@ -744,9 +770,12 @@ export async function pollOnce(
     for (const repoResult of repoResults) {
       processed += repoResult.processed
       errors += repoResult.errors
+      for (const repo of repoResult.immediateFollowupRepos) {
+        immediateFollowupRepos.add(repo)
+      }
     }
 
-    return { processed, errors }
+    return { processed, errors, immediateFollowupRepos: [...immediateFollowupRepos] }
   } finally {
     clearActiveAgentObservability(observability)
     await observability.close()
@@ -1045,6 +1074,13 @@ function coerceAgentName(
     return value
   }
   return fallback
+}
+
+function isImmediateFollowupStatus(status: RunRecord['status']): boolean {
+  return status === 'review_ready'
+    || status === 'blocked'
+    || status === 'error'
+    || status === 'completed'
 }
 
 function applyWorkflowAgentOverrides(

--- a/test/poller/poller.test.ts
+++ b/test/poller/poller.test.ts
@@ -177,6 +177,7 @@ describe('pollOnce', () => {
 
     expect(result.processed).toBe(0)
     expect(result.errors).toBe(0)
+    expect(result.immediateFollowupRepos).toEqual([])
   })
 
   it('dry run logs discovered issues without processing', async () => {
@@ -210,8 +211,10 @@ describe('pollOnce', () => {
 
     expect(result).toHaveProperty('processed')
     expect(result).toHaveProperty('errors')
+    expect(result).toHaveProperty('immediateFollowupRepos')
     expect(typeof result.processed).toBe('number')
     expect(typeof result.errors).toBe('number')
+    expect(Array.isArray(result.immediateFollowupRepos)).toBe(true)
   })
 
   it('trivial issues use lightweight workflow and fallback codex profile-by-type when agent mapping is missing', async () => {
@@ -324,6 +327,7 @@ describe('pollOnce', () => {
 
     expect(result.processed).toBe(1)
     expect(result.errors).toBe(0)
+    expect(result.immediateFollowupRepos).toEqual(['org/repo'])
     expect(mockPublishPR).not.toHaveBeenCalled()
 
     const row = db.prepare('SELECT status FROM runs ORDER BY created_at DESC LIMIT 1').get() as { status: string }
@@ -624,8 +628,35 @@ describe('pollOnce', () => {
 
     expect(result.processed).toBe(0)
     expect(result.errors).toBe(1)
+    expect(result.immediateFollowupRepos).toEqual(['org/repo'])
     const row = db.prepare('SELECT status FROM runs ORDER BY created_at DESC LIMIT 1').get() as { status: string }
     expect(row.status).toBe('error')
+  })
+
+  it('marks publish success as immediate follow-up eligible', async () => {
+    mockDiscoverEligibleIssues.mockResolvedValue([{
+      issue: { number: 1, nodeId: '', title: 'Test', body: '', labels: ['orch:ready'], assignees: [], state: 'open', createdAt: '', updatedAt: '', url: '' },
+      triage: { level: 'standard', reason: '' },
+    }])
+    mockExecuteLoop.mockResolvedValue({
+      currentPhase: 'completed',
+      terminalStatus: 'publish',
+    })
+    mockPublishPR.mockResolvedValueOnce({
+      prNumber: 101,
+      prTitle: 'Test PR',
+      prUrl: 'https://example.com/pr/101',
+      created: true,
+    })
+
+    const config = makeConfig(join(tmpDir, 'test.db'))
+    const result = await pollOnce(config, db, false)
+
+    expect(result.processed).toBe(1)
+    expect(result.errors).toBe(0)
+    expect(result.immediateFollowupRepos).toEqual(['org/repo'])
+    const row = db.prepare('SELECT status FROM runs ORDER BY created_at DESC LIMIT 1').get() as { status: string }
+    expect(row.status).toBe('review_ready')
   })
 
   it('posts a structured auto-retry status comment when publish fails and retries remain', async () => {


### PR DESCRIPTION
Closes #92

## Plan
**Objective:** After a run finishes (done, blocked, error), trigger an immediate poll cycle so the next eligible issue in that repo starts without waiting for the interval timer

1. Add optional `pollerControl?: PollerControl` parameter to `pollOnce()` function signature (after the existing `targetIssue` param)
2. After the `finally` block that releases the lease (line ~730), add a call to `pollerControl?.triggerPollCycle()` to wake the outer loop. This goes right after `leaseManager.release()` inside the finally block. Also trigger after auto-retry label transition in the catch block (line ~662) since a retry-queued issue should be picked up immediately too.
3. Pass `pollerControl` from the call sites in run.ts and web.ts where PollCycleController is available
4. Add/update tests: verify that when pollOnce is given a pollerControl, triggerPollCycle is called after run completion. Test both success and error paths.

## Implementation
Implemented immediate follow-up polling after terminal run outcomes. `pollOnce` now reports `immediateFollowupRepos` whenever a run ends in `review_ready`, `blocked`, `error`, or `completed`. The long-running poll loops in `run` and standalone `web` now consume that signal and call `pollerControl.triggerPollCycle()` so the next eligible issue can start right away instead of waiting for the interval timer. Added/updated poller tests to validate the new PollResult shape and terminal-outcome signaling (including publish success and publish failure paths). Verified with `pnpm test`, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/runner/poller.ts`
- `src/cli/commands/run.ts`
- `src/cli/commands/web.ts`
- `test/poller/poller.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed the full changes in src/runner/poller.ts (including terminal-status collection and PollResult propagation), src/cli/commands/run.ts, src/cli/commands/web.ts, and related tests in test/poller/poller.test.ts/test/poller/control.test.ts. The implementation correctly triggers a coalesced immediate follow-up poll when runs end in terminal states, and does so through existing PollCycleController semantics. No blocking correctness, security, or error-handling regressions were found in the modified paths. Verification was also confirmed by running the test suite (including poller/control coverage), which passed.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex