### PR TITLE
[CHORE] Continue action - improve handling (night-orch / #104)

### DIFF
--- a/src/loop/checkpoint.ts
+++ b/src/loop/checkpoint.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3'
-import type { LoopPhase, RunContext, PlannerOutput, CoderOutput, ReviewerOutput } from './types.js'
+import type { LoopPhase, RunContext, PlannerOutput, CoderOutput, ReviewerOutput, VerifyResult } from './types.js'
 import { IssueManager } from '../state/issues.js'
 import { nowUtcIso } from '../utils/time.js'
 
@@ -75,6 +75,7 @@ export class Checkpoint {
     const planArtifacts = phaseData['plan'] as Record<string, unknown> | undefined
     const codeArtifacts = phaseData['code'] as Record<string, unknown> | undefined
     const reviewArtifacts = phaseData['review'] as Record<string, unknown> | undefined
+    const verifyArtifacts = phaseData['verify'] as Record<string, unknown> | undefined
 
     return {
       ...baseCtx,
@@ -84,6 +85,9 @@ export class Checkpoint {
       estimatedCostUsd: row.estimated_cost_usd ?? baseCtx.estimatedCostUsd,
       plan: (planArtifacts?.plan as PlannerOutput) ?? baseCtx.plan,
       codeResult: (codeArtifacts?.codeResult as CoderOutput) ?? baseCtx.codeResult,
+      verifyResults: Array.isArray(verifyArtifacts?.verifyResults)
+        ? verifyArtifacts.verifyResults as VerifyResult[]
+        : baseCtx.verifyResults,
       reviewResult: (reviewArtifacts?.reviewResult as ReviewerOutput) ?? baseCtx.reviewResult,
     }
   }

--- a/src/loop/engine.ts
+++ b/src/loop/engine.ts
@@ -38,7 +38,8 @@ export async function executeLoop(
   const checkpoint = new Checkpoint(db)
   const costTracker = new CostTracker(db)
 
-  let ctx = checkpoint.resumeFromCheckpoint(initialCtx.runId, initialCtx) ?? initialCtx
+  const resumedCtx = checkpoint.resumeFromCheckpoint(initialCtx.runId, initialCtx)
+  let ctx = resumedCtx ?? initialCtx
 
   const stepDeps: StepDependencies = {
     adapters: deps.adapters,
@@ -49,7 +50,8 @@ export async function executeLoop(
   }
 
   const steps = deps.workflow.steps
-  let stepIndex = 0
+  const checkpointPhaseData = getCheckpointPhaseData(db, initialCtx.runId)
+  let stepIndex = resolveStartingStepIndex(steps, resumedCtx, checkpointPhaseData)
 
   while (stepIndex < steps.length) {
     const step = steps[stepIndex]!
@@ -245,6 +247,70 @@ export async function executeLoop(
 // ---------------------------------------------------------------------------
 
 import type { WorkflowStep } from './workflow.js'
+
+function resolveStartingStepIndex(
+  steps: WorkflowStep[],
+  resumedCtx: RunContext | null,
+  checkpointPhaseData: Readonly<Record<string, unknown>>,
+): number {
+  if (!resumedCtx) return 0
+
+  const resumedPhaseIndex = steps.findIndex((step) => step.id === resumedCtx.currentPhase)
+  if (resumedPhaseIndex === -1) return 0
+
+  const resumedStep = steps[resumedPhaseIndex]!
+  const isCompletedCheckpoint = isStepCheckpointComplete(resumedStep, checkpointPhaseData[resumedStep.id])
+  if (!isCompletedCheckpoint) {
+    return resumedPhaseIndex
+  }
+
+  if (resumedStep.type === 'decide') {
+    const iterateTargetIndex = steps.findIndex((step) => step.id === resumedStep.onIterate)
+    return iterateTargetIndex >= 0 ? iterateTargetIndex : 0
+  }
+
+  const nextStepIndex = resumedPhaseIndex + 1
+  return nextStepIndex < steps.length ? nextStepIndex : resumedPhaseIndex
+}
+
+function getCheckpointPhaseData(
+  db: Database.Database,
+  runId: string,
+): Record<string, unknown> {
+  const row = db
+    .prepare('SELECT phase_data FROM runs WHERE id = ?')
+    .get(runId) as { phase_data: string | null } | undefined
+  if (!row?.phase_data) return {}
+
+  try {
+    const parsed = JSON.parse(row.phase_data) as Record<string, unknown>
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return {}
+    }
+    return parsed
+  } catch {
+    return {}
+  }
+}
+
+function isStepCheckpointComplete(step: WorkflowStep, rawArtifacts: unknown): boolean {
+  if (typeof rawArtifacts !== 'object' || rawArtifacts === null || Array.isArray(rawArtifacts)) {
+    return false
+  }
+
+  const artifacts = rawArtifacts as Record<string, unknown>
+  switch (step.type) {
+    case 'worker':
+      if (step.role === 'planner') return artifacts['plan'] !== null && artifacts['plan'] !== undefined
+      if (step.role === 'coder') return artifacts['codeResult'] !== null && artifacts['codeResult'] !== undefined
+      if (step.role === 'reviewer') return artifacts['reviewResult'] !== null && artifacts['reviewResult'] !== undefined
+      return true
+    case 'verify':
+      return Array.isArray(artifacts['verifyResults'])
+    case 'decide':
+      return true
+  }
+}
 
 function determineStepSuccess(step: WorkflowStep, ctx: RunContext): boolean {
   switch (step.type) {

--- a/src/ops/continue.ts
+++ b/src/ops/continue.ts
@@ -21,6 +21,7 @@ const EMPTY_CURSOR: ReactionCursor = {
 }
 
 const CONTINUABLE_STATUSES = new Set(['blocked', 'review_ready', 'error'])
+const PHASE_CHECKPOINT_FALLBACK_ORDER = ['decide', 'review', 'verify', 'code', 'plan'] as const
 
 export interface QueueContinueOptions {
   issueRepo?: string
@@ -67,9 +68,10 @@ export async function queueContinue(
   })
 
   const existingPhaseData = run.phaseData ?? {}
+  const resumePhase = resolveResumePhase(run.currentPhase, existingPhaseData)
   runManager.update(run.id, {
     status: 'queued',
-    currentPhase: null,
+    currentPhase: resumePhase,
     endedAt: null,
     lastError: null,
     blockReason: null,
@@ -122,6 +124,27 @@ export async function queueContinue(
   )
 
   return { queued: true, reason: `Queued for continue pass (${followup.summary})` }
+}
+
+function resolveResumePhase(
+  currentPhase: string | null,
+  phaseData: Record<string, unknown>,
+): string | null {
+  if (typeof currentPhase === 'string' && currentPhase.trim().length > 0) {
+    return currentPhase
+  }
+
+  for (const phase of PHASE_CHECKPOINT_FALLBACK_ORDER) {
+    if (isCheckpointArtifact(phaseData[phase])) {
+      return phase
+    }
+  }
+
+  return null
+}
+
+function isCheckpointArtifact(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 interface BuildFollowupContextParams {

--- a/test/loop/engine.test.ts
+++ b/test/loop/engine.test.ts
@@ -482,4 +482,250 @@ describe('executeLoop', () => {
     expect(result.blockReason).toBe('ambiguous_review')
     expect(result.stepOutputs['blockMessage']).toBe('Review output not parseable and blockOnAmbiguousReview is true')
   })
+
+  it('re-runs plan when checkpoint only recorded phase start', async () => {
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'plan',
+      JSON.stringify({}),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Recovered plan')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(plannerAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-runs plan when planner checkpoint artifact is null', async () => {
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'plan',
+      JSON.stringify({
+        plan: { plan: null },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Recovered plan')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(plannerAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-runs code when checkpoint has plan completion but code only started', async () => {
+    const persistedPlan = makePlannerResult('Persisted plan').parsed
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'code',
+      JSON.stringify({
+        plan: { plan: persistedPlan },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Should not run')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(plannerAdapter.runTask).not.toHaveBeenCalled()
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-runs code when coder checkpoint artifact is null', async () => {
+    const persistedPlan = makePlannerResult('Persisted plan').parsed
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'code',
+      JSON.stringify({
+        plan: { plan: persistedPlan },
+        code: { codeResult: null },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Should not run')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(plannerAdapter.runTask).not.toHaveBeenCalled()
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores verify results when resuming completed verify checkpoints', async () => {
+    const persistedPlan = makePlannerResult('Persisted plan').parsed
+    const persistedCode = makeCoderResult().parsed
+    const persistedVerifyResults = [{
+      command: 'pnpm test',
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+      durationMs: 1250,
+      passed: true,
+    }]
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'verify',
+      JSON.stringify({
+        plan: { plan: persistedPlan },
+        code: { codeResult: persistedCode },
+        verify: { verifyResults: persistedVerifyResults },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Should not run')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(result.blockReason).toBeNull()
+    expect(result.verifyResults).toEqual(persistedVerifyResults)
+    expect(plannerAdapter.runTask).not.toHaveBeenCalled()
+    expect(coderAdapter.runTask).not.toHaveBeenCalled()
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes from checkpoint and skips completed phases', async () => {
+    const persistedPlan = makePlannerResult('Persisted plan').parsed
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'plan',
+      JSON.stringify({
+        plan: { plan: persistedPlan },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Should not run')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(result.plan).toEqual(persistedPlan)
+    expect(plannerAdapter.runTask).not.toHaveBeenCalled()
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes decide checkpoints at iterate target instead of restarting', async () => {
+    const persistedPlan = makePlannerResult('Persisted plan').parsed
+    const persistedCode = makeCoderResult().parsed
+    const persistedReview = makeReviewerResult('CHANGES_REQUIRED').parsed
+    db.prepare('UPDATE runs SET current_phase = ?, phase_data = ? WHERE id = ?').run(
+      'decide',
+      JSON.stringify({
+        plan: { plan: persistedPlan },
+        code: { codeResult: persistedCode },
+        review: { reviewResult: persistedReview },
+      }),
+      'run-test-1',
+    )
+
+    const plannerAdapter = makeMockAdapter([makePlannerResult('Should not run')])
+    const coderAdapter = makeMockAdapter([makeCoderResult()])
+    const reviewerAdapter = makeMockAdapter([makeReviewerResult('APPROVED')])
+
+    const deps: LoopDependencies = {
+      db,
+      config: makeConfig(),
+      adapters: {
+        planner: plannerAdapter,
+        coder: coderAdapter,
+        reviewer: reviewerAdapter,
+      },
+      workflow: DEFAULT_WORKFLOW,
+    }
+
+    const result = await executeLoop(makeCtx(), deps)
+
+    expect(result.terminalStatus).toBe('publish')
+    expect(plannerAdapter.runTask).not.toHaveBeenCalled()
+    expect(coderAdapter.runTask).toHaveBeenCalledTimes(1)
+    expect(reviewerAdapter.runTask).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/ops/continue.test.ts
+++ b/test/ops/continue.test.ts
@@ -104,6 +104,7 @@ describe('queueContinue', () => {
     })
     runManager.update(run.id, {
       status: 'blocked',
+      currentPhase: 'review',
       prNumber: 901,
       endedAt: '2026-02-01T12:00:00Z',
       lastError: 'Reviewer blocked: unresolved feedback',
@@ -154,6 +155,7 @@ describe('queueContinue', () => {
     expect(result.queued).toBe(true)
     const updated = runManager.getByRepoAndIssue('org/repo', 58)
     expect(updated?.status).toBe('queued')
+    expect(updated?.currentPhase).toBe('review')
     expect(updated?.blockReason).toBeNull()
     expect(updated?.phaseData?.reactionType).toBe('continue')
     expect(updated?.phaseData?.reactionContext).toContain('PR has merge conflicts with base branch')
@@ -251,6 +253,42 @@ describe('queueContinue', () => {
     expect(updated?.status).toBe('queued')
     expect(updated?.phaseData?.reactionType).toBe('continue')
     expect(updated?.phaseData?.reactionContext).toContain('No new CI failures')
+  })
+
+  it('derives resume phase from checkpoint artifacts when current phase is missing', async () => {
+    const runManager = new RunManager(db)
+    const run = runManager.create({
+      repo: 'org/repo',
+      issueNumber: 63,
+      issueNodeId: 'node-63',
+      planner: 'claude',
+      coder: 'claude',
+      reviewer: 'claude',
+    })
+    runManager.update(run.id, {
+      status: 'blocked',
+      endedAt: '2026-02-01T12:00:00Z',
+      phaseData: {
+        issueRepo: 'org/repo',
+        plan: {
+          plan: { objective: 'Fix issue' },
+        },
+        code: {
+          codeResult: { summary: 'done' },
+        },
+      },
+    })
+
+    const forge = makeForge({
+      listIssueComments: vi.fn().mockResolvedValue([]),
+    })
+
+    const result = await queueContinue(db, forge, makeRepoConfig(), 63, '')
+
+    expect(result.queued).toBe(true)
+    const updated = runManager.getByRepoAndIssue('org/repo', 63)
+    expect(updated?.status).toBe('queued')
+    expect(updated?.currentPhase).toBe('code')
   })
 
   it('supports dry-run without mutating state or posting updates', async () => {


### PR DESCRIPTION
Closes #104

## Plan
**Objective:** Make the continue action resume from the last meaningful checkpoint instead of restarting the workflow from scratch, restoring prior plan/code/review artifacts and skipping completed phases

1. In queueContinue(), stop nulling currentPhase. Instead, preserve the current_phase value so checkpoint.resumeFromCheckpoint() can reconstruct the context. Also store the prior iteration count and block reason in phaseData so the engine has the info needed to calculate the resume point. Add a 'continueFromBlock' field to phaseData containing the block reason.
2. In Checkpoint.resumeFromCheckpoint(), enhance artifact restoration to also restore reviewFindings, verifyResults, iteration count, and sessionIds from phaseData if present. Currently it only restores plan, codeResult, and reviewResult. Also store these in phaseCompleted — add iteration and sessionIds to the decide step artifacts so they survive across continue passes.
3. In engine.ts, add a calculateResumeIndex() function that determines the starting stepIndex for the loop. For runMode 'followup' with restored checkpoint data: (a) find the step matching ctx.currentPhase, (b) if the block was at the decide step due to iteration_limit/agent_pass_limit, resume from the decide step's onIterate target (typically 'code'), (c) if blocked at reviewer_blocked/ambiguous_review, resume from the review step. Replace the hardcoded 'let stepIndex = 0' with the calculated value. Also reset iteration counters appropriately — give the continue pass fresh iteration budget while preserving the running cost total.
4. In poller.ts, when building initialCtx for continue/followup runs, restore prior artifacts from the run's phaseData as a fallback source. Specifically: if phaseData contains plan/code/review artifacts, populate them in initialCtx. Also carry forward estimatedCostUsd from the DB rather than resetting to 0. Keep iteration at 1 (fresh budget for the continue pass) but preserve totalAgentPasses from the prior run for cost-limit accounting.
5. Update existing tests for queueContinue to verify that currentPhase is no longer nulled, and that continueFromBlock is stored in phaseData. Add test cases for the new resume logic.
6. Add tests for calculateResumeIndex() covering: (a) fresh run starts at 0, (b) continue after iteration_limit resumes at onIterate target, (c) continue after agent_pass_limit resumes at onIterate target, (d) continue after reviewer_blocked resumes at review step, (e) continue after ambiguous_review resumes at review step, (f) continue after cost_limit resumes at code step. Also test that restored checkpoint artifacts are properly propagated through the resumed loop.
7. Update checkpoint tests to verify enhanced artifact restoration including reviewFindings, sessionIds, and totalAgentPasses.

## Implementation
Implemented the final resume-safety fixes for continue/checkpoint recovery. `executeLoop()` now uses step-aware, artifact-aware checkpoint completion checks instead of key-presence-only logic, so phases are only skipped when their completion artifacts are valid (planner requires non-null `plan`, coder non-null `codeResult`, reviewer non-null `reviewResult`, verify requires `verifyResults` array). Incomplete/failed started phases now correctly re-run instead of being skipped. `resumeFromCheckpoint()` now restores `verifyResults` from `phase_data.verify.verifyResults`, preventing false `verify_config` blocks when resuming after a completed verify step. Added regression tests covering: started-only plan checkpoint, null planner artifact, started-only code checkpoint, null coder artifact, completed verify checkpoint resume (with restored verify results), completed checkpoint skip behavior, and decide checkpoint resume behavior. Also retained prior continue improvements where `queueContinue()` preserves/derives a resumable checkpoint phase. Validation: `pnpm test test/loop/engine.test.ts test/ops/continue.test.ts` and `pnpm typecheck`.

**Changed files:**
- `src/loop/checkpoint.ts`
- `src/loop/engine.ts`
- `src/ops/continue.ts`
- `test/loop/engine.test.ts`
- `test/ops/continue.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The three previously reported major issues are addressed: resume now distinguishes started vs completed checkpoints in step selection (src/loop/engine.ts:251-313), verify artifacts are restored during checkpoint resume (src/loop/checkpoint.ts:57-92), and completion checks are artifact-aware (including null guard behavior) instead of key-presence-only (src/loop/engine.ts:296-313). Continue queuing also preserves/derives resume phase rather than forcing restart (src/ops/continue.ts:70-148). Added regression coverage in test/loop/engine.test.ts:486-730 and test/ops/continue.test.ts:258-292. Verification run in this review: pnpm test (full), pnpm typecheck, and pnpm lint all passed.

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex