### PR TITLE
[CHORE] Re-Implement cost calculation (night-orch / #126)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -230,6 +230,22 @@ whichever matches the scope of the situation:
 | Key | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `model` | `pay-per-use` or `subscription` | `pay-per-use` | `pay-per-use` enforces `security.maxDailyCostUsd`/`security.maxCostPerRunUsd`; `subscription` bypasses cost-limit blocking and treats USD as advisory while emphasizing token usage. |
+| `pricing` | object | unset | Optional model-aware pricing table. When unset, `pay-per-use` uses built-in defaults (input `$3/M`, output `$15/M`, fallback `$0.008/min`) and `subscription` defaults to `$0` USD estimates. |
+
+### `cost.pricing`
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `defaultModel` | string | `"default"` | Fallback key when a worker's `pricingModel`/`type` has no direct pricing entry. |
+| `models` | record | `{}` | Per-model pricing map keyed by model name. |
+
+### `cost.pricing.models.<model>`
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `inputUsdPerMillionTokens` | non-negative number | `3` | Prompt/input token price in USD per 1,000,000 tokens. |
+| `outputUsdPerMillionTokens` | non-negative number | `15` | Completion/output token price in USD per 1,000,000 tokens. |
+| `minuteUsd` | non-negative number | `0.008` | Time-based fallback price per minute when token counts are unavailable. |
 
 ## `workerProfiles`
 
@@ -250,6 +266,7 @@ workerProfiles:
 | Key | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `type` | string | yes | none | Adapter type. Built-in: `claude`, `codex`, `acp`. |
+| `pricingModel` | string | no | none | Optional model key used by `cost.pricing.models` for cost estimation. Falls back to `type` when omitted. |
 | `command` | string | yes | none | Binary to execute. |
 | `args` | string[] | no | `[]` | Base CLI args for every task invocation. |
 | `workerTimeoutSeconds` | positive number | no | `1800` | Base timeout before triage scaling. |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -467,15 +467,23 @@ blocking is skipped.
 ```yaml
 cost:
   model: pay-per-use   # or: subscription
+  # pricing:
+  #   defaultModel: claude-sonnet-4
+  #   models:
+  #     claude-sonnet-4:
+  #       inputUsdPerMillionTokens: 3
+  #       outputUsdPerMillionTokens: 15
+  #       minuteUsd: 0.008
 ```
 
 - `pay-per-use` keeps USD spend as the primary dashboard metric and enforces `security.maxCostPerRunUsd` + `security.maxDailyCostUsd`.
-- `subscription` keeps token usage as the primary dashboard metric, shows USD as an estimate, and bypasses `cost_limit` enforcement (override commands do not affect loop gating in this mode).
+- `subscription` keeps token usage as the primary dashboard metric, defaults USD estimates to `$0.00`, and bypasses `cost_limit` enforcement (override commands do not affect loop gating in this mode).
+- `cost.pricing.models` optionally enables model-aware USD estimation keyed by `workerProfiles.<name>.pricingModel` (or worker `type` when unset).
 
 ### Cost estimation
 
-- **Token-based** (preferred) — when the agent adapter reports token counts, cost is calculated from input/output token rates
-- **Time-based** (fallback) — when token counts aren't available, cost is estimated at $0.008/minute per agent call
+- **Token-based** (preferred) — when the agent adapter reports token counts, cost is calculated from per-model input/output token rates
+- **Time-based** (fallback) — when token counts aren't available, cost is estimated from each model's `minuteUsd`
 
 View costs/usage:
 - `night-orch status` — shows daily cost summary

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -57,10 +57,25 @@ security:
 
 cost:
   model: pay-per-use # or: subscription
+  # Optional: model-aware pricing overrides.
+  # If omitted, pay-per-use uses built-in defaults and subscription defaults
+  # USD estimation to 0.00.
+  # pricing:
+  #   defaultModel: claude-sonnet-4
+  #   models:
+  #     claude-sonnet-4:
+  #       inputUsdPerMillionTokens: 3
+  #       outputUsdPerMillionTokens: 15
+  #       minuteUsd: 0.008
+  #     gpt-5:
+  #       inputUsdPerMillionTokens: 1.25
+  #       outputUsdPerMillionTokens: 10
+  #       minuteUsd: 0.01
 
 workerProfiles:
   claude-default:
     type: claude
+    # pricingModel: claude-sonnet-4
     command: claude
     args:
       - -p
@@ -69,6 +84,7 @@ workerProfiles:
     env: {}
   codex-default:
     type: codex
+    # pricingModel: gpt-5
     command: codex
     args:
       - exec

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -46,6 +46,7 @@ const AppMentionSchema = z.object({
 
 const WorkerProfileSchema = z.object({
   type: z.string().min(1, 'Worker type must not be empty'),
+  pricingModel: z.string().min(1).optional(),
   command: z.string(),
   args: z.array(z.string()).default([]),
   workerTimeoutSeconds: z.number().positive().default(1800),
@@ -260,8 +261,20 @@ const SecuritySchema = z.object({
 
 const CostModelSchema = z.enum(['pay-per-use', 'subscription'])
 
+const CostPricingModelSchema = z.object({
+  inputUsdPerMillionTokens: z.number().nonnegative().default(3),
+  outputUsdPerMillionTokens: z.number().nonnegative().default(15),
+  minuteUsd: z.number().nonnegative().default(0.008),
+})
+
+const CostPricingSchema = z.object({
+  defaultModel: z.string().min(1).default('default'),
+  models: z.record(CostPricingModelSchema).default({}),
+})
+
 const CostSchema = z.object({
   model: CostModelSchema.default('pay-per-use'),
+  pricing: CostPricingSchema.optional(),
 })
 
 // --- Metrics schema ---

--- a/src/loop/engine.ts
+++ b/src/loop/engine.ts
@@ -8,6 +8,7 @@ import { commitChanges } from './commit.js'
 import { executeStep, type StepDependencies } from './step-executor.js'
 import { Checkpoint } from './checkpoint.js'
 import { CostTracker, describeBudgetBlock, costLimitRecoveryHint } from './cost.js'
+import { estimateWorkerCostUsd } from './pricing.js'
 import { logger } from '../utils/logger.js'
 import { utcIsoFromMs } from '../utils/time.js'
 import type Database from 'better-sqlite3'
@@ -106,7 +107,15 @@ export async function executeLoop(
 
     // Cost tracking for worker steps
     if (step.type === 'worker') {
-      ctx = applyEstimatedWorkerCost(ctx, costTracker, step.role, stepDurationMs, result.tokenUsage)
+      ctx = applyEstimatedWorkerCost(
+        ctx,
+        costTracker,
+        config.cost,
+        step.role,
+        result.pricingIdentity,
+        stepDurationMs,
+        result.tokenUsage,
+      )
       try { metrics?.observePhaseDuration(step.id, stepDurationMs / 1000) } catch { /* best-effort */ }
     }
     if (step.type === 'verify') {
@@ -355,35 +364,34 @@ function buildStepArtifacts(step: WorkflowStep, ctx: RunContext): Record<string,
 // Cost estimation
 // ---------------------------------------------------------------------------
 
-const ESTIMATED_USD_PER_INPUT_TOKEN = 0.000003
-const ESTIMATED_USD_PER_OUTPUT_TOKEN = 0.000015
-
-const ESTIMATED_USD_PER_MINUTE: Record<string, number> = {
-  planner: 0.008,
-  coder: 0.008,
-  reviewer: 0.008,
-}
-
 function applyEstimatedWorkerCost(
   ctx: RunContext,
   costTracker: CostTracker,
+  costConfig: Config['cost'] | undefined,
   role: string,
+  pricingIdentity: {
+    role: string
+    workerType: string
+    pricingModel: string | null
+  } | undefined,
   durationMs: number,
   tokenUsage?: { promptTokens: number; completionTokens: number },
 ): RunContext {
-  let estimatedCost: number
-  if (tokenUsage) {
-    estimatedCost = Number((
-      tokenUsage.promptTokens * ESTIMATED_USD_PER_INPUT_TOKEN +
-      tokenUsage.completionTokens * ESTIMATED_USD_PER_OUTPUT_TOKEN
-    ).toFixed(6))
-  } else {
-    const rate = ESTIMATED_USD_PER_MINUTE[role] ?? 0.008
-    estimatedCost = Number(((durationMs / 60_000) * rate).toFixed(6))
-  }
-  estimatedCost = Math.max(0, estimatedCost)
+  const estimatedCost = estimateWorkerCostUsd({
+    cost: costConfig,
+    identity: {
+      role,
+      workerType: pricingIdentity?.workerType,
+      pricingModel: pricingIdentity?.pricingModel,
+    },
+    durationMs,
+    tokenUsage,
+  })
+
   if (estimatedCost <= 0 && !tokenUsage) return ctx
   costTracker.recordCost(ctx.runId, estimatedCost, tokenUsage)
+  if (estimatedCost <= 0) return ctx
+
   return updateContext(ctx, {
     estimatedCostUsd: Number((ctx.estimatedCostUsd + estimatedCost).toFixed(6)),
   })

--- a/src/loop/pricing.ts
+++ b/src/loop/pricing.ts
@@ -1,0 +1,117 @@
+import type { Config } from '../config/schema.js'
+
+interface TokenUsageInput {
+  promptTokens: number
+  completionTokens: number
+}
+
+interface ModelPricing {
+  inputUsdPerMillionTokens: number
+  outputUsdPerMillionTokens: number
+  minuteUsd: number
+}
+
+interface CostConfigInput {
+  model: Config['cost']['model']
+  pricing?: Config['cost']['pricing']
+}
+
+export interface PricingIdentity {
+  role: string
+  workerType?: string | null
+  pricingModel?: string | null
+}
+
+export interface EstimateWorkerCostInput {
+  cost: CostConfigInput | undefined
+  identity: PricingIdentity
+  durationMs: number
+  tokenUsage?: TokenUsageInput
+}
+
+const DEFAULT_MODEL_KEY = 'default'
+
+const DEFAULT_PAY_PER_USE_PRICING: ModelPricing = {
+  inputUsdPerMillionTokens: 3,
+  outputUsdPerMillionTokens: 15,
+  minuteUsd: 0.008,
+}
+
+const DEFAULT_SUBSCRIPTION_PRICING: ModelPricing = {
+  inputUsdPerMillionTokens: 0,
+  outputUsdPerMillionTokens: 0,
+  minuteUsd: 0,
+}
+
+export function estimateWorkerCostUsd(input: EstimateWorkerCostInput): number {
+  const costModel = input.cost?.model === 'subscription' ? 'subscription' : 'pay-per-use'
+  const fallbackPricing = costModel === 'subscription'
+    ? DEFAULT_SUBSCRIPTION_PRICING
+    : DEFAULT_PAY_PER_USE_PRICING
+
+  const configuredPricing = input.cost?.pricing
+  const configuredDefaultModel = normalizeModelKey(configuredPricing?.defaultModel) ?? DEFAULT_MODEL_KEY
+  const modelKey = resolveModelKey(input.identity, configuredDefaultModel)
+  const modelPricing = resolveModelPricing(
+    configuredPricing?.models ?? {},
+    modelKey,
+    configuredDefaultModel,
+    fallbackPricing,
+  )
+
+  const usd = input.tokenUsage !== undefined
+    ? estimateTokenCost(input.tokenUsage, modelPricing)
+    : estimateDurationCost(input.durationMs, modelPricing.minuteUsd)
+
+  return Number(Math.max(0, usd).toFixed(6))
+}
+
+function resolveModelKey(identity: PricingIdentity, defaultModel: string): string {
+  return (
+    normalizeModelKey(identity.pricingModel) ??
+    normalizeModelKey(identity.workerType) ??
+    normalizeModelKey(identity.role) ??
+    defaultModel
+  )
+}
+
+function resolveModelPricing(
+  models: Record<string, ModelPricing>,
+  modelKey: string,
+  defaultModel: string,
+  fallback: ModelPricing,
+): ModelPricing {
+  const configured = models[modelKey] ?? models[defaultModel]
+  if (!configured) return fallback
+
+  return {
+    inputUsdPerMillionTokens: configured.inputUsdPerMillionTokens,
+    outputUsdPerMillionTokens: configured.outputUsdPerMillionTokens,
+    minuteUsd: configured.minuteUsd,
+  }
+}
+
+function estimateTokenCost(tokenUsage: TokenUsageInput, pricing: ModelPricing): number {
+  const promptTokens = normalizeTokenCount(tokenUsage.promptTokens)
+  const completionTokens = normalizeTokenCount(tokenUsage.completionTokens)
+  return (
+    (promptTokens / 1_000_000) * pricing.inputUsdPerMillionTokens +
+    (completionTokens / 1_000_000) * pricing.outputUsdPerMillionTokens
+  )
+}
+
+function estimateDurationCost(durationMs: number, minuteUsd: number): number {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return 0
+  return (durationMs / 60_000) * minuteUsd
+}
+
+function normalizeTokenCount(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0
+  return Math.floor(value)
+}
+
+function normalizeModelKey(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/src/loop/step-executor.ts
+++ b/src/loop/step-executor.ts
@@ -25,6 +25,11 @@ export interface StepDependencies {
 export interface StepResult {
   ctx: RunContext
   tokenUsage?: { promptTokens: number; completionTokens: number }
+  pricingIdentity?: {
+    role: string
+    workerType: string
+    pricingModel: string | null
+  }
   /** For decide steps: the decision action. */
   decision?: LoopDecision
 }
@@ -135,6 +140,11 @@ export async function executeWorkerStep(
   return {
     ctx: updatedCtx,
     tokenUsage: result.tokenUsage,
+    pricingIdentity: {
+      role: step.role,
+      workerType: profile.type,
+      pricingModel: profile.pricingModel ?? null,
+    },
   }
 }
 

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -20,6 +20,7 @@ export interface WorkerTaskInput {
 
 export interface WorkerProfileInput {
   type: string
+  pricingModel?: string
   command: string
   args: string[]
   workerTimeoutSeconds: number

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -164,6 +164,55 @@ describe('ConfigSchema', () => {
     }
   })
 
+  it('accepts configurable cost pricing by model', () => {
+    const raw = loadExampleConfig()
+    raw.cost = {
+      model: 'pay-per-use',
+      pricing: {
+        defaultModel: 'claude-sonnet-4',
+        models: {
+          'claude-sonnet-4': {
+            inputUsdPerMillionTokens: 3,
+            outputUsdPerMillionTokens: 15,
+            minuteUsd: 0.01,
+          },
+          'gpt-5': {
+            inputUsdPerMillionTokens: 1.25,
+            outputUsdPerMillionTokens: 10,
+            minuteUsd: 0.02,
+          },
+        },
+      },
+    }
+    raw.workerProfiles['claude-default'].pricingModel = 'claude-sonnet-4'
+
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cost.pricing?.defaultModel).toBe('claude-sonnet-4')
+      expect(result.data.cost.pricing?.models['gpt-5']?.outputUsdPerMillionTokens).toBe(10)
+      expect(result.data.workerProfiles['claude-default']?.pricingModel).toBe('claude-sonnet-4')
+    }
+  })
+
+  it('rejects negative configured pricing rates', () => {
+    const raw = loadExampleConfig()
+    raw.cost = {
+      model: 'pay-per-use',
+      pricing: {
+        models: {
+          default: {
+            inputUsdPerMillionTokens: -1,
+            outputUsdPerMillionTokens: 15,
+            minuteUsd: 0.008,
+          },
+        },
+      },
+    }
+    const result = ConfigSchema.safeParse(raw)
+    expect(result.success).toBe(false)
+  })
+
   it('excludes orch:needs-human by default', () => {
     const minimal = {
       version: 1,

--- a/test/loop/engine.test.ts
+++ b/test/loop/engine.test.ts
@@ -468,6 +468,7 @@ describe('executeLoop', () => {
 
     expect(result.terminalStatus).toBe('publish')
     expect(result.blockReason).toBeNull()
+    expect(result.estimatedCostUsd).toBe(250)
   })
 
   it('BLOCKED verdict → blocked', async () => {

--- a/test/loop/pricing.test.ts
+++ b/test/loop/pricing.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { estimateWorkerCostUsd } from '../../src/loop/pricing.js'
+
+describe('estimateWorkerCostUsd', () => {
+  it('uses default pay-per-use token rates', () => {
+    const usd = estimateWorkerCostUsd({
+      cost: { model: 'pay-per-use' },
+      identity: { role: 'planner', workerType: 'claude' },
+      durationMs: 1_000,
+      tokenUsage: { promptTokens: 1_000, completionTokens: 500 },
+    })
+
+    expect(usd).toBe(0.0105)
+  })
+
+  it('defaults to zero USD pricing in subscription mode', () => {
+    const usd = estimateWorkerCostUsd({
+      cost: { model: 'subscription' },
+      identity: { role: 'coder', workerType: 'codex' },
+      durationMs: 10_000,
+      tokenUsage: { promptTokens: 25_000, completionTokens: 8_000 },
+    })
+
+    expect(usd).toBe(0)
+  })
+
+  it('uses configured model pricing when pricingModel is set on worker profile', () => {
+    const usd = estimateWorkerCostUsd({
+      cost: {
+        model: 'subscription',
+        pricing: {
+          defaultModel: 'fallback',
+          models: {
+            fallback: { inputUsdPerMillionTokens: 0, outputUsdPerMillionTokens: 0, minuteUsd: 0 },
+            'gpt-5': { inputUsdPerMillionTokens: 10, outputUsdPerMillionTokens: 20, minuteUsd: 0.5 },
+          },
+        },
+      },
+      identity: { role: 'reviewer', workerType: 'codex', pricingModel: 'gpt-5' },
+      durationMs: 5_000,
+      tokenUsage: { promptTokens: 1_000, completionTokens: 1_000 },
+    })
+
+    expect(usd).toBe(0.03)
+  })
+
+  it('falls back to minute pricing when token usage is unavailable', () => {
+    const usd = estimateWorkerCostUsd({
+      cost: { model: 'pay-per-use' },
+      identity: { role: 'planner', workerType: 'claude' },
+      durationMs: 60_000,
+    })
+
+    expect(usd).toBe(0.008)
+  })
+
+  it('uses configured default model when worker model key has no direct pricing entry', () => {
+    const usd = estimateWorkerCostUsd({
+      cost: {
+        model: 'pay-per-use',
+        pricing: {
+          defaultModel: 'shared-default',
+          models: {
+            'shared-default': { inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 4, minuteUsd: 0.25 },
+          },
+        },
+      },
+      identity: { role: 'planner', workerType: 'unknown-model' },
+      durationMs: 120_000,
+    })
+
+    expect(usd).toBe(0.5)
+  })
+})

--- a/test/loop/step-executor.test.ts
+++ b/test/loop/step-executor.test.ts
@@ -321,6 +321,11 @@ describe('executeWorkerStep', () => {
     const result = await executeWorkerStep(makeCtx(), step, deps)
 
     expect(result.tokenUsage).toEqual({ promptTokens: 100, completionTokens: 50 })
+    expect(result.pricingIdentity).toEqual({
+      role: 'planner',
+      workerType: 'claude',
+      pricingModel: null,
+    })
   })
 
   it('throws when worker times out', async () => {


### PR DESCRIPTION
Closes #126

## Plan
**Objective:** Replace hardcoded cost estimation with a configurable, model-aware pricing module that defaults to zero USD for subscription mode

1. Create src/loop/pricing.ts — a pure pricing module that computes USD from token counts + config. Exports estimateWorkerCostUsd(tokenUsage, durationMs, role, costConfig) which returns 0 for subscription mode, uses configurable per-profile rates for pay-per-use, and falls back to configurable defaults. Contains a DEFAULT_RATES table with sensible per-profile-type rates.
2. Extend CostSchema in schema.ts to support optional rate overrides: add `rates` (record of profile-type → {inputTokenRate, outputTokenRate}), `defaultInputTokenRate`, `defaultOutputTokenRate`, and `durationFallbackRate` fields with sensible defaults. For subscription mode, all rate defaults are 0.
3. Refactor applyEstimatedWorkerCost in engine.ts to use the new pricing module instead of hardcoded constants. Remove ESTIMATED_USD_PER_INPUT_TOKEN, ESTIMATED_USD_PER_OUTPUT_TOKEN, ESTIMATED_USD_PER_MINUTE constants. Pass the cost config and worker profile type to the pricing function.
4. Write comprehensive tests for the pricing module: subscription mode returns $0, pay-per-use with default rates, custom per-profile rates, duration fallback, edge cases (zero tokens, missing config).
5. Update existing engine tests that reference cost estimation to work with the new pricing module approach. Update any test fixtures that construct cost config.
6. Update docs/CONFIGURATION.md cost section to document the new rate configuration fields, explain subscription vs pay-per-use behavior, and provide examples of custom rate overrides.

## Implementation
Replaced hardcoded loop cost constants with a configurable pricing estimator module (`src/loop/pricing.ts`) that is model-aware (`workerProfiles.*.pricingModel` -> `cost.pricing.models`) and defaults subscription-mode USD estimation to 0. Wired worker pricing identity through step execution into engine cost recording, extended config schema/types, updated docs and example config, and added tests for pricing behavior/config validation plus subscription-mode cost stability. Validation passed with `pnpm test`, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/config/schema.ts`
- `src/workers/types.ts`
- `src/loop/step-executor.ts`
- `src/loop/engine.ts`
- `src/loop/pricing.ts`
- `test/loop/pricing.test.ts`
- `test/loop/engine.test.ts`
- `test/loop/step-executor.test.ts`
- `test/config/schema.test.ts`
- `docs/CONFIGURATION.md`
- `docs/USAGE.md`
- `examples/config.example.yaml`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The pricing refactor is coherent and matches the implementation plan: cost estimation moved into a dedicated model-aware module, subscription defaults now produce $0 USD estimates unless pricing is explicitly configured, schema/docs/examples are aligned, and loop/runtime integration preserves existing pay-per-use behavior. I found no blocking correctness, security, or regression issues in the reviewed changes.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex