### PR TITLE
[CHORE] Stats - real usage data from Claude code and codex (night-orch / #103)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -82,6 +82,7 @@ Update surfaces:
 | `notifications` | object | no | object with defaults | Channel/event notification config. |
 | `loop` | object | no | object with defaults | Loop decision limits and behavior. |
 | `security` | object | no | object with defaults | Diff/cost safety limits. |
+| `cost` | object | no | object with defaults | Cost display model (`pay-per-use` or `subscription`). |
 | `workerProfiles` | record | no | `{}` | Named CLI profiles for agents. |
 | `metrics` | object | no | object with defaults | Prometheus exporter config. |
 | `observability` | object | no | object with defaults | Live agent event streaming/persistence settings. |
@@ -196,6 +197,12 @@ When `decompose: true`, issues classified as `standard` triage level with a body
 | `maxChangedLines` | positive number | `5000` | Diff guard threshold. |
 | `maxDailyCostUsd` | positive number | `50` | Daily budget cap used by decision logic. |
 | `maxCostPerRunUsd` | positive number | `10` | Per-run budget cap used by decision logic. |
+
+## `cost`
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `model` | `pay-per-use` or `subscription` | `pay-per-use` | Controls whether dashboards emphasize USD or token usage while still tracking both. |
 
 ## `workerProfiles`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -460,14 +460,24 @@ security:
 
 When a budget is exceeded, the run is blocked with reason `cost_limit`.
 
+### Cost model
+
+```yaml
+cost:
+  model: pay-per-use   # or: subscription
+```
+
+- `pay-per-use` keeps USD spend as the primary dashboard metric.
+- `subscription` keeps token usage as the primary dashboard metric and shows USD as an estimate.
+
 ### Cost estimation
 
 - **Token-based** (preferred) — when the agent adapter reports token counts, cost is calculated from input/output token rates
 - **Time-based** (fallback) — when token counts aren't available, cost is estimated at $0.008/minute per agent call
 
-View costs:
+View costs/usage:
 - `night-orch status` — shows daily cost summary
-- `night-orch watch` — live cost bar
+- `night-orch watch` — live cost/usage summaries
 - Prometheus metric: `night_orch_estimated_cost_dollars`
 
 ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -55,6 +55,9 @@ security:
   maxDailyCostUsd: 50
   maxCostPerRunUsd: 10
 
+cost:
+  model: pay-per-use # or: subscription
+
 workerProfiles:
   claude-default:
     type: claude

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -39,9 +39,17 @@ export async function statusCommand(globalOpts?: GlobalOpts): Promise<void> {
     .prepare("SELECT * FROM leases WHERE leased_until > datetime('now')")
     .all() as LeaseRow[]
 
-  const dailyCost = db
-    .prepare("SELECT SUM(estimated_cost_usd) as total FROM runs WHERE date(created_at) = date('now')")
-    .get() as { total: number | null } | undefined
+  const dailyUsage = db
+    .prepare(
+      `SELECT
+         total_cost_usd,
+         run_count,
+         total_prompt_tokens,
+         total_completion_tokens
+       FROM daily_costs
+       WHERE date = date('now')`,
+    )
+    .get() as DailyUsageRow | undefined
 
   // Header
   console.log('\n  night-orch status\n')
@@ -67,10 +75,19 @@ export async function statusCommand(globalOpts?: GlobalOpts): Promise<void> {
   }
 
   // Daily cost
-  const cost = dailyCost?.total ?? 0
+  const cost = dailyUsage?.total_cost_usd ?? 0
+  const promptTokens = dailyUsage?.total_prompt_tokens ?? 0
+  const completionTokens = dailyUsage?.total_completion_tokens ?? 0
+  const totalTokens = promptTokens + completionTokens
   const budget = config.security.maxDailyCostUsd
   const costPct = budget > 0 ? Math.round((cost / budget) * 100) : 0
-  console.log(`\n  Daily cost:   $${cost.toFixed(2)} / $${budget.toFixed(2)} (${costPct}%)`)
+  if (config.cost.model === 'subscription') {
+    console.log(`\n  Daily usage:  ${formatTokenCount(totalTokens)} tokens (${dailyUsage?.run_count ?? 0} runs)`)
+    console.log(`  Est. cost:    $${cost.toFixed(2)} / $${budget.toFixed(2)} (${costPct}%)`)
+  } else {
+    console.log(`\n  Daily cost:   $${cost.toFixed(2)} / $${budget.toFixed(2)} (${costPct}%)`)
+    console.log(`  Token usage:  ${formatTokenCount(totalTokens)} tokens`)
+  }
 
   // Recent runs
   console.log('\n  Recent runs:')
@@ -159,4 +176,19 @@ interface LeaseRow {
   issue_number: number
   lease_owner: string
   leased_until: string
+}
+
+interface DailyUsageRow {
+  total_cost_usd: number | null
+  run_count: number | null
+  total_prompt_tokens: number | null
+  total_completion_tokens: number | null
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
 }

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -363,7 +363,10 @@ export function App({
     [db, tick, selectedRun?.id, runsViewMode],
   )
   const mergeBatches = useMemo(() => loadMergeBatches(db), [db, tick])
-  const stats = useMemo(() => loadTuiStats(db), [db, tick])
+  const stats = useMemo(
+    () => loadTuiStats(db, { costModel: runtimeConfig.cost.model }),
+    [db, runtimeConfig.cost.model, tick],
+  )
   const logWindowSize = useMemo(() => resolveLogWindowSize(termRows), [termRows])
   const selectedLogIndex = useMemo(() => resolveSelectedLogIndex(logLines, selectedLogId), [logLines, selectedLogId])
 

--- a/src/cli/tui/header.tsx
+++ b/src/cli/tui/header.tsx
@@ -48,8 +48,19 @@ export function Header({
         ))}
       </Box>
       <Text dimColor>
-        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  running {status.overview.runningRuns}  cost today ${status.cost.todayCostUsd.toFixed(2)}
+        runs {status.overview.totalRuns}  active {status.overview.activeRuns}  queued {status.overview.queuedRuns}  running {status.overview.runningRuns}
+        {status.cost.model === 'subscription'
+          ? `  tokens today ${formatTokenCount(status.usage.todayTotalTokens)}`
+          : `  cost today $${status.cost.todayCostUsd.toFixed(2)}`}
       </Text>
     </Box>
   )
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
 }

--- a/src/cli/tui/stats-view.tsx
+++ b/src/cli/tui/stats-view.tsx
@@ -19,6 +19,7 @@ interface StatsViewProps {
 
 export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }: StatsViewProps): React.ReactElement {
   const costSeries = stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd)
+  const usageSeries = stats.usage.dailyHistory.slice().reverse().map((row) => row.totalTokens)
   const successColor = colorForHigherIsBetter(stats.throughput.successRate7d, 80, 60)
   const failureRateColor = colorForLowerIsBetter(stats.reliability.failureRate7d, 10, 25)
   const overviewBlockedColor = colorForPresence(stats.overview.blockedRuns, 1, 2)
@@ -26,14 +27,18 @@ export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }:
   const throughputBlockedColor = colorForPresence(stats.throughput.blocked7d, 1, 2)
   const throughputErrorColor = colorForPresence(stats.throughput.error7d, 1, 2)
   const todayCostColor = colorForRatioToBaseline(stats.cost.todayCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)
+  const todayUsageColor = colorForRatioToBaseline(stats.usage.todayTotalTokens, stats.usage.avgDailyTokens7d, 1.05, 1.35)
   const costPerRunColor = colorForLowerIsBetter(stats.efficiency.avgCostPerRun7d, 1.5, 3)
   const costPerSuccessColor = colorForLowerIsBetter(stats.efficiency.avgCostPerSuccess7d, 3, 6)
+  const tokensPerRunColor = colorForLowerIsBetter(stats.efficiency.avgTokensPerRun7d, 8_000, 16_000)
+  const tokensPerSuccessColor = colorForLowerIsBetter(stats.efficiency.avgTokensPerSuccess7d, 16_000, 32_000)
   const expiredLeaseColor = colorForPresence(stats.resources.expiredLeases, 1, 2)
   const expiringLeaseColor = colorForPresence(stats.resources.expiringLeases, 1, 3)
   const missingWorktreeColor = colorForPresence(stats.resources.missingWorktrees, 1, 2)
   const staleWorktreeColor = colorForPresence(stats.resources.staleWorktrees, 1, 2)
   const tailLatencyRatio = stats.timing.p50Minutes > 0 ? stats.timing.p90Minutes / stats.timing.p50Minutes : 1
   const tailLatencyColor = colorForLowerIsBetter(tailLatencyRatio, 2.5, 4.5)
+  const usageFirst = stats.cost.model === 'subscription'
 
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -83,32 +88,68 @@ export function StatsView({ stats, autoRefresh, pollIntervalMs, lastRefreshAt }:
       </Box>
 
       <Box marginBottom={1}>
-        <StatCard title="Cost" width="50%" marginRight={1}>
-          <Text>
-            today <Text color={todayCostColor}>${stats.cost.todayCostUsd.toFixed(2)}</Text> ({stats.cost.todayRunCount} runs)
-          </Text>
-          <Text>7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
-          <Text>avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
-          <Text>
-            cost/run 7d <Text color={costPerRunColor}>${stats.efficiency.avgCostPerRun7d.toFixed(2)}</Text>
-            {'  '}
-            cost/success <Text color={costPerSuccessColor}>${stats.efficiency.avgCostPerSuccess7d.toFixed(2)}</Text>
-          </Text>
-          <Text>
-            cost/iter <Text color={costPerRunColor}>${stats.efficiency.avgCostPerIteration7d.toFixed(2)}</Text>
-            {'  '}
-            completed/$ <Text color={successColor}>{stats.efficiency.completedPerDollar7d.toFixed(2)}</Text>
-          </Text>
-          <Text>trend {buildSparkline(costSeries)}</Text>
-          {stats.cost.dailyHistory.slice(0, 4).map((row) => (
-            <Text key={row.date} dimColor>
-              <Text color={colorForRatioToBaseline(row.totalCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)}>
-                {row.date}: ${row.totalCostUsd.toFixed(2)}
+        <StatCard title="Cost & Usage" width="50%" marginRight={1}>
+          {usageFirst ? (
+            <>
+              <Text>model subscription</Text>
+              <Text>
+                today tokens <Text color={todayUsageColor}>{formatTokenCount(stats.usage.todayTotalTokens)}</Text> ({stats.cost.todayRunCount} runs)
               </Text>
-              {'  '}
-              ({row.runCount})
-            </Text>
-          ))}
+              <Text>7d {formatTokenCount(stats.usage.tokens7d)}  30d {formatTokenCount(stats.usage.tokens30d)}</Text>
+              <Text>avg/day 7d {formatTokenCount(stats.usage.avgDailyTokens7d)}</Text>
+              <Text>
+                tokens/run 7d <Text color={tokensPerRunColor}>{formatTokenCount(stats.efficiency.avgTokensPerRun7d)}</Text>
+                {'  '}
+                tokens/success <Text color={tokensPerSuccessColor}>{formatTokenCount(stats.efficiency.avgTokensPerSuccess7d)}</Text>
+              </Text>
+              <Text>tokens/iter {formatTokenCount(stats.efficiency.avgTokensPerIteration7d)}</Text>
+              <Text dimColor>estimated cost today ${stats.cost.todayCostUsd.toFixed(2)}  7d ${stats.cost.cost7d.toFixed(2)}</Text>
+              <Text>trend {buildSparkline(usageSeries)}</Text>
+              {stats.usage.dailyHistory.slice(0, 4).map((row) => (
+                <Text key={row.date} dimColor>
+                  <Text color={colorForRatioToBaseline(row.totalTokens, stats.usage.avgDailyTokens7d, 1.05, 1.35)}>
+                    {row.date}: {formatTokenCount(row.totalTokens)}
+                  </Text>
+                  {'  '}
+                  ({row.runCount})
+                </Text>
+              ))}
+            </>
+          ) : (
+            <>
+              <Text>model pay-per-use</Text>
+              <Text>
+                today <Text color={todayCostColor}>${stats.cost.todayCostUsd.toFixed(2)}</Text> ({stats.cost.todayRunCount} runs)
+              </Text>
+              <Text>7d ${stats.cost.cost7d.toFixed(2)}  30d ${stats.cost.cost30d.toFixed(2)}</Text>
+              <Text>avg/day 7d ${stats.cost.avgDailyCost7d.toFixed(2)}</Text>
+              <Text>
+                cost/run 7d <Text color={costPerRunColor}>${stats.efficiency.avgCostPerRun7d.toFixed(2)}</Text>
+                {'  '}
+                cost/success <Text color={costPerSuccessColor}>${stats.efficiency.avgCostPerSuccess7d.toFixed(2)}</Text>
+              </Text>
+              <Text>
+                cost/iter <Text color={costPerRunColor}>${stats.efficiency.avgCostPerIteration7d.toFixed(2)}</Text>
+                {'  '}
+                completed/$ <Text color={successColor}>{stats.efficiency.completedPerDollar7d.toFixed(2)}</Text>
+              </Text>
+              <Text>
+                tokens today <Text color={todayUsageColor}>{formatTokenCount(stats.usage.todayTotalTokens)}</Text>
+                {'  '}
+                tokens 7d {formatTokenCount(stats.usage.tokens7d)}
+              </Text>
+              <Text>trend {buildSparkline(costSeries)}</Text>
+              {stats.cost.dailyHistory.slice(0, 4).map((row) => (
+                <Text key={row.date} dimColor>
+                  <Text color={colorForRatioToBaseline(row.totalCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)}>
+                    {row.date}: ${row.totalCostUsd.toFixed(2)}
+                  </Text>
+                  {'  '}
+                  ({row.runCount})
+                </Text>
+              ))}
+            </>
+          )}
         </StatCard>
 
         <StatCard title="Agent Activity" width="50%">
@@ -226,4 +267,12 @@ function StatCard({ title, width, marginRight = 0, children }: StatCardProps): R
       {children}
     </Box>
   )
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -249,6 +249,14 @@ const SecuritySchema = z.object({
   maxCostPerRunUsd: z.number().positive().default(10),
 })
 
+// --- Cost schema ---
+
+const CostModelSchema = z.enum(['pay-per-use', 'subscription'])
+
+const CostSchema = z.object({
+  model: CostModelSchema.default('pay-per-use'),
+})
+
 // --- Metrics schema ---
 
 const MetricsSchema = z.object({
@@ -317,6 +325,8 @@ export const ConfigSchema = z.object({
 
   security: SecuritySchema.default({}),
 
+  cost: CostSchema.default({}),
+
   workerProfiles: z.record(WorkerProfileSchema).default({}),
 
   metrics: MetricsSchema.default({}),
@@ -345,3 +355,4 @@ export type Config = z.infer<typeof ConfigSchema>
 export type RepoConfig = z.infer<typeof RepoConfigSchema>
 export type WorkerProfile = z.infer<typeof WorkerProfileSchema>
 export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>
+export type CostModel = z.infer<typeof CostModelSchema>

--- a/src/loop/cost.ts
+++ b/src/loop/cost.ts
@@ -3,6 +3,17 @@ import type { Config } from '../config/schema.js'
 import { IssueManager } from '../state/issues.js'
 import { utcDayKey } from '../utils/time.js'
 
+interface TokenUsageInput {
+  promptTokens: number
+  completionTokens: number
+}
+
+export interface TokenUsageTotals {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+}
+
 export class CostTracker {
   private issueManager: IssueManager
 
@@ -10,34 +21,48 @@ export class CostTracker {
     this.issueManager = new IssueManager(db)
   }
 
-  recordCost(runId: string, costUsd: number): void {
-    if (costUsd <= 0) return
+  recordCost(runId: string, costUsd: number, tokenUsage?: TokenUsageInput): void {
+    const amountUsd = Number(Math.max(0, costUsd).toFixed(6))
+    const normalizedTokens = normalizeTokenUsage(tokenUsage)
+    if (amountUsd <= 0 && normalizedTokens.totalTokens <= 0) return
 
     const today = utcDayKey()
-    const tx = this.db.transaction((id: string, date: string, amountUsd: number) => {
-      const row = this.db
-        .prepare('SELECT estimated_cost_usd FROM runs WHERE id = ?')
-        .get(id) as { estimated_cost_usd: number } | undefined
-      const firstCostForRun = (row?.estimated_cost_usd ?? 0) <= 0
+    const tx = this.db.transaction((id: string, date: string, usage: TokenUsageTotals, usdAmount: number) => {
+      const runUsageInsert = this.db
+        .prepare(
+          `INSERT INTO daily_run_usage (date, run_id)
+           VALUES (?, ?)
+           ON CONFLICT(date, run_id) DO NOTHING`,
+        )
+        .run(date, id)
+      const dailyRunCountIncrement = runUsageInsert.changes > 0 ? 1 : 0
 
       this.db
         .prepare(
-          `INSERT INTO daily_costs (date, total_cost_usd, run_count)
-           VALUES (?, ?, ?)
+          `INSERT INTO daily_costs (date, total_cost_usd, run_count, total_prompt_tokens, total_completion_tokens)
+           VALUES (?, ?, ?, ?, ?)
            ON CONFLICT(date) DO UPDATE SET
              total_cost_usd = total_cost_usd + excluded.total_cost_usd,
-             run_count = run_count + excluded.run_count`,
+             run_count = run_count + excluded.run_count,
+             total_prompt_tokens = total_prompt_tokens + excluded.total_prompt_tokens,
+             total_completion_tokens = total_completion_tokens + excluded.total_completion_tokens`,
         )
-        .run(date, amountUsd, firstCostForRun ? 1 : 0)
+        .run(date, usdAmount, dailyRunCountIncrement, usage.promptTokens, usage.completionTokens)
 
       this.db
-        .prepare('UPDATE runs SET estimated_cost_usd = estimated_cost_usd + ? WHERE id = ?')
-        .run(amountUsd, id)
+        .prepare(
+          `UPDATE runs
+           SET estimated_cost_usd = estimated_cost_usd + ?,
+               prompt_tokens = prompt_tokens + ?,
+               completion_tokens = completion_tokens + ?
+           WHERE id = ?`,
+        )
+        .run(usdAmount, usage.promptTokens, usage.completionTokens, id)
 
       this.issueManager.syncFromRunId(id)
     })
 
-    tx(runId, today, costUsd)
+    tx(runId, today, normalizedTokens, amountUsd)
   }
 
   getDailyCost(): number {
@@ -55,6 +80,35 @@ export class CostTracker {
     return row?.estimated_cost_usd ?? 0
   }
 
+  getDailyTokenUsage(): TokenUsageTotals {
+    const today = utcDayKey()
+    const row = this.db
+      .prepare('SELECT total_prompt_tokens, total_completion_tokens FROM daily_costs WHERE date = ?')
+      .get(today) as DailyTokenRow | undefined
+
+    const promptTokens = row?.total_prompt_tokens ?? 0
+    const completionTokens = row?.total_completion_tokens ?? 0
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+    }
+  }
+
+  getRunTokenUsage(runId: string): TokenUsageTotals {
+    const row = this.db
+      .prepare('SELECT prompt_tokens, completion_tokens FROM runs WHERE id = ?')
+      .get(runId) as RunTokenRow | undefined
+
+    const promptTokens = row?.prompt_tokens ?? 0
+    const completionTokens = row?.completion_tokens ?? 0
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+    }
+  }
+
   isOverBudget(runId: string, limits: Config['security']): boolean {
     const dailyCost = this.getDailyCost()
     if (dailyCost >= limits.maxDailyCostUsd) return true
@@ -64,4 +118,29 @@ export class CostTracker {
 
     return false
   }
+}
+
+function normalizeTokenUsage(tokenUsage: TokenUsageInput | undefined): TokenUsageTotals {
+  const promptTokens = normalizeTokenCount(tokenUsage?.promptTokens)
+  const completionTokens = normalizeTokenCount(tokenUsage?.completionTokens)
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  }
+}
+
+function normalizeTokenCount(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.max(0, Math.floor(value))
+}
+
+interface DailyTokenRow {
+  total_prompt_tokens: number | null
+  total_completion_tokens: number | null
+}
+
+interface RunTokenRow {
+  prompt_tokens: number | null
+  completion_tokens: number | null
 }

--- a/src/loop/engine.ts
+++ b/src/loop/engine.ts
@@ -371,8 +371,8 @@ function applyEstimatedWorkerCost(
     estimatedCost = Number(((durationMs / 60_000) * rate).toFixed(6))
   }
   estimatedCost = Math.max(0, estimatedCost)
-  if (estimatedCost <= 0) return ctx
-  costTracker.recordCost(ctx.runId, estimatedCost)
+  if (estimatedCost <= 0 && !tokenUsage) return ctx
+  costTracker.recordCost(ctx.runId, estimatedCost, tokenUsage)
   return updateContext(ctx, {
     estimatedCostUsd: Number((ctx.estimatedCostUsd + estimatedCost).toFixed(6)),
   })

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -73,11 +73,15 @@ async function readStatusResource(deps: MCPDependencies): Promise<unknown> {
   const statusCounts = deps.db
     .prepare("SELECT status, COUNT(*) as count FROM runs GROUP BY status")
     .all() as Array<{ status: string; count: number }>
+  const dailyTokens = costTracker.getDailyTokenUsage()
 
   return {
     activeRuns: active.length,
     statusCounts: Object.fromEntries(statusCounts.map((r) => [r.status, r.count])),
     dailyCostUsd: costTracker.getDailyCost(),
+    dailyPromptTokens: dailyTokens.promptTokens,
+    dailyCompletionTokens: dailyTokens.completionTokens,
+    dailyTotalTokens: dailyTokens.totalTokens,
     repos: deps.config.repos.map((r) => r.repo),
     metricsEnabled: deps.config.metrics.enabled,
   }
@@ -119,6 +123,7 @@ function readConfigResource(deps: MCPDependencies): unknown {
     storage: deps.config.storage,
     loop: deps.config.loop,
     security: deps.config.security,
+    cost: deps.config.cost,
     metrics: deps.config.metrics,
     mcp: deps.config.mcp,
     workerProfiles: Object.fromEntries(

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -365,6 +365,7 @@ async function handleStatus(args: { repo?: string }, deps: MCPDependencies): Pro
 
   const active = runManager.getActive()
   const filtered = args.repo ? active.filter((r) => r.repo === args.repo) : active
+  const dailyTokens = costTracker.getDailyTokenUsage()
 
   // Recent completed runs
   const recentSql = args.repo
@@ -392,6 +393,9 @@ async function handleStatus(args: { repo?: string }, deps: MCPDependencies): Pro
       endedAt: r.ended_at,
     })),
     dailyCostUsd: costTracker.getDailyCost(),
+    dailyPromptTokens: dailyTokens.promptTokens,
+    dailyCompletionTokens: dailyTokens.completionTokens,
+    dailyTotalTokens: dailyTokens.totalTokens,
     configuredRepos: deps.config.repos.map((r) => r.repo),
   }
 }
@@ -566,22 +570,52 @@ function normalizeListRunsLimit(limit: number | undefined): number {
 
 async function handleCostReport(args: { days?: number }, deps: MCPDependencies): Promise<unknown> {
   const days = args.days ?? 7
+  const costModel = deps.config.cost?.model ?? 'pay-per-use'
   const rows = deps.db
-    .prepare('SELECT date, total_cost_usd, run_count FROM daily_costs ORDER BY date DESC LIMIT ?')
-    .all(days) as Array<{ date: string; total_cost_usd: number; run_count: number }>
+    .prepare(
+      `SELECT
+         date,
+         total_cost_usd,
+         run_count,
+         total_prompt_tokens,
+         total_completion_tokens
+       FROM daily_costs
+       ORDER BY date DESC
+       LIMIT ?`,
+    )
+    .all(days) as Array<{
+      date: string
+      total_cost_usd: number
+      run_count: number
+      total_prompt_tokens: number
+      total_completion_tokens: number
+    }>
 
   const totalCost = rows.reduce((sum, r) => sum + r.total_cost_usd, 0)
   const totalRuns = rows.reduce((sum, r) => sum + r.run_count, 0)
+  const totalPromptTokens = rows.reduce((sum, r) => sum + r.total_prompt_tokens, 0)
+  const totalCompletionTokens = rows.reduce((sum, r) => sum + r.total_completion_tokens, 0)
 
   return {
+    model: costModel,
     period: `Last ${days} days`,
     totalCostUsd: Math.round(totalCost * 100) / 100,
     totalRuns,
+    totalPromptTokens,
+    totalCompletionTokens,
+    totalTokens: totalPromptTokens + totalCompletionTokens,
     dailyBudgetUsd: deps.config.security.maxDailyCostUsd,
     budgetUtilizationPct: rows.length > 0
       ? Math.round((rows[0]!.total_cost_usd / deps.config.security.maxDailyCostUsd) * 100)
       : 0,
-    daily: rows,
+    daily: rows.map((row) => ({
+      date: row.date,
+      totalCostUsd: row.total_cost_usd,
+      runCount: row.run_count,
+      promptTokens: row.total_prompt_tokens,
+      completionTokens: row.total_completion_tokens,
+      totalTokens: row.total_prompt_tokens + row.total_completion_tokens,
+    })),
   }
 }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -14,6 +14,8 @@ import { up as migration009 } from './migrations/009-run-titles.js'
 import { up as migration010 } from './migrations/010-issues.js'
 import { up as migration011 } from './migrations/011-rebuild-issues-from-latest-run.js'
 import { up as migration012 } from './migrations/012-settings-overrides.js'
+import { up as migration013 } from './migrations/013-token-usage.js'
+import { up as migration014 } from './migrations/014-daily-run-usage.js'
 
 const MIGRATIONS = [
   { version: 1, name: '001-initial', up: migration001 },
@@ -28,6 +30,8 @@ const MIGRATIONS = [
   { version: 10, name: '010-issues', up: migration010 },
   { version: 11, name: '011-rebuild-issues-from-latest-run', up: migration011 },
   { version: 12, name: '012-settings-overrides', up: migration012 },
+  { version: 13, name: '013-token-usage', up: migration013 },
+  { version: 14, name: '014-daily-run-usage', up: migration014 },
 ]
 
 export function initDatabase(dbPath: string): Database.Database {

--- a/src/state/migrations/013-token-usage.ts
+++ b/src/state/migrations/013-token-usage.ts
@@ -1,0 +1,23 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  if (!hasColumn(db, 'runs', 'prompt_tokens')) {
+    db.exec('ALTER TABLE runs ADD COLUMN prompt_tokens INTEGER NOT NULL DEFAULT 0')
+  }
+  if (!hasColumn(db, 'runs', 'completion_tokens')) {
+    db.exec('ALTER TABLE runs ADD COLUMN completion_tokens INTEGER NOT NULL DEFAULT 0')
+  }
+  if (!hasColumn(db, 'daily_costs', 'total_prompt_tokens')) {
+    db.exec('ALTER TABLE daily_costs ADD COLUMN total_prompt_tokens INTEGER NOT NULL DEFAULT 0')
+  }
+  if (!hasColumn(db, 'daily_costs', 'total_completion_tokens')) {
+    db.exec('ALTER TABLE daily_costs ADD COLUMN total_completion_tokens INTEGER NOT NULL DEFAULT 0')
+  }
+}
+
+function hasColumn(db: Database.Database, tableName: string, columnName: string): boolean {
+  const rows = db
+    .prepare(`PRAGMA table_info(${tableName})`)
+    .all() as Array<{ name: string }>
+  return rows.some((row) => row.name === columnName)
+}

--- a/src/state/migrations/014-daily-run-usage.ts
+++ b/src/state/migrations/014-daily-run-usage.ts
@@ -1,0 +1,15 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS daily_run_usage (
+      date TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (date, run_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_daily_run_usage_run_id
+      ON daily_run_usage(run_id);
+  `)
+}

--- a/src/state/runs.ts
+++ b/src/state/runs.ts
@@ -27,6 +27,8 @@ export interface RunRecord {
   branchSlug: string | null
   worktreePath: string | null
   estimatedCostUsd: number
+  promptTokens: number
+  completionTokens: number
   blockReason: string | null
   parentRunId: string | null
 }
@@ -114,6 +116,8 @@ export class RunManager {
       'branchSlug',
       'worktreePath',
       'estimatedCostUsd',
+      'promptTokens',
+      'completionTokens',
       'blockReason',
       'parentRunId',
     ] as const
@@ -134,6 +138,8 @@ export class RunManager {
       branchSlug: 'branch_slug',
       worktreePath: 'worktree_path',
       estimatedCostUsd: 'estimated_cost_usd',
+      promptTokens: 'prompt_tokens',
+      completionTokens: 'completion_tokens',
       blockReason: 'block_reason',
       parentRunId: 'parent_run_id',
     }
@@ -286,6 +292,8 @@ export class RunManager {
       branchSlug: row.branch_slug,
       worktreePath: row.worktree_path,
       estimatedCostUsd: row.estimated_cost_usd ?? 0,
+      promptTokens: row.prompt_tokens ?? 0,
+      completionTokens: row.completion_tokens ?? 0,
       blockReason: row.block_reason ?? null,
       parentRunId: row.parent_run_id ?? null,
     }
@@ -314,6 +322,8 @@ interface RawRunRow {
   branch_slug: string | null
   worktree_path: string | null
   estimated_cost_usd: number | null
+  prompt_tokens: number | null
+  completion_tokens: number | null
   block_reason: string | null
   parent_run_id: string | null
 }

--- a/src/state/stats.ts
+++ b/src/state/stats.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3'
+import type { CostModel } from '../config/schema.js'
 import { nowUtcIso } from '../utils/time.js'
 
 export interface StatusAggregate {
@@ -33,9 +34,21 @@ export interface DailyCostAggregate {
   runCount: number
 }
 
+export interface DailyUsageAggregate {
+  date: string
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  runCount: number
+}
+
 export interface ErrorPatternAggregate {
   pattern: string
   count: number
+}
+
+export interface TuiStatsOptions {
+  costModel?: CostModel
 }
 
 export interface TuiStatsSnapshot {
@@ -69,6 +82,7 @@ export interface TuiStatsSnapshot {
     topErrorPatterns7d: ErrorPatternAggregate[]
   }
   readonly cost: {
+    model: CostModel
     todayCostUsd: number
     todayRunCount: number
     cost7d: number
@@ -76,12 +90,24 @@ export interface TuiStatsSnapshot {
     avgDailyCost7d: number
     dailyHistory: DailyCostAggregate[]
   }
+  readonly usage: {
+    todayPromptTokens: number
+    todayCompletionTokens: number
+    todayTotalTokens: number
+    tokens7d: number
+    tokens30d: number
+    avgDailyTokens7d: number
+    dailyHistory: DailyUsageAggregate[]
+  }
   readonly efficiency: {
     totalCostUsd7d: number
     avgCostPerRun7d: number
     avgCostPerSuccess7d: number
     avgCostPerIteration7d: number
     completedPerDollar7d: number
+    avgTokensPerRun7d: number
+    avgTokensPerSuccess7d: number
+    avgTokensPerIteration7d: number
   }
   readonly resources: {
     activeLeases: number
@@ -114,7 +140,12 @@ export interface TuiStatsSnapshot {
   readonly topRepos30d: RepoAggregate[]
 }
 
-export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
+export function loadTuiStats(
+  db: Database.Database,
+  options: TuiStatsOptions = {},
+): TuiStatsSnapshot {
+  const costModel = options.costModel ?? 'pay-per-use'
+
   const overviewRow = db
     .prepare(
       `SELECT
@@ -186,7 +217,9 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
          COUNT(*) AS runs_7d,
          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_7d,
          SUM(COALESCE(estimated_cost_usd, 0)) AS total_cost_usd_7d,
-         SUM(COALESCE(iteration_count, 0)) AS total_iterations_7d
+         SUM(COALESCE(iteration_count, 0)) AS total_iterations_7d,
+         SUM(COALESCE(prompt_tokens, 0)) AS total_prompt_tokens_7d,
+         SUM(COALESCE(completion_tokens, 0)) AS total_completion_tokens_7d
        FROM runs
        WHERE datetime(created_at) >= datetime('now', '-7 days')`,
     )
@@ -197,16 +230,21 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
       `SELECT
          SUM(CASE WHEN date = date('now') THEN total_cost_usd ELSE 0 END) AS today_cost_usd,
          SUM(CASE WHEN date = date('now') THEN run_count ELSE 0 END) AS today_run_count,
+         SUM(CASE WHEN date = date('now') THEN total_prompt_tokens ELSE 0 END) AS today_prompt_tokens,
+         SUM(CASE WHEN date = date('now') THEN total_completion_tokens ELSE 0 END) AS today_completion_tokens,
          SUM(CASE WHEN date >= date('now', '-6 days') THEN total_cost_usd ELSE 0 END) AS cost_7d,
          SUM(CASE WHEN date >= date('now', '-29 days') THEN total_cost_usd ELSE 0 END) AS cost_30d,
-         AVG(CASE WHEN date >= date('now', '-6 days') THEN total_cost_usd ELSE NULL END) AS avg_daily_cost_7d
+         AVG(CASE WHEN date >= date('now', '-6 days') THEN total_cost_usd ELSE NULL END) AS avg_daily_cost_7d,
+         SUM(CASE WHEN date >= date('now', '-6 days') THEN total_prompt_tokens + total_completion_tokens ELSE 0 END) AS tokens_7d,
+         SUM(CASE WHEN date >= date('now', '-29 days') THEN total_prompt_tokens + total_completion_tokens ELSE 0 END) AS tokens_30d,
+         AVG(CASE WHEN date >= date('now', '-6 days') THEN total_prompt_tokens + total_completion_tokens ELSE NULL END) AS avg_daily_tokens_7d
        FROM daily_costs`,
     )
     .get() as CostRow | undefined
 
   const dailyHistory = db
     .prepare(
-      `SELECT date, total_cost_usd, run_count
+      `SELECT date, total_cost_usd, run_count, total_prompt_tokens, total_completion_tokens
        FROM daily_costs
        WHERE date >= date('now', '-6 days')
        ORDER BY date DESC`,
@@ -365,12 +403,18 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
   const totalCostUsd7d = toNumber(efficiencyRow?.total_cost_usd_7d)
   const completedRunsForEfficiency = toNumber(efficiencyRow?.completed_7d)
   const totalIterations7d = toNumber(efficiencyRow?.total_iterations_7d)
+  const totalPromptTokens7d = toNumber(efficiencyRow?.total_prompt_tokens_7d)
+  const totalCompletionTokens7d = toNumber(efficiencyRow?.total_completion_tokens_7d)
+  const totalTokens7d = totalPromptTokens7d + totalCompletionTokens7d
   const runsForEfficiency = toNumber(efficiencyRow?.runs_7d)
 
   const avgCostPerRun7d = runsForEfficiency > 0 ? totalCostUsd7d / runsForEfficiency : 0
   const avgCostPerSuccess7d = completedRunsForEfficiency > 0 ? totalCostUsd7d / completedRunsForEfficiency : 0
   const avgCostPerIteration7d = totalIterations7d > 0 ? totalCostUsd7d / totalIterations7d : 0
   const completedPerDollar7d = totalCostUsd7d > 0 ? completedRunsForEfficiency / totalCostUsd7d : 0
+  const avgTokensPerRun7d = runsForEfficiency > 0 ? totalTokens7d / runsForEfficiency : 0
+  const avgTokensPerSuccess7d = completedRunsForEfficiency > 0 ? totalTokens7d / completedRunsForEfficiency : 0
+  const avgTokensPerIteration7d = totalIterations7d > 0 ? totalTokens7d / totalIterations7d : 0
 
   const durations = durationRows
     .map((row) => toNumber(row.duration_minutes))
@@ -414,6 +458,7 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
       topErrorPatterns7d,
     },
     cost: {
+      model: costModel,
       todayCostUsd: toNumber(costRow?.today_cost_usd),
       todayRunCount: toNumber(costRow?.today_run_count),
       cost7d: toNumber(costRow?.cost_7d),
@@ -425,12 +470,34 @@ export function loadTuiStats(db: Database.Database): TuiStatsSnapshot {
         runCount: toNumber(row.run_count),
       })),
     },
+    usage: {
+      todayPromptTokens: toNumber(costRow?.today_prompt_tokens),
+      todayCompletionTokens: toNumber(costRow?.today_completion_tokens),
+      todayTotalTokens: toNumber(costRow?.today_prompt_tokens) + toNumber(costRow?.today_completion_tokens),
+      tokens7d: toNumber(costRow?.tokens_7d),
+      tokens30d: toNumber(costRow?.tokens_30d),
+      avgDailyTokens7d: toNumber(costRow?.avg_daily_tokens_7d),
+      dailyHistory: dailyHistory.map((row) => {
+        const promptTokens = toNumber(row.total_prompt_tokens)
+        const completionTokens = toNumber(row.total_completion_tokens)
+        return {
+          date: row.date,
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+          runCount: toNumber(row.run_count),
+        }
+      }),
+    },
     efficiency: {
       totalCostUsd7d,
       avgCostPerRun7d,
       avgCostPerSuccess7d,
       avgCostPerIteration7d,
       completedPerDollar7d,
+      avgTokensPerRun7d,
+      avgTokensPerSuccess7d,
+      avgTokensPerIteration7d,
     },
     resources: {
       activeLeases: toNumber(leaseHealthRow?.active_leases),
@@ -577,14 +644,21 @@ interface EfficiencyRow {
   completed_7d: number | null
   total_cost_usd_7d: number | null
   total_iterations_7d: number | null
+  total_prompt_tokens_7d: number | null
+  total_completion_tokens_7d: number | null
 }
 
 interface CostRow {
   today_cost_usd: number | null
   today_run_count: number | null
+  today_prompt_tokens: number | null
+  today_completion_tokens: number | null
   cost_7d: number | null
   cost_30d: number | null
   avg_daily_cost_7d: number | null
+  tokens_7d: number | null
+  tokens_30d: number | null
+  avg_daily_tokens_7d: number | null
 }
 
 interface AgentRow {
@@ -600,6 +674,8 @@ interface DailyCostRow {
   date: string
   total_cost_usd: number | null
   run_count: number | null
+  total_prompt_tokens: number | null
+  total_completion_tokens: number | null
 }
 
 interface ErrorMessageRow {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -453,7 +453,7 @@ async function handleApiRequest(
   }
 
   if (method === 'GET' && pathname === '/api/stats') {
-    writeJson(res, 200, loadTuiStats(runtimeDeps.db))
+    writeJson(res, 200, loadTuiStats(runtimeDeps.db, { costModel: runtimeDeps.config.cost.model }))
     return
   }
 
@@ -1109,7 +1109,7 @@ async function buildDashboardSnapshot(deps: MCPDependencies): Promise<DashboardS
       repos: runtimeConfig.repos.map((repo) => repo.repo),
       pollIntervalSeconds: runtimeConfig.github.pollIntervalSeconds,
     },
-    stats: loadTuiStats(runtimeDeps.db),
+    stats: loadTuiStats(runtimeDeps.db, { costModel: runtimeConfig.cost.model }),
   }
 }
 

--- a/src/workers/claude.ts
+++ b/src/workers/claude.ts
@@ -62,6 +62,7 @@ export class ClaudeWorkerAdapter implements WorkerAdapter {
     // With --output-format json, extract assistant text and session ID from the JSON envelope.
     // Fall back to raw text if not parseable as JSON.
     const { assistantText, sessionId } = extractFromJsonOutput(result.stdout)
+    const tokenUsage = extractClaudeTokenUsage(result.stdout)
 
     logger.info({ role: input.role, rawLength: result.stdout.length, textLength: assistantText.length, sessionId }, 'Claude output received')
 
@@ -81,6 +82,7 @@ export class ClaudeWorkerAdapter implements WorkerAdapter {
       timedOut: result.timedOut,
       durationMs: result.durationMs,
       sessionId,
+      tokenUsage,
     })
 
     return {
@@ -91,6 +93,7 @@ export class ClaudeWorkerAdapter implements WorkerAdapter {
       parsed,
       parseError,
       sessionId,
+      tokenUsage,
     }
   }
 
@@ -281,6 +284,47 @@ function tryParseJson(line: string): unknown | null {
   } catch {
     return null
   }
+}
+
+function extractClaudeTokenUsage(raw: string): WorkerTaskResult['tokenUsage'] {
+  const parsed = tryParseJson(raw)
+  if (!parsed) return undefined
+
+  let promptTokens = 0
+  let completionTokens = 0
+
+  const addUsage = (usageCandidate: unknown) => {
+    if (!isRecord(usageCandidate)) return
+    const inputTokens = parseTokenCount(usageCandidate['input_tokens'])
+      + parseTokenCount(usageCandidate['cache_creation_input_tokens'])
+      + parseTokenCount(usageCandidate['cache_read_input_tokens'])
+    const outputTokens = parseTokenCount(usageCandidate['output_tokens'])
+    promptTokens += inputTokens
+    completionTokens += outputTokens
+  }
+
+  if (Array.isArray(parsed)) {
+    for (const event of parsed) {
+      if (!isRecord(event)) continue
+      if (event['type'] !== 'result') continue
+      addUsage(event['usage'])
+    }
+  } else if (isRecord(parsed)) {
+    if (parsed['type'] === 'result') {
+      addUsage(parsed['usage'])
+    }
+  }
+
+  if (promptTokens <= 0 && completionTokens <= 0) return undefined
+  return {
+    promptTokens,
+    completionTokens,
+  }
+}
+
+function parseTokenCount(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.max(0, Math.floor(value))
 }
 
 function getTextBlock(value: unknown): string | null {

--- a/src/workers/codex.ts
+++ b/src/workers/codex.ts
@@ -86,6 +86,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
 
     // Extract thread ID from Codex streaming events for session continuity
     const sessionId = extractCodexThreadId(result.stdout)
+    const tokenUsage = extractCodexTokenUsage(result.stdout)
 
     // Parse output based on role
     const { parsed, parseError } = parseOutput(input.role, assistantText)
@@ -99,6 +100,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       timedOut: result.timedOut,
       durationMs: result.durationMs,
       sessionId,
+      tokenUsage,
     })
 
     return {
@@ -109,6 +111,7 @@ export class CodexWorkerAdapter implements WorkerAdapter {
       parsed,
       parseError,
       sessionId,
+      tokenUsage,
     }
   }
 
@@ -253,6 +256,66 @@ function parseCodexEvents(raw: string): unknown[] {
   return events
 }
 
+function extractCodexTokenUsage(raw: string): WorkerTaskResult['tokenUsage'] {
+  const events = parseCodexEvents(raw)
+  if (events.length === 0) return undefined
+
+  const fromResponseCompleted = sumUsageForEventType(events, 'response.completed')
+  const totals = fromResponseCompleted.seen
+    ? fromResponseCompleted
+    : sumUsageForEventType(events, 'turn.completed')
+
+  if (totals.promptTokens <= 0 && totals.completionTokens <= 0) return undefined
+  return {
+    promptTokens: totals.promptTokens,
+    completionTokens: totals.completionTokens,
+  }
+}
+
+function sumUsageForEventType(
+  events: unknown[],
+  expectedType: string,
+): { seen: boolean; promptTokens: number; completionTokens: number } {
+  let promptTokens = 0
+  let completionTokens = 0
+  let seen = false
+
+  for (const event of events) {
+    if (!isRecord(event)) continue
+    if (event['type'] !== expectedType) continue
+    const usage = extractUsageFromCodexEvent(event)
+    if (usage.promptTokens <= 0 && usage.completionTokens <= 0) continue
+    seen = true
+    promptTokens += usage.promptTokens
+    completionTokens += usage.completionTokens
+  }
+
+  return { seen, promptTokens, completionTokens }
+}
+
+function extractUsageFromCodexEvent(event: Record<string, unknown>): {
+  promptTokens: number
+  completionTokens: number
+} {
+  const directUsage = event['usage']
+  if (isRecord(directUsage)) {
+    return {
+      promptTokens: parseTokenCount(directUsage['input_tokens']),
+      completionTokens: parseTokenCount(directUsage['output_tokens']),
+    }
+  }
+
+  const response = event['response']
+  if (isRecord(response) && isRecord(response['usage'])) {
+    return {
+      promptTokens: parseTokenCount(response['usage']['input_tokens']),
+      completionTokens: parseTokenCount(response['usage']['output_tokens']),
+    }
+  }
+
+  return { promptTokens: 0, completionTokens: 0 }
+}
+
 /**
  * Extract a thread/session ID from Codex streaming events.
  * Codex emits thread_id in session-related events.
@@ -278,6 +341,11 @@ function tryParseJson(line: string): unknown | null {
   } catch {
     return null
   }
+}
+
+function parseTokenCount(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.max(0, Math.floor(value))
 }
 
 function parseOutput(role: string, raw: string): { parsed: WorkerTaskResult['parsed']; parseError: string | null } {

--- a/test/cli/tui/runs-view.test.ts
+++ b/test/cli/tui/runs-view.test.ts
@@ -229,11 +229,21 @@ function makeStats(): TuiStatsSnapshot {
       topErrorPatterns7d: [],
     },
     cost: {
+      model: 'pay-per-use',
       todayCostUsd: 0,
       todayRunCount: 0,
       cost7d: 0,
       cost30d: 0,
       avgDailyCost7d: 0,
+      dailyHistory: [],
+    },
+    usage: {
+      todayPromptTokens: 0,
+      todayCompletionTokens: 0,
+      todayTotalTokens: 0,
+      tokens7d: 0,
+      tokens30d: 0,
+      avgDailyTokens7d: 0,
       dailyHistory: [],
     },
     efficiency: {
@@ -242,6 +252,9 @@ function makeStats(): TuiStatsSnapshot {
       avgCostPerSuccess7d: 0,
       avgCostPerIteration7d: 0,
       completedPerDollar7d: 0,
+      avgTokensPerRun7d: 0,
+      avgTokensPerSuccess7d: 0,
+      avgTokensPerIteration7d: 0,
     },
     resources: {
       activeLeases: 0,

--- a/test/cli/tui/stats-view.test.ts
+++ b/test/cli/tui/stats-view.test.ts
@@ -42,6 +42,7 @@ describe('StatsView', () => {
         topErrorPatterns7d: [],
       },
       cost: {
+        model: 'pay-per-use',
         todayCostUsd: 3.5,
         todayRunCount: 2,
         cost7d: 12.2,
@@ -49,12 +50,24 @@ describe('StatsView', () => {
         avgDailyCost7d: 2.5,
         dailyHistory: [{ date: '2026-04-01', totalCostUsd: 3.5, runCount: 2 }],
       },
+      usage: {
+        todayPromptTokens: 1200,
+        todayCompletionTokens: 400,
+        todayTotalTokens: 1600,
+        tokens7d: 3200,
+        tokens30d: 9800,
+        avgDailyTokens7d: 900,
+        dailyHistory: [{ date: '2026-04-01', promptTokens: 1200, completionTokens: 400, totalTokens: 1600, runCount: 2 }],
+      },
       efficiency: {
         totalCostUsd7d: 12.2,
         avgCostPerRun7d: 2.4,
         avgCostPerSuccess7d: 6.1,
         avgCostPerIteration7d: 1.2,
         completedPerDollar7d: 0.16,
+        avgTokensPerRun7d: 640,
+        avgTokensPerSuccess7d: 1600,
+        avgTokensPerIteration7d: 533.33,
       },
       resources: {
         activeLeases: 1,

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -96,6 +96,7 @@ describe('ConfigSchema', () => {
       expect(result.data.github.pollIntervalSeconds).toBe(300)
       expect(result.data.loop.maxReviewIterations).toBe(4)
       expect(result.data.security.maxDailyCostUsd).toBe(50)
+      expect(result.data.cost.model).toBe('pay-per-use')
       expect(result.data.metrics.host).toBe('0.0.0.0')
       expect(result.data.repos[0]?.maxConcurrentRuns).toBe(1)
       expect(result.data.repos[0]?.baseBranch).toBe('main')
@@ -150,6 +151,16 @@ describe('ConfigSchema', () => {
       expect(result.data.security.maxChangedFiles).toBe(50)
       expect(result.data.security.maxChangedLines).toBe(5000)
       expect(result.data.security.maxCostPerRunUsd).toBe(10)
+    }
+  })
+
+  it('accepts subscription cost model', () => {
+    const raw = loadExampleConfig()
+    raw.cost = { model: 'subscription' }
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cost.model).toBe('subscription')
     }
   })
 

--- a/test/loop/cost.test.ts
+++ b/test/loop/cost.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { CostTracker } from '../../src/loop/cost.js'
 import { initDatabase } from '../../src/state/db.js'
 import { RunManager } from '../../src/state/runs.js'
@@ -51,6 +51,21 @@ describe('CostTracker', () => {
     expect(costTracker.getDailyCost()).toBe(2.0)
   })
 
+  it('tracks token usage per run and per day', () => {
+    costTracker.recordCost(runId, 0, { promptTokens: 120, completionTokens: 45 })
+
+    expect(costTracker.getRunTokenUsage(runId)).toEqual({
+      promptTokens: 120,
+      completionTokens: 45,
+      totalTokens: 165,
+    })
+    expect(costTracker.getDailyTokenUsage()).toEqual({
+      promptTokens: 120,
+      completionTokens: 45,
+      totalTokens: 165,
+    })
+  })
+
   it('increments daily run_count once per run', () => {
     costTracker.recordCost(runId, 1.0)
     costTracker.recordCost(runId, 0.5)
@@ -61,6 +76,42 @@ describe('CostTracker', () => {
       .get(today) as { run_count: number } | undefined
 
     expect(row?.run_count).toBe(1)
+  })
+
+  it('increments daily run_count once for token-only updates', () => {
+    costTracker.recordCost(runId, 0, { promptTokens: 10, completionTokens: 5 })
+    costTracker.recordCost(runId, 0, { promptTokens: 20, completionTokens: 2 })
+
+    const today = new Date().toISOString().split('T')[0]
+    const row = db
+      .prepare('SELECT run_count FROM daily_costs WHERE date = ?')
+      .get(today) as { run_count: number } | undefined
+
+    expect(row?.run_count).toBe(1)
+  })
+
+  it('increments daily run_count once per UTC day for long-running runs', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-04-01T23:59:00.000Z'))
+      costTracker.recordCost(runId, 1.0, { promptTokens: 10, completionTokens: 5 })
+      costTracker.recordCost(runId, 0.5, { promptTokens: 20, completionTokens: 2 })
+
+      vi.setSystemTime(new Date('2026-04-02T00:01:00.000Z'))
+      costTracker.recordCost(runId, 0.25, { promptTokens: 7, completionTokens: 3 })
+
+      const firstDay = db
+        .prepare('SELECT run_count FROM daily_costs WHERE date = ?')
+        .get('2026-04-01') as { run_count: number } | undefined
+      const secondDay = db
+        .prepare('SELECT run_count FROM daily_costs WHERE date = ?')
+        .get('2026-04-02') as { run_count: number } | undefined
+
+      expect(firstDay?.run_count).toBe(1)
+      expect(secondDay?.run_count).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('detects per-run budget exceeded', () => {

--- a/test/state/db.test.ts
+++ b/test/state/db.test.ts
@@ -37,6 +37,7 @@ describe('initDatabase', () => {
     expect(tables).toContain('events')
     expect(tables).toContain('agent_events')
     expect(tables).toContain('daily_costs')
+    expect(tables).toContain('daily_run_usage')
     expect(tables).toContain('schema_migrations')
   })
 

--- a/test/state/stats.test.ts
+++ b/test/state/stats.test.ts
@@ -27,8 +27,11 @@ describe('loadTuiStats', () => {
     expect(stats.overview.activeRuns).toBe(0)
     expect(stats.throughput.runs7d).toBe(0)
     expect(stats.reliability.failureCount7d).toBe(0)
+    expect(stats.cost.model).toBe('pay-per-use')
     expect(stats.cost.todayCostUsd).toBe(0)
+    expect(stats.usage.todayTotalTokens).toBe(0)
     expect(stats.efficiency.avgCostPerRun7d).toBe(0)
+    expect(stats.efficiency.avgTokensPerRun7d).toBe(0)
     expect(stats.resources.activeLeases).toBe(0)
     expect(stats.timing.sampleSize30d).toBe(0)
     expect(stats.queue.activeBatches).toBe(0)
@@ -50,9 +53,9 @@ describe('loadTuiStats', () => {
 
     const insertRun = db.prepare(
       `INSERT INTO runs (
-        id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, started_at, ended_at,
+        id, repo, issue_number, status, current_phase, iteration_count, estimated_cost_usd, prompt_tokens, completion_tokens, started_at, ended_at,
         last_error, block_reason, worktree_path, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
 
     insertRun.run(
@@ -63,6 +66,8 @@ describe('loadTuiStats', () => {
       'publish',
       2,
       4.2,
+      900,
+      300,
       twoDaysAgo,
       twoDaysAgoPlusFortyFiveMinutes,
       null,
@@ -79,6 +84,8 @@ describe('loadTuiStats', () => {
       'code',
       1,
       1.5,
+      200,
+      100,
       oneDayAgo,
       oneDayAgoPlusThirtyMinutes,
       'API timeout after 30s while calling provider',
@@ -95,6 +102,8 @@ describe('loadTuiStats', () => {
       'plan',
       0,
       0.4,
+      100,
+      50,
       oneHourAgo,
       null,
       null,
@@ -109,6 +118,8 @@ describe('loadTuiStats', () => {
       4,
       'queued',
       'plan',
+      0,
+      0,
       0,
       0,
       oneHourAgo,
@@ -127,6 +138,8 @@ describe('loadTuiStats', () => {
       'review',
       3,
       2,
+      50,
+      25,
       thirtyFiveDaysAgo,
       oneDayAgo,
       null,
@@ -138,8 +151,12 @@ describe('loadTuiStats', () => {
 
     const today = dateOnly(now)
     const yesterday = dateOnly(now - (24 * 60 * 60 * 1000))
-    db.prepare('INSERT INTO daily_costs (date, total_cost_usd, run_count) VALUES (?, ?, ?)').run(today, 12.5, 2)
-    db.prepare('INSERT INTO daily_costs (date, total_cost_usd, run_count) VALUES (?, ?, ?)').run(yesterday, 3.5, 1)
+    db.prepare(
+      'INSERT INTO daily_costs (date, total_cost_usd, run_count, total_prompt_tokens, total_completion_tokens) VALUES (?, ?, ?, ?, ?)',
+    ).run(today, 12.5, 2, 1500, 500)
+    db.prepare(
+      'INSERT INTO daily_costs (date, total_cost_usd, run_count, total_prompt_tokens, total_completion_tokens) VALUES (?, ?, ?, ?, ?)',
+    ).run(yesterday, 3.5, 1, 400, 100)
 
     const insertLease = db.prepare(
       'INSERT INTO leases (repo, issue_number, lease_owner, leased_until) VALUES (?, ?, ?, ?)',
@@ -192,11 +209,18 @@ describe('loadTuiStats', () => {
     expect(stats.cost.cost7d).toBeCloseTo(16, 5)
     expect(stats.cost.todayRunCount).toBe(2)
     expect(stats.cost.dailyHistory.length).toBe(2)
+    expect(stats.usage.todayTotalTokens).toBe(2000)
+    expect(stats.usage.tokens7d).toBe(2500)
+    expect(stats.usage.avgDailyTokens7d).toBe(1250)
+    expect(stats.usage.dailyHistory.length).toBe(2)
     expect(stats.efficiency.totalCostUsd7d).toBeCloseTo(6.1, 5)
     expect(stats.efficiency.avgCostPerRun7d).toBeCloseTo(1.525, 5)
     expect(stats.efficiency.avgCostPerSuccess7d).toBeCloseTo(6.1, 5)
     expect(stats.efficiency.avgCostPerIteration7d).toBeCloseTo(6.1 / 3, 5)
     expect(stats.efficiency.completedPerDollar7d).toBeCloseTo(1 / 6.1, 5)
+    expect(stats.efficiency.avgTokensPerRun7d).toBeCloseTo(1650 / 4, 5)
+    expect(stats.efficiency.avgTokensPerSuccess7d).toBeCloseTo(1650, 5)
+    expect(stats.efficiency.avgTokensPerIteration7d).toBeCloseTo(1650 / 3, 5)
 
     expect(stats.resources.activeLeases).toBe(2)
     expect(stats.resources.expiringLeases).toBe(1)

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -54,6 +54,9 @@ function makeMinimalConfig() {
       maxDailyCostUsd: 50,
       maxCostPerRunUsd: 10,
     },
+    cost: {
+      model: 'pay-per-use' as const,
+    },
     workerProfiles: {},
     metrics: { enabled: false, port: 9090, host: '127.0.0.1' },
     observability: {

--- a/test/web/stats-page.test.ts
+++ b/test/web/stats-page.test.ts
@@ -70,6 +70,7 @@ const FULL_SNAPSHOT: DashboardSnapshot = {
       ],
     },
     cost: {
+      model: 'pay-per-use',
       todayCostUsd: 8.1,
       todayRunCount: 3,
       cost7d: 36.2,
@@ -81,12 +82,28 @@ const FULL_SNAPSHOT: DashboardSnapshot = {
         { date: '2026-03-30', totalCostUsd: 1.4, runCount: 1 },
       ],
     },
+    usage: {
+      todayPromptTokens: 3000,
+      todayCompletionTokens: 1200,
+      todayTotalTokens: 4200,
+      tokens7d: 15000,
+      tokens30d: 62000,
+      avgDailyTokens7d: 2200,
+      dailyHistory: [
+        { date: '2026-04-01', promptTokens: 3000, completionTokens: 1200, totalTokens: 4200, runCount: 3 },
+        { date: '2026-03-31', promptTokens: 1800, completionTokens: 400, totalTokens: 2200, runCount: 2 },
+        { date: '2026-03-30', promptTokens: 900, completionTokens: 250, totalTokens: 1150, runCount: 1 },
+      ],
+    },
     efficiency: {
       totalCostUsd7d: 36.2,
       avgCostPerRun7d: 3.62,
       avgCostPerSuccess7d: 6.03,
       avgCostPerIteration7d: 1.2,
       completedPerDollar7d: 0.17,
+      avgTokensPerRun7d: 1500,
+      avgTokensPerSuccess7d: 2500,
+      avgTokensPerIteration7d: 750,
     },
     resources: {
       activeLeases: 3,

--- a/test/workers/adapter.test.ts
+++ b/test/workers/adapter.test.ts
@@ -207,6 +207,33 @@ describe('ClaudeWorkerAdapter', () => {
     expect(result.rawOutput).toBe(rawOutput)
   })
 
+  it('extracts token usage from Claude result usage payload', async () => {
+    mockStreamingExec.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: '```json\n{"objective":"Plan"}\n```' }],
+          },
+        },
+        {
+          type: 'result',
+          usage: {
+            input_tokens: 120,
+            output_tokens: 45,
+          },
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+      durationMs: 1000,
+    })
+
+    const result = await adapter.runTask(makeTaskInput({ role: 'planner' }))
+    expect(result.tokenUsage).toEqual({ promptTokens: 120, completionTokens: 45 })
+  })
+
   it('checkAvailability returns available when command succeeds', async () => {
     mockExecWithTimeout.mockResolvedValue({
       stdout: 'claude v1.2.3\n',
@@ -352,6 +379,37 @@ describe('CodexWorkerAdapter', () => {
     expect(call?.args).toEqual(expect.arrayContaining(['--json', '--output-last-message']))
     expect(call?.args).not.toContain('resume')
     expect(call?.args).not.toContain('--resume')
+  })
+
+  it('extracts token usage from Codex completion events', async () => {
+    mockStreamingExec.mockResolvedValue({
+      stdout: [
+        JSON.stringify({
+          type: 'response.completed',
+          usage: {
+            input_tokens: 321,
+            output_tokens: 123,
+          },
+        }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            type: 'agent_message',
+            text: '```json\n{"objective":"Codex plan"}\n```',
+          },
+        }),
+      ].join('\n'),
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+      durationMs: 2000,
+    })
+
+    const result = await adapter.runTask(makeTaskInput({
+      role: 'planner',
+      profile: { ...baseProfile, type: 'codex', command: 'codex' },
+    }))
+    expect(result.tokenUsage).toEqual({ promptTokens: 321, completionTokens: 123 })
   })
 })
 

--- a/web/src/components/DashboardMetrics.tsx
+++ b/web/src/components/DashboardMetrics.tsx
@@ -9,15 +9,19 @@ interface DashboardMetricsProps {
 }
 
 export function DashboardMetrics({ snapshot }: DashboardMetricsProps): ReactElement {
+  const usageFirst = snapshot?.stats.cost.model === 'subscription'
+
   return (
     <section className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
       <MetricCard label="Active" value={snapshot?.status.activeRuns ?? 0} accent="cyan" />
       <MetricCard label="Running" value={snapshot?.stats.overview.runningRuns ?? 0} accent="amber" />
       <MetricCard
-        label="Daily Cost"
-        value={`$${formatMoney(snapshot?.status.dailyCostUsd ?? 0)}`}
+        label={usageFirst ? 'Daily Usage' : 'Daily Cost'}
+        value={usageFirst ? formatTokenCount(snapshot?.stats.usage.todayTotalTokens ?? 0) : `$${formatMoney(snapshot?.status.dailyCostUsd ?? 0)}`}
         accent="emerald"
-        subValue={`Budget $${formatMoney(snapshot?.cost.dailyBudgetUsd ?? 0)}`}
+        subValue={usageFirst
+          ? `Est. $${formatMoney(snapshot?.status.dailyCostUsd ?? 0)} today`
+          : `Budget $${formatMoney(snapshot?.cost.dailyBudgetUsd ?? 0)}`}
       />
       <MetricCard
         label="24h Throughput"
@@ -27,4 +31,12 @@ export function DashboardMetrics({ snapshot }: DashboardMetricsProps): ReactElem
       />
     </section>
   )
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
 }

--- a/web/src/components/StatsPage.tsx
+++ b/web/src/components/StatsPage.tsx
@@ -40,18 +40,23 @@ export function StatsPage({ snapshot, socketConnected }: StatsPageProps): ReactE
   const blockedThroughputTone = toneForPresence(stats.throughput.blocked7d, 1, 2)
   const errorThroughputTone = toneForPresence(stats.throughput.error7d, 1, 2)
   const todayCostTone = toneForRatioToBaseline(stats.cost.todayCostUsd, stats.cost.avgDailyCost7d, 1.05, 1.35)
+  const todayUsageTone = toneForRatioToBaseline(stats.usage.todayTotalTokens, stats.usage.avgDailyTokens7d, 1.05, 1.35)
   const costPerRunTone = toneForLowerIsBetter(stats.efficiency.avgCostPerRun7d, 1.5, 3)
   const costPerSuccessTone = toneForLowerIsBetter(stats.efficiency.avgCostPerSuccess7d, 3, 6)
+  const tokensPerRunTone = toneForLowerIsBetter(stats.efficiency.avgTokensPerRun7d, 8_000, 16_000)
+  const tokensPerSuccessTone = toneForLowerIsBetter(stats.efficiency.avgTokensPerSuccess7d, 16_000, 32_000)
   const expiringLeaseTone = toneForPresence(stats.resources.expiringLeases, 1, 3)
   const expiredLeaseTone = toneForPresence(stats.resources.expiredLeases, 1, 2)
   const missingWorktreeTone = toneForPresence(stats.resources.missingWorktrees, 1, 2)
   const staleWorktreeTone = toneForPresence(stats.resources.staleWorktrees, 1, 2)
+  const usageFirst = stats.cost.model === 'subscription'
 
   const hasLatencySample = stats.timing.sampleSize30d > 0 && stats.timing.p50Minutes > 0
   const tailLatencyRatio = hasLatencySample ? stats.timing.p90Minutes / stats.timing.p50Minutes : 0
   const tailLatencyTone = toneForLowerIsBetter(tailLatencyRatio, 2.5, 4.5)
 
   const costTrend = buildAsciiSparkline(stats.cost.dailyHistory.slice().reverse().map((row) => row.totalCostUsd))
+  const usageTrend = buildAsciiSparkline(stats.usage.dailyHistory.slice().reverse().map((row) => row.totalTokens))
 
   return (
     <div className="flex flex-col gap-5">
@@ -145,41 +150,86 @@ export function StatsPage({ snapshot, socketConnected }: StatsPageProps): ReactE
 
         <article className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
           <div className="card-body p-4 sm:p-5">
-            <h2 className="card-title text-lg">Cost</h2>
-            <div className="mt-2 space-y-2 text-sm">
-              <SignalRow
-                label="Today"
-                value={`$${formatMoney(stats.cost.todayCostUsd)} (${stats.cost.todayRunCount} runs)`}
-                valueClassName={toTextClass(todayCostTone)}
-              />
-              <SignalRow label="Cost (7d)" value={`$${formatMoney(stats.cost.cost7d)}`} />
-              <SignalRow label="Cost (30d)" value={`$${formatMoney(stats.cost.cost30d)}`} />
-              <SignalRow label="Average Daily Cost (7d)" value={`$${formatMoney(stats.cost.avgDailyCost7d)}`} />
-              <SignalRow label="Total Cost (7d)" value={`$${formatMoney(stats.efficiency.totalCostUsd7d)}`} />
-              <SignalRow
-                label="Cost Per Run (7d)"
-                value={`$${formatMoney(stats.efficiency.avgCostPerRun7d)}`}
-                valueClassName={toTextClass(costPerRunTone)}
-              />
-              <SignalRow
-                label="Cost Per Success (7d)"
-                value={`$${formatMoney(stats.efficiency.avgCostPerSuccess7d)}`}
-                valueClassName={toTextClass(costPerSuccessTone)}
-              />
-              <SignalRow label="Cost Per Iteration (7d)" value={`$${formatMoney(stats.efficiency.avgCostPerIteration7d)}`} />
-              <SignalRow label="Completed Per Dollar (7d)" value={stats.efficiency.completedPerDollar7d.toFixed(2)} />
-              <SignalRow label="Cost Trend (7d)" value={costTrend} />
-            </div>
-            <div className="mt-3 space-y-1">
-              {stats.cost.dailyHistory.length === 0 && (
-                <p className="text-xs text-base-content/60">No daily cost rows in the last 7 days.</p>
-              )}
-              {stats.cost.dailyHistory.map((row) => (
-                <p key={row.date} className="text-xs text-base-content/70">
-                  {row.date} ${formatMoney(row.totalCostUsd)} ({row.runCount})
-                </p>
-              ))}
-            </div>
+            <h2 className="card-title text-lg">Cost & Usage</h2>
+            {usageFirst ? (
+              <>
+                <div className="mt-2 space-y-2 text-sm">
+                  <SignalRow label="Cost Model" value="subscription" />
+                  <SignalRow
+                    label="Today Tokens"
+                    value={`${formatTokenCount(stats.usage.todayTotalTokens)} (${stats.cost.todayRunCount} runs)`}
+                    valueClassName={toTextClass(todayUsageTone)}
+                  />
+                  <SignalRow label="Tokens (7d)" value={formatTokenCount(stats.usage.tokens7d)} />
+                  <SignalRow label="Tokens (30d)" value={formatTokenCount(stats.usage.tokens30d)} />
+                  <SignalRow label="Average Daily Tokens (7d)" value={formatTokenCount(stats.usage.avgDailyTokens7d)} />
+                  <SignalRow
+                    label="Tokens Per Run (7d)"
+                    value={formatTokenCount(stats.efficiency.avgTokensPerRun7d)}
+                    valueClassName={toTextClass(tokensPerRunTone)}
+                  />
+                  <SignalRow
+                    label="Tokens Per Success (7d)"
+                    value={formatTokenCount(stats.efficiency.avgTokensPerSuccess7d)}
+                    valueClassName={toTextClass(tokensPerSuccessTone)}
+                  />
+                  <SignalRow label="Tokens Per Iteration (7d)" value={formatTokenCount(stats.efficiency.avgTokensPerIteration7d)} />
+                  <SignalRow label="Est. Cost Today" value={`$${formatMoney(stats.cost.todayCostUsd)}`} valueClassName={toTextClass(todayCostTone)} />
+                  <SignalRow label="Est. Cost (7d)" value={`$${formatMoney(stats.cost.cost7d)}`} />
+                  <SignalRow label="Usage Trend (7d)" value={usageTrend} />
+                </div>
+                <div className="mt-3 space-y-1">
+                  {stats.usage.dailyHistory.length === 0 && (
+                    <p className="text-xs text-base-content/60">No daily usage rows in the last 7 days.</p>
+                  )}
+                  {stats.usage.dailyHistory.map((row) => (
+                    <p key={row.date} className="text-xs text-base-content/70">
+                      {row.date} {formatTokenCount(row.totalTokens)} ({row.runCount})
+                    </p>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="mt-2 space-y-2 text-sm">
+                  <SignalRow label="Cost Model" value="pay-per-use" />
+                  <SignalRow
+                    label="Today"
+                    value={`$${formatMoney(stats.cost.todayCostUsd)} (${stats.cost.todayRunCount} runs)`}
+                    valueClassName={toTextClass(todayCostTone)}
+                  />
+                  <SignalRow label="Cost (7d)" value={`$${formatMoney(stats.cost.cost7d)}`} />
+                  <SignalRow label="Cost (30d)" value={`$${formatMoney(stats.cost.cost30d)}`} />
+                  <SignalRow label="Average Daily Cost (7d)" value={`$${formatMoney(stats.cost.avgDailyCost7d)}`} />
+                  <SignalRow label="Total Cost (7d)" value={`$${formatMoney(stats.efficiency.totalCostUsd7d)}`} />
+                  <SignalRow
+                    label="Cost Per Run (7d)"
+                    value={`$${formatMoney(stats.efficiency.avgCostPerRun7d)}`}
+                    valueClassName={toTextClass(costPerRunTone)}
+                  />
+                  <SignalRow
+                    label="Cost Per Success (7d)"
+                    value={`$${formatMoney(stats.efficiency.avgCostPerSuccess7d)}`}
+                    valueClassName={toTextClass(costPerSuccessTone)}
+                  />
+                  <SignalRow label="Cost Per Iteration (7d)" value={`$${formatMoney(stats.efficiency.avgCostPerIteration7d)}`} />
+                  <SignalRow label="Completed Per Dollar (7d)" value={stats.efficiency.completedPerDollar7d.toFixed(2)} />
+                  <SignalRow label="Today Tokens" value={formatTokenCount(stats.usage.todayTotalTokens)} valueClassName={toTextClass(todayUsageTone)} />
+                  <SignalRow label="Tokens (7d)" value={formatTokenCount(stats.usage.tokens7d)} />
+                  <SignalRow label="Cost Trend (7d)" value={costTrend} />
+                </div>
+                <div className="mt-3 space-y-1">
+                  {stats.cost.dailyHistory.length === 0 && (
+                    <p className="text-xs text-base-content/60">No daily cost rows in the last 7 days.</p>
+                  )}
+                  {stats.cost.dailyHistory.map((row) => (
+                    <p key={row.date} className="text-xs text-base-content/70">
+                      {row.date} ${formatMoney(row.totalCostUsd)} ({row.runCount})
+                    </p>
+                  ))}
+                </div>
+              </>
+            )}
           </div>
         </article>
       </section>
@@ -376,6 +426,14 @@ function formatMinutes(minutes: number): string {
   const hours = Math.floor(minutes / 60)
   const mins = Math.round(minutes % 60)
   return `${hours}h${String(mins).padStart(2, '0')}m`
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
 }
 
 function toneForHigherIsBetter(value: number, greenAt: number, yellowAt: number): Tone {

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -54,6 +54,14 @@ export interface DailyCostAggregate {
   runCount: number
 }
 
+export interface DailyUsageAggregate {
+  date: string
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  runCount: number
+}
+
 export interface ErrorPatternAggregate {
   pattern: string
   count: number
@@ -90,6 +98,7 @@ export interface TuiStatsSnapshot {
     topErrorPatterns7d: ErrorPatternAggregate[]
   }
   cost: {
+    model: 'pay-per-use' | 'subscription'
     todayCostUsd: number
     todayRunCount: number
     cost7d: number
@@ -97,12 +106,24 @@ export interface TuiStatsSnapshot {
     avgDailyCost7d: number
     dailyHistory: DailyCostAggregate[]
   }
+  usage: {
+    todayPromptTokens: number
+    todayCompletionTokens: number
+    todayTotalTokens: number
+    tokens7d: number
+    tokens30d: number
+    avgDailyTokens7d: number
+    dailyHistory: DailyUsageAggregate[]
+  }
   efficiency: {
     totalCostUsd7d: number
     avgCostPerRun7d: number
     avgCostPerSuccess7d: number
     avgCostPerIteration7d: number
     completedPerDollar7d: number
+    avgTokensPerRun7d: number
+    avgTokensPerSuccess7d: number
+    avgTokensPerIteration7d: number
   }
   resources: {
     activeLeases: number


### PR DESCRIPTION
Closes #103

## Plan
**Objective:** Track real token usage from Claude Code and Codex alongside estimated USD cost, with configurable cost model (subscription vs pay-per-use) to show appropriate metrics

1. Create DB migration 013-token-tracking: Add total_input_tokens and total_output_tokens columns (INTEGER DEFAULT 0) to runs, daily_costs, and issues tables
2. Extract token usage from Claude worker: In extractFromJsonOutput, also extract input_tokens and output_tokens from the result event's usage object. Return tokenUsage in WorkerTaskResult. Similarly, accumulate token counts from streaming events in the Codex worker and return them in WorkerTaskResult
3. Update CostTracker to record token counts alongside cost: Add recordTokens method (or extend recordCost) to update total_input_tokens/total_output_tokens on runs and daily_costs tables. Add getRunTokens and getDailyTokens queries
4. Update applyEstimatedWorkerCost in engine.ts to also pass token counts to CostTracker when available. Update RunContext to include totalInputTokens and totalOutputTokens fields
5. Add costTracking config section to schema: costModel ('estimated' | 'subscription', default 'estimated'), subscriptionLabel (optional string), overageRates (optional per-token rates for overage pricing beyond quota). Update CONFIGURATION.md
6. Update TuiStatsSnapshot to include token metrics: total tokens today, 7d, 30d; tokens per run; daily token history. Update loadTuiStats SQL queries to aggregate token columns
7. Update issues table sync (IssueManager) to propagate token counts from runs to issues
8. Update TUI stats view to show token metrics alongside cost. When costModel is 'subscription', show tokens as primary metric with cost as secondary. Show both input and output token counts
9. Update CLI status command and MCP cost-report tool to include token data in output
10. Update checkpoint restore to include token counts so resumed runs have correct cumulative tokens
11. Write tests: token extraction from Claude/Codex output, CostTracker token recording, stats aggregation with tokens, config validation for costTracking

## Implementation
Addressed both review findings. Fixed daily run counting by introducing a new `daily_run_usage` table keyed by `(date, run_id)` and updated `CostTracker.recordCost` to increment `daily_costs.run_count` only on first usage for that run on that UTC day (so cross-day usage now increments each day correctly). Added a migration for the new table and a regression test covering day rollover behavior. Also fixed token efficiency coloring mismatch by replacing per-run-vs-per-day baseline comparisons with explicit lower-is-better thresholds for `tokens/run` and `tokens/success` in both TUI and web stats views. Validation run: `pnpm typecheck`, `pnpm lint`, and targeted tests (`test/loop/cost.test.ts`, `test/state/db.test.ts`, `test/cli/tui/stats-view.test.ts`, `test/web/stats-page.test.ts`) all passed.

**Changed files:**
- `src/loop/cost.ts`
- `src/state/db.ts`
- `src/state/migrations/014-daily-run-usage.ts`
- `src/cli/tui/stats-view.tsx`
- `web/src/components/StatsPage.tsx`
- `test/loop/cost.test.ts`
- `test/state/db.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed the changed files end-to-end (runtime, UI, docs, migrations, and tests). The previously reported issues are addressed: daily run counting is now deduped per UTC day via `daily_run_usage` in `src/loop/cost.ts`, with cross-day regression coverage in `test/loop/cost.test.ts`; and tokens-per-run coloring now uses explicit per-run thresholds in both `src/cli/tui/stats-view.tsx` and `web/src/components/StatsPage.tsx` (no longer comparing per-run to per-day baselines). I also ran targeted tests for the modified areas; all passed.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex