### PR TITLE
[CHORE] Project - keep source branches synced (night-orch / #122)

### DIFF
--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -52,8 +52,9 @@ export function createWorktreeManager(): WorktreeManager {
           logger.info({ branchName }, 'Creating local tracking branch from remote')
           await createTrackingBranch(repoLocalPath, branchName)
         } else {
-          logger.info({ branchName, baseBranch }, 'Creating new branch from base')
-          await createBranch(repoLocalPath, branchName, baseBranch)
+          const remoteBaseRef = `origin/${baseBranch}`
+          logger.info({ branchName, baseBranch: remoteBaseRef }, 'Creating new branch from base')
+          await createBranch(repoLocalPath, branchName, remoteBaseRef)
         }
       }
 

--- a/test/git/worktree-lifecycle.test.ts
+++ b/test/git/worktree-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createWorktreeManager } from '../../src/git/worktree.js'
 import { execa } from 'execa'
-import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -115,5 +115,29 @@ describe('WorktreeManager lifecycle', () => {
 
     const list = await manager.list(repoPath, worktreeRoot)
     expect(list.length).toBe(2)
+  })
+
+  it('creates new branch from origin/base even when local base has extra commits', async () => {
+    // Create a local-only commit on main that is not pushed to origin.
+    const localOnlyFile = join(repoPath, 'local-only.txt')
+    writeFileSync(localOnlyFile, 'local only')
+    await execa('git', ['-C', repoPath, 'add', 'local-only.txt'])
+    await execa('git', ['-C', repoPath, 'commit', '-m', 'local-only-main-commit'])
+
+    const worktreePath = join(worktreeRoot, 'test-wt')
+    const branchName = 'orch/3-remote-base'
+    await manager.ensure({
+      repoLocalPath: repoPath,
+      baseBranch: 'main',
+      branchName,
+      worktreePath,
+    })
+
+    const { stdout: branchSha } = await execa('git', ['-C', repoPath, 'rev-parse', branchName])
+    const { stdout: localMainSha } = await execa('git', ['-C', repoPath, 'rev-parse', 'main'])
+    const { stdout: remoteMainSha } = await execa('git', ['-C', repoPath, 'rev-parse', 'origin/main'])
+
+    expect(branchSha.trim()).toBe(remoteMainSha.trim())
+    expect(branchSha.trim()).not.toBe(localMainSha.trim())
   })
 })


### PR DESCRIPTION
Closes #122

## Plan
**Objective:** Ensure new work branches are created from the latest remote base branch, not a potentially stale local ref

1. In src/git/worktree.ts line 56, change `createBranch(repoLocalPath, branchName, baseBranch)` to `createBranch(repoLocalPath, branchName, `origin/${baseBranch}`)` so new branches fork from the freshly-fetched remote ref instead of a potentially stale local ref
2. Check if test/git/worktree.test.ts exists and update any mocks/assertions to expect `origin/<baseBranch>` as the start point for new branch creation
3. Run pnpm typecheck && pnpm lint && pnpm test to verify the change

## Implementation
Updated worktree branch initialization to create new issue branches from `origin/<baseBranch>` (after fetch) instead of the local base ref, ensuring new runs start from the latest remote base and do not inherit local-only base commits. Added a regression test covering a local-ahead base branch scenario. Verified with `pnpm test test/git/worktree-lifecycle.test.ts test/git/worktree.test.ts test/git/branch.test.ts` and `pnpm typecheck`.

**Changed files:**
- `src/git/worktree.ts`
- `test/git/worktree-lifecycle.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The change in src/git/worktree.ts:55-57 correctly creates new branches from origin/<baseBranch>, preventing local-only base commits from leaking into new issue branches. The added test in test/git/worktree-lifecycle.test.ts:120-141 validates that behavior, and the suite passes (139 files / 1188 tests). No blocking correctness, security, or error-handling issues were found.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex