### PR TITLE
[CHORE] Web - ui component - modal (night-orch / #108)

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './card/index.js'
 export * from './issue-row/index.js'
+export * from './modal/index.js'

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -1,0 +1,2 @@
+export type { ModalProps } from './types.js'
+export { ModalWeb } from './modal.web.js'

--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -1,0 +1,77 @@
+import { type ReactElement, useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ModalWeb } from './modal.web.js'
+import type { ModalProps } from './types.js'
+
+const meta = {
+  title: 'Components/Modal/Web',
+  component: ModalWeb,
+  args: {
+    open: true,
+    title: 'Confirm branch cleanup',
+    description: 'This action permanently removes stale worktrees.',
+    closeOnBackdropClick: true,
+    blocking: false,
+    children: (
+      <p className="mt-4 text-sm text-base-content/85">
+        Modal bodies can render any children, including forms, status lists, and warnings.
+      </p>
+    ),
+  },
+} satisfies Meta<typeof ModalWeb>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Dismissible: Story = {
+  render: (args) => <DismissiblePreview {...args} />,
+}
+
+export const Blocking: Story = {
+  args: {
+    title: 'Applying self-update',
+    description: 'Dashboard controls stay locked until restart is healthy.',
+    blocking: true,
+    closeOnBackdropClick: true,
+    children: (
+      <div className="mt-4 space-y-3">
+        <div className="flex items-center gap-3 text-sm">
+          <span className="loading loading-spinner loading-md text-info" />
+          <span>Installing and verifying the new build</span>
+        </div>
+        <p className="text-xs text-base-content/70">
+          Backdrop clicks and close controls are disabled while blocking mode is active.
+        </p>
+      </div>
+    ),
+  },
+}
+
+function DismissiblePreview(args: ModalProps): ReactElement {
+  const [open, setOpen] = useState<boolean>(args.open)
+
+  return (
+    <div className="flex min-h-[26rem] items-center justify-center">
+      <button type="button" className="btn btn-primary btn-sm" onClick={() => setOpen(true)}>
+        Open modal
+      </button>
+      <ModalWeb
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false)
+        }}
+        actions={
+          <>
+            <button type="button" className="btn btn-ghost btn-sm" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button type="button" className="btn btn-error btn-sm" onClick={() => setOpen(false)}>
+              Remove worktrees
+            </button>
+          </>
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/modal/modal.web.tsx
+++ b/src/components/modal/modal.web.tsx
@@ -1,0 +1,169 @@
+import { type ReactElement, useCallback, useEffect, useId } from 'react'
+import type { ModalProps } from './types.js'
+
+const DEFAULT_WIDTH_CLASS = 'max-w-xl'
+
+interface ModalDismissState {
+  canRequestClose: boolean
+  shouldCloseOnBackdropClick: boolean
+}
+
+interface ModalKeyEvent {
+  key: string
+  preventDefault: () => void
+}
+
+interface GlobalEventTargetLike {
+  addEventListener: (eventName: string, listener: (event: unknown) => void) => void
+  removeEventListener: (eventName: string, listener: (event: unknown) => void) => void
+}
+
+export function ModalWeb(props: ModalProps): ReactElement | null {
+  const titleId = useId()
+  const descriptionId = useId()
+  const dismissState = resolveModalDismissState(props)
+
+  const widthClassName = props.widthClassName ?? DEFAULT_WIDTH_CLASS
+  const hasActions = isRenderableNode(props.actions)
+  const closeButtonLabel = props.closeButtonLabel ?? 'Close dialog'
+  const ariaLabel = resolveAriaLabel(props)
+  const labelledBy = props.ariaLabel !== undefined ? undefined : props.title ? titleId : undefined
+
+  const requestClose = useCallback((): void => {
+    requestModalClose(dismissState.canRequestClose, props.onClose)
+  }, [dismissState.canRequestClose, props.onClose])
+
+  useEffect(() => {
+    if (!props.open || !dismissState.canRequestClose) {
+      return
+    }
+
+    const eventTarget = getGlobalEventTarget()
+    if (eventTarget === null) {
+      return
+    }
+
+    const onKeyDown = (event: unknown): void => {
+      if (!isModalKeyEvent(event)) {
+        return
+      }
+      handleModalEscapeKey(event, dismissState.canRequestClose, props.onClose)
+    }
+
+    eventTarget.addEventListener('keydown', onKeyDown)
+    return () => {
+      eventTarget.removeEventListener('keydown', onKeyDown)
+    }
+  }, [props.open, dismissState.canRequestClose, props.onClose])
+
+  if (!props.open) {
+    return null
+  }
+
+  return (
+    <div
+      className="modal modal-open bg-slate-950/78 px-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      aria-describedby={props.description ? descriptionId : undefined}
+      aria-label={ariaLabel}
+    >
+      <section
+        className={`modal-box relative w-full ${widthClassName} rounded-box border border-base-300/80 bg-base-100/95 p-5 shadow-2xl`}
+      >
+        {dismissState.canRequestClose ? (
+          <button
+            type="button"
+            className="btn btn-circle btn-ghost btn-sm absolute right-3 top-3"
+            onClick={requestClose}
+            aria-label={closeButtonLabel}
+          >
+            x
+          </button>
+        ) : null}
+
+        {props.title ? <h2 id={titleId} className="pr-10 text-lg font-semibold">{props.title}</h2> : null}
+        {props.description ? <p id={descriptionId} className="mt-1 text-sm text-base-content/75">{props.description}</p> : null}
+        {props.children}
+        {hasActions ? <footer className="mt-5 flex justify-end gap-2">{props.actions}</footer> : null}
+      </section>
+
+      {dismissState.shouldCloseOnBackdropClick ? (
+        <button type="button" className="modal-backdrop" aria-label={closeButtonLabel} onClick={requestClose}>
+          close
+        </button>
+      ) : (
+        <div className="modal-backdrop cursor-default" aria-hidden="true" />
+      )}
+    </div>
+  )
+}
+
+function isRenderableNode(node: ModalProps['actions']): boolean {
+  return node !== undefined && node !== null && typeof node !== 'boolean'
+}
+
+export function resolveModalDismissState(
+  props: Pick<ModalProps, 'onClose' | 'blocking' | 'closeOnBackdropClick'>,
+): ModalDismissState {
+  const canRequestClose = typeof props.onClose === 'function' && !props.blocking
+  const shouldCloseOnBackdropClick = canRequestClose && (props.closeOnBackdropClick ?? true)
+  return {
+    canRequestClose,
+    shouldCloseOnBackdropClick,
+  }
+}
+
+export function requestModalClose(
+  canRequestClose: boolean,
+  onClose: ModalProps['onClose'],
+): boolean {
+  if (!canRequestClose || onClose === undefined) {
+    return false
+  }
+  onClose()
+  return true
+}
+
+export function handleModalEscapeKey(
+  event: ModalKeyEvent,
+  canRequestClose: boolean,
+  onClose: ModalProps['onClose'],
+): boolean {
+  if (!canRequestClose || event.key !== 'Escape') {
+    return false
+  }
+  event.preventDefault()
+  return requestModalClose(canRequestClose, onClose)
+}
+
+function resolveAriaLabel(props: Pick<ModalProps, 'title' | 'ariaLabel'>): string | undefined {
+  if (props.ariaLabel !== undefined) {
+    return props.ariaLabel
+  }
+  if (props.title === undefined) {
+    return 'Modal dialog'
+  }
+  return undefined
+}
+
+function isModalKeyEvent(event: unknown): event is ModalKeyEvent {
+  if (typeof event !== 'object' || event === null) {
+    return false
+  }
+
+  const candidate = event as { key?: unknown; preventDefault?: unknown }
+  return typeof candidate.key === 'string' && typeof candidate.preventDefault === 'function'
+}
+
+function getGlobalEventTarget(): GlobalEventTargetLike | null {
+  const candidate = globalThis as Partial<GlobalEventTargetLike>
+  if (typeof candidate.addEventListener !== 'function') {
+    return null
+  }
+  if (typeof candidate.removeEventListener !== 'function') {
+    return null
+  }
+  return candidate as GlobalEventTargetLike
+}

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+export interface ModalProps {
+  open: boolean
+  title?: string
+  description?: string
+  children?: ReactNode
+  actions?: ReactNode
+  onClose?: () => void
+  blocking?: boolean
+  closeOnBackdropClick?: boolean
+  ariaLabel?: string
+  closeButtonLabel?: string
+  widthClassName?: string
+}

--- a/test/components/modal-web.test.ts
+++ b/test/components/modal-web.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import {
+  handleModalEscapeKey,
+  ModalWeb,
+  requestModalClose,
+  resolveModalDismissState,
+} from '../../src/components/modal/modal.web.js'
+
+describe('ModalWeb', () => {
+  it('returns empty output when closed', () => {
+    const html = renderToStaticMarkup(React.createElement(ModalWeb, {
+      open: false,
+      title: 'Hidden modal',
+    }))
+
+    expect(html).toBe('')
+  })
+
+  it('renders close button and clickable backdrop by default', () => {
+    const html = renderToStaticMarkup(React.createElement(ModalWeb, {
+      open: true,
+      title: 'Dismissible modal',
+      onClose: () => undefined,
+    }))
+
+    expect(html).toContain('btn-circle')
+    expect(html).toContain('<button type="button" class="modal-backdrop"')
+  })
+
+  it('renders non-clickable backdrop when closeOnBackdropClick is false', () => {
+    const html = renderToStaticMarkup(React.createElement(ModalWeb, {
+      open: true,
+      title: 'No backdrop dismiss',
+      onClose: () => undefined,
+      closeOnBackdropClick: false,
+    }))
+
+    expect(html).toContain('btn-circle')
+    expect(html).toContain('<div class="modal-backdrop cursor-default" aria-hidden="true"></div>')
+    expect(html).not.toContain('<button type="button" class="modal-backdrop"')
+  })
+
+  it('suppresses close controls in blocking mode', () => {
+    const html = renderToStaticMarkup(React.createElement(ModalWeb, {
+      open: true,
+      title: 'Blocking modal',
+      onClose: () => undefined,
+      blocking: true,
+    }))
+
+    expect(html).not.toContain('btn-circle')
+    expect(html).toContain('<div class="modal-backdrop cursor-default" aria-hidden="true"></div>')
+  })
+
+  it('uses explicit ariaLabel even when title is present', () => {
+    const html = renderToStaticMarkup(React.createElement(ModalWeb, {
+      open: true,
+      title: 'Visible title',
+      ariaLabel: 'Self update in progress',
+    }))
+
+    expect(html).toContain('aria-label="Self update in progress"')
+    expect(html).not.toContain('aria-labelledby=')
+  })
+})
+
+describe('modal dismissal helpers', () => {
+  it('computes dismiss state for default, opt-out, and blocking modes', () => {
+    const onClose = () => undefined
+
+    expect(resolveModalDismissState({ onClose })).toEqual({
+      canRequestClose: true,
+      shouldCloseOnBackdropClick: true,
+    })
+    expect(resolveModalDismissState({ onClose, closeOnBackdropClick: false })).toEqual({
+      canRequestClose: true,
+      shouldCloseOnBackdropClick: false,
+    })
+    expect(resolveModalDismissState({ onClose, blocking: true })).toEqual({
+      canRequestClose: false,
+      shouldCloseOnBackdropClick: false,
+    })
+  })
+
+  it('only invokes close callback when closure is permitted', () => {
+    const onClose = vi.fn()
+
+    expect(requestModalClose(false, onClose)).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(requestModalClose(true, onClose)).toBe(true)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles Escape key only when closure is permitted', () => {
+    const onClose = vi.fn()
+    const preventDefault = vi.fn()
+
+    expect(handleModalEscapeKey({ key: 'Enter', preventDefault }, true, onClose)).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+
+    expect(handleModalEscapeKey({ key: 'Escape', preventDefault }, false, onClose)).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+
+    expect(handleModalEscapeKey({ key: 'Escape', preventDefault }, true, onClose)).toBe(true)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/UpdateProgressModal.tsx
+++ b/web/src/components/UpdateProgressModal.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement } from 'react'
 
+import { ModalWeb } from '../../../src/components/modal/modal.web.js'
 import { type UpdateStatus } from '../types/dashboard.js'
 
 const UPDATE_STEPS = [
@@ -39,61 +40,56 @@ function getStepStatus(
 
 export function UpdateProgressModal({ status }: { status: UpdateStatus }): ReactElement {
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/78 px-4 backdrop-blur-sm">
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-label="Self update in progress"
-        className="w-full max-w-xl rounded-box border border-base-300/80 bg-base-100/95 p-5 shadow-2xl"
-      >
-        <div className="flex items-center gap-3">
-          <span className="loading loading-spinner loading-md text-info" />
-          <div>
-            <h2 className="text-lg font-semibold">Applying self-update</h2>
-            <p className="text-sm text-base-content/75">
-              Current stage: {formatUpdateState(status.state)}
-            </p>
-          </div>
+    <ModalWeb
+      open
+      title="Applying self-update"
+      description={`Current stage: ${formatUpdateState(status.state)}`}
+      ariaLabel="Self update in progress"
+      blocking
+      widthClassName="max-w-xl"
+    >
+      <div className="mt-3 flex items-center gap-3 text-sm text-base-content/80">
+        <span className="loading loading-spinner loading-md text-info" />
+        <span>Update workflow is running and cannot be interrupted.</span>
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {UPDATE_STEPS.map((step) => {
+          const stepStatus = getStepStatus(step.id, status.state)
+          const badgeTone =
+            stepStatus === 'active'
+              ? 'badge-info'
+              : stepStatus === 'done'
+                ? 'badge-success'
+                : 'badge-ghost'
+          const badgeLabel =
+            stepStatus === 'active'
+              ? 'live'
+              : stepStatus === 'done'
+                ? 'done'
+                : 'pending'
+
+          return (
+            <li key={step.id} className="flex items-center justify-between gap-3 text-sm">
+              <span className={stepStatus === 'pending' ? 'text-base-content/65' : undefined}>
+                {step.label}
+              </span>
+              <span className={`badge badge-sm ${badgeTone}`}>{badgeLabel}</span>
+            </li>
+          )
+        })}
+      </ul>
+
+      {status.state === 'rolling-back' && (
+        <div className="mt-4 rounded border border-warning/35 bg-warning/10 p-2 text-xs text-warning-content">
+          Health checks failed. Rolling back to the previous known-good build.
         </div>
+      )}
 
-        <ul className="mt-4 space-y-2">
-          {UPDATE_STEPS.map((step) => {
-            const stepStatus = getStepStatus(step.id, status.state)
-            const badgeTone =
-              stepStatus === 'active'
-                ? 'badge-info'
-                : stepStatus === 'done'
-                  ? 'badge-success'
-                  : 'badge-ghost'
-            const badgeLabel =
-              stepStatus === 'active'
-                ? 'live'
-                : stepStatus === 'done'
-                  ? 'done'
-                  : 'pending'
-
-            return (
-              <li key={step.id} className="flex items-center justify-between gap-3 text-sm">
-                <span className={stepStatus === 'pending' ? 'text-base-content/65' : undefined}>
-                  {step.label}
-                </span>
-                <span className={`badge badge-sm ${badgeTone}`}>{badgeLabel}</span>
-              </li>
-            )
-          })}
-        </ul>
-
-        {status.state === 'rolling-back' && (
-          <div className="mt-4 rounded border border-warning/35 bg-warning/10 p-2 text-xs text-warning-content">
-            Health checks failed. Rolling back to the previous known-good build.
-          </div>
-        )}
-
-        <p className="mt-4 text-xs text-base-content/70">
-          Dashboard controls are temporarily blocked. This page refreshes automatically after a
-          healthy restart.
-        </p>
-      </section>
-    </div>
+      <p className="mt-4 text-xs text-base-content/70">
+        Dashboard controls are temporarily blocked. This page refreshes automatically after a
+        healthy restart.
+      </p>
+    </ModalWeb>
   )
 }


### PR DESCRIPTION
Closes #108

## Plan
**Objective:** Create a generic reusable Modal component with dark backdrop, click-to-close, and blocking mode, plus Storybook stories

1. Create src/components/modal/types.ts with shared ModalProps interface: open (boolean), onClose (optional callback — omit for blocking), blocking (optional boolean to suppress backdrop close), title (optional string), children (ReactNode)
2. Create src/components/modal/modal.web.tsx — uses DaisyUI dialog element pattern with modal class, modal-box for content, dark backdrop (modal-backdrop). Clicking backdrop calls onClose unless blocking is true. Includes aria attributes (role=dialog, aria-modal). Uses useEffect to sync the open prop with the dialog element's showModal/close methods for proper native dialog behavior, or uses the DaisyUI checkbox/class toggle pattern. Escape key should also close unless blocking.
3. Create src/components/modal/modal.tui.tsx — Ink-based modal using Box with absolute-like rendering (borderStyle, full width). Shows/hides based on open prop. Displays title and children. Blocking variant omits the close hint text.
4. Create src/components/modal/modal.stories.tsx — Storybook stories covering: Default (open modal with title and body text), Blocking (no close on backdrop click), WithCloseButton (custom close action in children), LongContent (scrollable body). Include interactive toggle to open/close.
5. Create src/components/modal/index.ts — re-export types and both surface implementations
6. Update src/components/index.ts to add export for the new modal component
7. Run pnpm typecheck, pnpm lint, and pnpm storybook:typecheck to verify everything compiles cleanly

## Implementation
Addressed the review findings by updating `ModalWeb` to support Escape-key dismissal in non-blocking mode, honoring explicit `ariaLabel` even when `title` is set, and adding dedicated modal behavior tests. Added coverage for closed rendering, backdrop/default dismissal behavior, `closeOnBackdropClick=false`, blocking-mode dismissal suppression, aria labeling, and close-callback/escape helper logic. Verification passed with `pnpm typecheck`, `pnpm lint`, and `pnpm test`.

**Changed files:**
- `src/components/index.ts`
- `src/components/modal/index.ts`
- `src/components/modal/types.ts`
- `src/components/modal/modal.web.tsx`
- `src/components/modal/modal.stories.tsx`
- `web/src/components/UpdateProgressModal.tsx`
- `test/components/modal-web.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
No blocking findings. The previously reported issues are addressed: Escape-key dismissal is implemented for dismissible modals, dedicated ModalWeb tests now cover close/backdrop/blocking behavior, and explicit ariaLabel now takes precedence when title exists. Verification passed locally with `pnpm test` (1187 tests), `pnpm lint`, and `pnpm typecheck`. Residual risk: Escape behavior is validated through helper/unit coverage rather than a DOM interaction test.

---

**Triage:** standard | **Iterations:** 4 | **Roles:** plan=claude code=codex review=codex