### PR TITLE
[CHORE] Web - Settings improvements (night-orch / #112)

### DIFF
--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -1,5 +1,5 @@
 import type { Server } from 'node:http'
-import { loadConfig, resolveConfigPath, ConfigError } from '../../config/loader.js'
+import { loadConfigWithRaw, resolveConfigPath, ConfigError } from '../../config/loader.js'
 import { initDatabase } from '../../state/db.js'
 import { pollOnce } from '../../runner/poller.js'
 import { SyncEngine } from '../../ops/sync.js'
@@ -35,11 +35,14 @@ export async function webCommand(
   const dryRun = globalOpts?.dryRun ?? false
 
   let baseConfig
+  let rawConfig: unknown
   try {
     const configPath = resolveConfigPath(globalOpts?.config, {
       trustWorkspace: globalOpts?.trustWorkspace ?? false,
     })
-    baseConfig = loadConfig(configPath)
+    const loadedConfig = loadConfigWithRaw(configPath)
+    baseConfig = loadedConfig.config
+    rawConfig = loadedConfig.raw
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`Config error: ${err.message}\n`)
@@ -124,7 +127,14 @@ export async function webCommand(
   try {
     webServer = await startWebServer(
       { db, config: baseConfig, forgeAdapters, poller: pollerControl, metrics: metrics ?? null },
-      { host, allowedHosts, port, snapshotIntervalMs, operationsEnabled: true },
+      {
+        host,
+        allowedHosts,
+        port,
+        snapshotIntervalMs,
+        operationsEnabled: true,
+        rawConfig,
+      },
     )
   } catch (err) {
     logger.error({ err, host, allowedHosts, port }, 'Failed to start web server')

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -15,27 +15,22 @@ export class ConfigError extends Error {
   }
 }
 
+export interface LoadedConfig {
+  raw: unknown
+  config: Config
+}
+
 /**
  * Load and validate config from a YAML file.
  * Expands all path fields (~, $ENV).
  */
 export function loadConfig(configPath: string): Config {
+  return loadConfigWithRaw(configPath).config
+}
+
+export function loadConfigWithRaw(configPath: string): LoadedConfig {
   const resolvedPath = expandPath(configPath)
-
-  if (!existsSync(resolvedPath)) {
-    throw new ConfigError(`Config file not found: ${resolvedPath}`)
-  }
-
-  let raw: unknown
-  try {
-    const content = readFileSync(resolvedPath, 'utf-8')
-    raw = parseYaml(content)
-  } catch (err) {
-    throw new ConfigError(
-      `Failed to parse YAML config: ${resolvedPath}`,
-      [(err as Error).message],
-    )
-  }
+  const raw = loadRawConfig(resolvedPath)
 
   let config: Config
   try {
@@ -63,7 +58,28 @@ export function loadConfig(configPath: string): Config {
   validateWorkerProfileRefs(config)
 
   logger.debug({ configPath: resolvedPath }, 'Config loaded successfully')
-  return config
+  return {
+    raw,
+    config,
+  }
+}
+
+export function loadRawConfig(configPath: string): unknown {
+  const resolvedPath = expandPath(configPath)
+
+  if (!existsSync(resolvedPath)) {
+    throw new ConfigError(`Config file not found: ${resolvedPath}`)
+  }
+
+  try {
+    const content = readFileSync(resolvedPath, 'utf-8')
+    return parseYaml(content)
+  } catch (err) {
+    throw new ConfigError(
+      `Failed to parse YAML config: ${resolvedPath}`,
+      [(err as Error).message],
+    )
+  }
 }
 
 function expandConfigPaths(config: Config): Config {

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -15,7 +15,10 @@ interface SettingDefinitionBase<K extends SettingKey, V extends SettingValue> {
   key: K
   label: string
   description: string
+  details: string
   type: SettingType
+  defaultValue: V
+  yamlPath: readonly [string, ...string[]]
   read: (config: Config) => V
   apply: (config: Config, value: V) => Config
   parseInput: (raw: unknown) => V
@@ -38,12 +41,20 @@ export interface BooleanSettingDefinition<K extends SettingKey = SettingKey>
 
 export type SettingDefinition = NumberSettingDefinition | BooleanSettingDefinition
 
+export interface SettingYamlValue {
+  hasYamlValue: boolean
+  yamlValue: SettingValue | null
+}
+
 const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
   'github.pollIntervalSeconds': {
     key: 'github.pollIntervalSeconds',
     label: 'Poll Interval (seconds)',
     description: 'Delay between automatic poll cycles.',
+    details: 'Controls how often night-orch checks configured repos for work. Lower values react faster but increase API traffic; higher values reduce background load.',
     type: 'number',
+    defaultValue: 300,
+    yamlPath: ['github', 'pollIntervalSeconds'],
     min: 5,
     max: 3600,
     step: 5,
@@ -73,7 +84,10 @@ const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     key: 'security.maxDailyCostUsd',
     label: 'Daily Cost Budget (USD)',
     description: 'Maximum allowed spend per UTC day before new runs are blocked.',
+    details: 'Sets the global daily spend cap for pay-per-use mode. When the cap is reached, new runs are blocked until the next UTC day or until you raise the limit.',
     type: 'number',
+    defaultValue: 50,
+    yamlPath: ['security', 'maxDailyCostUsd'],
     min: 1,
     max: 10000,
     step: 1,
@@ -103,7 +117,10 @@ const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     key: 'security.maxCostPerRunUsd',
     label: 'Per-Run Cost Budget (USD)',
     description: 'Maximum allowed spend for a single run before it is blocked.',
+    details: 'Sets the per-issue run cost ceiling. Useful for preventing one expensive issue from consuming most of the daily budget.',
     type: 'number',
+    defaultValue: 10,
+    yamlPath: ['security', 'maxCostPerRunUsd'],
     min: 0.1,
     max: 1000,
     step: 0.5,
@@ -133,7 +150,10 @@ const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     key: 'loop.maxReviewIterations',
     label: 'Max Review Iterations',
     description: 'Maximum review correction loops per run.',
+    details: 'Limits how many review-fix-review cycles a run can execute before stopping. Higher values can improve completion rate, but may increase runtime and cost.',
     type: 'number',
+    defaultValue: 4,
+    yamlPath: ['loop', 'maxReviewIterations'],
     min: 1,
     max: 20,
     step: 1,
@@ -163,7 +183,10 @@ const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     key: 'loop.maxTotalAgentPasses',
     label: 'Max Total Agent Passes',
     description: 'Hard cap on planner/coder/reviewer passes in one run.',
+    details: 'Caps total planner/coder/reviewer passes across the full run. This is a safety guard against long loops and runaway spend.',
     type: 'number',
+    defaultValue: 10,
+    yamlPath: ['loop', 'maxTotalAgentPasses'],
     min: 1,
     max: 50,
     step: 1,
@@ -193,7 +216,10 @@ const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     key: 'observability.agentStreaming',
     label: 'Agent Streaming',
     description: 'Enable in-flight agent event streaming to TUI/Web.',
+    details: 'Turns live agent event streaming on or off for terminal and web views. Disable this if you want quieter live output while runs are active.',
     type: 'boolean',
+    defaultValue: true,
+    yamlPath: ['observability', 'agentStreaming'],
     read: (config) => config.observability?.agentStreaming ?? true,
     apply: (config, value) => ({
       ...config,
@@ -216,6 +242,24 @@ export function listSettingDefinitions(): SettingDefinition[] {
 
 export function getSettingDefinition(key: string): SettingDefinition | null {
   return SETTING_DEFINITIONS[key as SettingKey] ?? null
+}
+
+export function resolveSettingYamlValue(
+  definition: SettingDefinition,
+  rawConfig: unknown,
+  baseConfig: Config,
+): SettingYamlValue {
+  if (!hasValueAtPath(rawConfig, definition.yamlPath)) {
+    return {
+      hasYamlValue: false,
+      yamlValue: null,
+    }
+  }
+
+  return {
+    hasYamlValue: true,
+    yamlValue: definition.read(baseConfig),
+  }
 }
 
 function parseNumberInput(
@@ -316,4 +360,24 @@ function buildDefaultObservability(config: Config): Config['observability'] {
     sessionLogs: config.observability?.sessionLogs ?? true,
     sessionLogRetention: config.observability?.sessionLogRetention ?? 7,
   }
+}
+
+function hasValueAtPath(
+  source: unknown,
+  path: readonly string[],
+): boolean {
+  let current: unknown = source
+
+  for (const segment of path) {
+    if (!isRecord(current) || !(segment in current)) {
+      return false
+    }
+    current = current[segment]
+  }
+
+  return true
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }

--- a/src/settings/runtime.ts
+++ b/src/settings/runtime.ts
@@ -15,10 +15,12 @@ export interface RuntimeSettingSnapshot {
   key: SettingKey
   label: string
   description: string
+  details: string
   type: SettingType
   min?: number
   max?: number
   step?: number
+  defaultValue: SettingValue
   baseValue: SettingValue
   overrideValue: SettingValue | null
   effectiveValue: SettingValue
@@ -62,6 +64,7 @@ export function listRuntimeSettings(
       key: definition.key,
       label: definition.label,
       description: definition.description,
+      details: definition.details,
       type: definition.type,
       ...(definition.type === 'number'
         ? {
@@ -70,6 +73,7 @@ export function listRuntimeSettings(
             ...(definition.step !== undefined ? { step: definition.step } : {}),
           }
         : {}),
+      defaultValue: definition.defaultValue,
       baseValue,
       overrideValue,
       effectiveValue,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,8 +17,10 @@ import { nowUtcIso } from '../utils/time.js'
 import {
   listRuntimeSettings,
   resolveConfigWithRuntimeSettings,
+  type RuntimeSettingSnapshot,
   RuntimeSettingInputError,
 } from '../settings/runtime.js'
+import { getSettingDefinition, resolveSettingYamlValue, type SettingValue } from '../settings/registry.js'
 
 export interface WebServerOptions {
   host: string
@@ -27,6 +29,7 @@ export interface WebServerOptions {
   frontendDistPath?: string
   snapshotIntervalMs?: number
   operationsEnabled?: boolean
+  rawConfig?: unknown
 }
 
 interface WsClientState {
@@ -51,7 +54,12 @@ interface DashboardSnapshot {
 
 interface SettingsSnapshot {
   generatedAt: string
-  settings: ReturnType<typeof listRuntimeSettings>
+  settings: SettingsSnapshotEntry[]
+}
+
+interface SettingsSnapshotEntry extends RuntimeSettingSnapshot {
+  hasYamlValue: boolean
+  yamlValue: SettingValue | null
 }
 
 type CommandSpec = string | string[]
@@ -236,7 +244,7 @@ export async function startWebServer(
           writeJson(res, 403, { error: 'Forbidden host' })
           return
         }
-        await handleApiRequest(req, res, requestUrl, deps, security, operationsEnabled)
+        await handleApiRequest(req, res, requestUrl, deps, security, operationsEnabled, options.rawConfig)
         return
       }
 
@@ -376,6 +384,7 @@ async function handleApiRequest(
   deps: MCPDependencies,
   security: WebSecurityContext,
   operationsEnabled: boolean,
+  rawConfig: unknown,
 ): Promise<void> {
   const method = req.method ?? 'GET'
   const { pathname, searchParams } = requestUrl
@@ -416,7 +425,7 @@ async function handleApiRequest(
   }
 
   if (method === 'GET' && pathname === '/api/settings') {
-    const snapshot = buildSettingsSnapshot(deps)
+    const snapshot = buildSettingsSnapshot(deps, rawConfig)
     writeJson(res, 200, snapshot)
     return
   }
@@ -1225,10 +1234,28 @@ function buildProjectsSnapshot(deps: MCPDependencies): ProjectsSnapshot {
   }
 }
 
-function buildSettingsSnapshot(deps: MCPDependencies): SettingsSnapshot {
+function buildSettingsSnapshot(deps: MCPDependencies, rawConfig: unknown): SettingsSnapshot {
+  const runtimeSettings = listRuntimeSettings(deps.config, deps.db)
+
   return {
     generatedAt: nowUtcIso(),
-    settings: listRuntimeSettings(deps.config, deps.db),
+    settings: runtimeSettings.map((setting) => {
+      const definition = getSettingDefinition(setting.key)
+      if (!definition) {
+        return {
+          ...setting,
+          hasYamlValue: false,
+          yamlValue: null,
+        }
+      }
+
+      const { hasYamlValue, yamlValue } = resolveSettingYamlValue(definition, rawConfig, deps.config)
+      return {
+        ...setting,
+        hasYamlValue,
+        yamlValue,
+      }
+    }),
   }
 }
 

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -243,6 +243,11 @@ describe('startWebServer', () => {
         host: '127.0.0.1',
         port: 0,
         frontendDistPath: frontendDir,
+        rawConfig: {
+          github: {
+            pollIntervalSeconds: 300,
+          },
+        },
       },
     )
 
@@ -256,11 +261,25 @@ describe('startWebServer', () => {
     const initial = await fetch(`${baseUrl}/api/settings`)
     expect(initial.status).toBe(200)
     const initialPayload = await initial.json() as {
-      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+      settings: Array<{
+        key: string
+        source: string
+        effectiveValue: number | boolean
+        defaultValue: number | boolean
+        hasYamlValue: boolean
+        yamlValue: number | boolean | null
+      }>
     }
     const pollBefore = initialPayload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
     expect(pollBefore?.source).toBe('base')
     expect(pollBefore?.effectiveValue).toBe(300)
+    expect(pollBefore?.defaultValue).toBe(300)
+    expect(pollBefore?.hasYamlValue).toBe(true)
+    expect(pollBefore?.yamlValue).toBe(300)
+
+    const maxReviewBefore = initialPayload.settings.find((setting) => setting.key === 'loop.maxReviewIterations')
+    expect(maxReviewBefore?.hasYamlValue).toBe(false)
+    expect(maxReviewBefore?.yamlValue).toBeNull()
 
     const setResponse = await fetch(`${baseUrl}/api/operations/settings/set`, {
       method: 'POST',
@@ -311,6 +330,54 @@ describe('startWebServer', () => {
         effectiveValue: 300,
         source: 'base',
       },
+    })
+  })
+
+  it('keeps yaml presence for schema-valid values outside runtime override bounds', async () => {
+    const config = makeMinimalConfig()
+    config.github.pollIntervalSeconds = 7200
+    deps.config = config as MCPDependencies['config']
+
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+        rawConfig: {
+          github: {
+            pollIntervalSeconds: 7200,
+          },
+        },
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    const response = await fetch(`${baseUrl}/api/settings`)
+    expect(response.status).toBe(200)
+    const payload = await response.json() as {
+      settings: Array<{
+        key: string
+        baseValue: number | boolean
+        effectiveValue: number | boolean
+        defaultValue: number | boolean
+        hasYamlValue: boolean
+        yamlValue: number | boolean | null
+      }>
+    }
+
+    const pollSetting = payload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
+    expect(pollSetting).toMatchObject({
+      baseValue: 7200,
+      effectiveValue: 7200,
+      defaultValue: 300,
+      hasYamlValue: true,
+      yamlValue: 7200,
     })
   })
 

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -1,5 +1,6 @@
-import { type ReactElement } from 'react'
+import { type ReactElement, useEffect, useMemo, useState } from 'react'
 import { ButtonWeb } from '../../../src/components/button/button.web.js'
+import { ModalWeb } from '../../../src/components/modal/modal.web.js'
 import type { RuntimeSettingSnapshot } from '../types/dashboard.js'
 
 interface SettingsPageProps {
@@ -23,115 +24,229 @@ export function SettingsPage({
   onApply,
   onClear,
 }: SettingsPageProps): ReactElement {
+  const [selectedSettingKey, setSelectedSettingKey] = useState<string | null>(null)
+  const [overwriteEnabled, setOverwriteEnabled] = useState<Record<string, boolean>>({})
+
+  const selectedSetting = useMemo(
+    () => settings.find((setting) => setting.key === selectedSettingKey) ?? null,
+    [selectedSettingKey, settings],
+  )
+  const selectedDraft = selectedSetting
+    ? (drafts[selectedSetting.key] ?? formatSettingValue(selectedSetting.effectiveValue))
+    : ''
+  const selectedOverwriteEnabled = selectedSetting
+    ? (overwriteEnabled[selectedSetting.key] ?? selectedSetting.overrideValue !== null)
+    : false
+  const selectedBusy = selectedSetting
+    ? isSettingBusy(activeOperation, selectedSetting.key)
+    : false
+
+  useEffect(() => {
+    setOverwriteEnabled(
+      Object.fromEntries(
+        settings.map((setting) => [setting.key, setting.overrideValue !== null]),
+      ),
+    )
+
+    if (selectedSettingKey && !settings.some((setting) => setting.key === selectedSettingKey)) {
+      setSelectedSettingKey(null)
+    }
+  }, [selectedSettingKey, settings])
+
   return (
     <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
-      <div className="card-body p-6 sm:p-8">
+      <div className="card-body p-5 sm:p-8">
         <h2 className="card-title text-2xl font-semibold capitalize text-base-content">settings</h2>
         <p className="max-w-3xl text-sm text-base-content/75">
           Runtime overrides are stored in SQLite and applied on top of YAML/default values.
         </p>
-        <p className="text-xs text-base-content/60">
-          Last refresh: {generatedAt ?? '-'}
-        </p>
+        <p className="text-xs text-base-content/60">Last refresh: {generatedAt ?? '-'}</p>
 
         {isLoading ? (
           <p className="text-sm text-base-content/70">Loading settings…</p>
         ) : settings.length === 0 ? (
           <p className="text-sm text-base-content/70">No curated settings available.</p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="table table-zebra table-sm">
-              <thead>
-                <tr>
-                  <th>Key</th>
-                  <th>Base</th>
-                  <th>Override</th>
-                  <th>Effective</th>
-                  <th>Value</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {settings.map((setting) => {
-                  const draft = drafts[setting.key] ?? formatSettingValue(setting.effectiveValue)
-                  const rowBusy = activeOperation === `setting:set:${setting.key}` || activeOperation === `setting:clear:${setting.key}`
+          <ul className="mt-2 grid gap-3">
+            {settings.map((setting) => (
+              <li key={setting.key}>
+                <button
+                  type="button"
+                  className="group w-full rounded-box border border-base-300/80 bg-base-100/60 p-4 text-left transition hover:border-info/40 hover:bg-base-100/85 focus:outline-none focus-visible:ring-2 focus-visible:ring-info/70"
+                  onClick={() => {
+                    setSelectedSettingKey(setting.key)
+                  }}
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold text-base-content">{setting.label}</span>
+                        <span
+                          className={`badge badge-xs ${setting.source === 'override' ? 'badge-info' : 'badge-ghost'}`}
+                        >
+                          {setting.source === 'override' ? 'overwritten' : 'default/yaml'}
+                        </span>
+                      </div>
+                      <p className="mt-1 break-all font-mono text-[11px] text-base-content/55">{setting.key}</p>
+                      <p className="mt-2 text-sm text-base-content/75">{setting.description}</p>
+                    </div>
 
-                  return (
-                    <tr key={setting.key}>
-                      <td>
-                        <div className="flex flex-col">
-                          <span className="font-mono text-xs">{setting.key}</span>
-                          <span className="text-xs text-base-content/60">{setting.label}</span>
-                        </div>
-                      </td>
-                      <td className="font-mono text-xs">{formatSettingValue(setting.baseValue)}</td>
-                      <td className="font-mono text-xs">
-                        {setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)}
-                      </td>
-                      <td className="font-mono text-xs">
+                    <div className="shrink-0 rounded-lg border border-base-300/80 bg-base-100/60 px-3 py-2 sm:min-w-[150px] sm:text-right">
+                      <p className="text-[11px] uppercase tracking-wide text-base-content/55">Applied</p>
+                      <p className="mt-1 font-mono text-sm font-semibold text-base-content">
                         {formatSettingValue(setting.effectiveValue)}
-                        <span className="ml-2 badge badge-ghost badge-xs">{setting.source}</span>
-                      </td>
-                      <td>
-                        {setting.type === 'boolean' ? (
-                          <select
-                            className="select select-bordered select-xs w-28"
-                            value={normalizeBooleanDraft(draft)}
-                            onChange={(event) => onDraftChange(setting.key, event.target.value)}
-                            disabled={rowBusy}
-                          >
-                            <option value="true">true</option>
-                            <option value="false">false</option>
-                          </select>
-                        ) : (
-                          <input
-                            className="input input-bordered input-xs w-32 font-mono"
-                            type="number"
-                            value={draft}
-                            min={setting.min}
-                            max={setting.max}
-                            step={setting.step}
-                            onChange={(event) => onDraftChange(setting.key, event.target.value)}
-                            disabled={rowBusy}
-                          />
-                        )}
-                      </td>
-                      <td>
-                        <div className="flex gap-2">
-                          <ButtonWeb
-                            type="button"
-                            tone="info"
-                            size="xs"
-                            onClick={() => onApply(setting.key)}
-                            disabled={rowBusy}
-                          >
-                            apply
-                          </ButtonWeb>
-                          <ButtonWeb
-                            type="button"
-                            tone="ghost"
-                            size="xs"
-                            onClick={() => onClear(setting.key)}
-                            disabled={rowBusy}
-                          >
-                            clear
-                          </ButtonWeb>
-                        </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
         )}
       </div>
+
+      <ModalWeb
+        open={selectedSetting !== null}
+        title={selectedSetting?.label}
+        description={selectedSetting?.details}
+        widthClassName="max-w-2xl"
+        onClose={() => {
+          setSelectedSettingKey(null)
+        }}
+        actions={selectedSetting ? (
+          <>
+            <ButtonWeb
+              type="button"
+              tone="ghost"
+              onClick={() => {
+                setSelectedSettingKey(null)
+              }}
+            >
+              close
+            </ButtonWeb>
+            <ButtonWeb
+              type="button"
+              tone={selectedOverwriteEnabled ? 'info' : 'neutral'}
+              onClick={() => {
+                if (!selectedSetting) {
+                  return
+                }
+                if (selectedOverwriteEnabled) {
+                  onApply(selectedSetting.key)
+                  return
+                }
+                onClear(selectedSetting.key)
+              }}
+              disabled={selectedBusy}
+            >
+              {selectedBusy
+                ? 'saving...'
+                : selectedOverwriteEnabled
+                  ? 'apply override'
+                  : 'clear override'}
+            </ButtonWeb>
+          </>
+        ) : null}
+      >
+        {selectedSetting ? (
+          <div className="mt-4 space-y-4">
+            <dl className="grid gap-2 rounded-box border border-base-300/70 bg-base-200/50 p-3 text-sm sm:grid-cols-2">
+              <SettingFact label="Night-orch default" value={formatSettingValue(selectedSetting.defaultValue)} />
+              <SettingFact
+                label="YAML value"
+                value={
+                  selectedSetting.hasYamlValue && selectedSetting.yamlValue !== null
+                    ? formatSettingValue(selectedSetting.yamlValue)
+                    : 'Not set'
+                }
+              />
+              <SettingFact label="Effective value" value={formatSettingValue(selectedSetting.effectiveValue)} />
+              <SettingFact
+                label="Current override"
+                value={
+                  selectedSetting.overrideValue === null
+                    ? 'None'
+                    : formatSettingValue(selectedSetting.overrideValue)
+                }
+              />
+            </dl>
+
+            <label className="flex items-center gap-3 rounded-box border border-base-300/70 bg-base-200/45 p-3">
+              <input
+                type="checkbox"
+                className="checkbox checkbox-sm checkbox-info"
+                checked={selectedOverwriteEnabled}
+                disabled={selectedBusy}
+                onChange={(event) => {
+                  setOverwriteEnabled((current) => ({
+                    ...current,
+                    [selectedSetting.key]: event.target.checked,
+                  }))
+                }}
+              />
+              <div>
+                <p className="text-sm font-medium text-base-content">Overwrite this value</p>
+                <p className="text-xs text-base-content/65">
+                  Disable to use YAML/default value. Enable to set a DB runtime override.
+                </p>
+              </div>
+            </label>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-base-content/60">
+                Override value
+              </p>
+              {selectedSetting.type === 'boolean' ? (
+                <select
+                  className="select select-bordered w-full max-w-xs font-mono"
+                  value={normalizeBooleanDraft(selectedDraft)}
+                  onChange={(event) => {
+                    onDraftChange(selectedSetting.key, event.target.value)
+                  }}
+                  disabled={!selectedOverwriteEnabled || selectedBusy}
+                >
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select>
+              ) : (
+                <input
+                  className="input input-bordered w-full max-w-xs font-mono"
+                  type="number"
+                  value={selectedDraft}
+                  min={selectedSetting.min}
+                  max={selectedSetting.max}
+                  step={selectedSetting.step}
+                  onChange={(event) => {
+                    onDraftChange(selectedSetting.key, event.target.value)
+                  }}
+                  disabled={!selectedOverwriteEnabled || selectedBusy}
+                />
+              )}
+            </div>
+          </div>
+        ) : null}
+      </ModalWeb>
     </section>
   )
 }
 
+function SettingFact({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div>
+      <dt className="text-[11px] uppercase tracking-wide text-base-content/55">{label}</dt>
+      <dd className="mt-1 font-mono text-sm text-base-content">{value}</dd>
+    </div>
+  )
+}
+
+function isSettingBusy(activeOperation: string | null, key: string): boolean {
+  return activeOperation === `setting:set:${key}` || activeOperation === `setting:clear:${key}`
+}
+
 function formatSettingValue(value: string | number | boolean): string {
-  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
   return String(value)
 }
 

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -212,10 +212,14 @@ export interface RuntimeSettingSnapshot {
   key: string
   label: string
   description: string
+  details: string
   type: RuntimeSettingType
   min?: number
   max?: number
   step?: number
+  defaultValue: number | boolean
+  hasYamlValue: boolean
+  yamlValue: number | boolean | null
   baseValue: number | boolean
   overrideValue: number | boolean | null
   effectiveValue: number | boolean


### PR DESCRIPTION
Closes #112

## Plan
**Objective:** Redesign the web settings page as a mobile-first list view with detail modals for viewing and overriding settings

1. Rewrite SettingsPage.tsx: Replace the table with a mobile-first list view. Each setting rendered as a compact card/row showing: setting label, key (font-mono), brief description, effective value, and an 'overridden' badge when source === 'override'. Use a responsive grid (1 col mobile, 2 cols on lg+). Each row is clickable to open the detail modal.
2. Add a setting detail modal inside SettingsPage.tsx using ModalWeb. The modal shows: (1) setting label as title, (2) full description, (3) a read-only section with night-orch default value (baseValue) and yaml/override value if present, (4) a DaisyUI toggle checkbox labeled 'Override' — when source is already 'override', the toggle starts checked, (5) an input field (number input with min/max/step for number type, select for boolean type) that is disabled when the override toggle is off, pre-filled with the current effective value, (6) modal actions: 'Save' button (calls onApply with draft value) enabled only when toggle is on and value differs, and a 'Clear override' button (calls onClear) shown only when an override exists.
3. Add local state management to SettingsPage for the modal: selectedSettingKey (string | null) to track which setting modal is open, a local overrideEnabled boolean toggle, and a local draft value. When a setting row is clicked, populate these from the setting's snapshot data. Remove the external drafts/onDraftChange props since draft state moves inside the modal.
4. Update App.tsx to simplify the SettingsPage props — remove drafts and onDraftChange since draft state now lives inside SettingsPage. The onApply callback signature changes to accept (key: string, value: string) so the modal can pass the draft value directly rather than relying on external draft state. Keep onClear as-is.

## Implementation
Addressed both review findings. YAML presence detection now reports `hasYamlValue` based on YAML-path existence and derives `yamlValue` from validated config (`definition.read(baseConfig)`), so schema-valid values outside runtime-override bounds (e.g. `pollIntervalSeconds: 7200`) are shown correctly. Added a regression test for that case. Removed double config parsing on web startup by introducing `loadConfigWithRaw()` and using its single parsed result for both validated config and raw YAML metadata. Existing settings UI/modal behavior from the prior iteration remains intact.

**Changed files:**
- `src/config/loader.ts`
- `src/cli/commands/web.ts`
- `src/settings/registry.ts`
- `src/web/server.ts`
- `test/web/server.test.ts`
- `src/settings/runtime.ts`
- `web/src/components/SettingsPage.tsx`
- `web/src/types/dashboard.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Both previously reported issues are resolved. YAML presence detection now checks path existence in raw YAML and derives value from validated config (`src/settings/registry.ts:247-263`), and web startup now parses config once via `loadConfigWithRaw` (`src/cli/commands/web.ts:37-46`, `src/config/loader.ts:31-65`). Regression coverage was added for schema-valid values outside runtime-override bounds (`test/web/server.test.ts:336-382`). Verification passed locally: `pnpm test` (1197 passed), `pnpm typecheck`, and `pnpm lint`.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex