### PR TITLE
[CHORE] Web - improve header, layout and navigation (night-orch / #114)

### DIFF
--- a/test/web/dashboard-header.test.ts
+++ b/test/web/dashboard-header.test.ts
@@ -1,73 +1,161 @@
-import { describe, expect, it } from 'vitest'
+import { type ReactElement, type ReactNode, isValidElement } from 'react'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
 import { DashboardHeader } from '../../web/src/components/DashboardHeader.js'
 
 type DashboardHeaderProps = React.ComponentProps<typeof DashboardHeader>
 
-function renderHeader(overrides: Partial<DashboardHeaderProps>): string {
-  const props: DashboardHeaderProps = {
-    activePage: 'issues',
-    onPageChange: () => {},
+interface ButtonProps {
+  'aria-label'?: string
+  disabled?: boolean
+  onClick?: () => void
+}
+
+function buildProps(overrides: Partial<DashboardHeaderProps>): DashboardHeaderProps {
+  return {
     currentStateLabel: 'idle',
     currentStateToneClass: 'badge-ghost',
+    socketConnected: true,
+    lastRefreshAt: '2026-04-01T10:00:00.000Z',
+    pollIntervalSeconds: 30,
+    reposCount: 2,
+    activeRuns: 1,
+    runningRuns: 1,
+    queuedRuns: 0,
     frontendVersion: '1.2.3',
     frontendGitSha: '1111111111111111111111111111111111111111',
     backendVersion: '2.3.4',
     backendGitSha: '1111111111111111111111111111111111111111',
+    operationsEnabled: true,
+    activeOperation: null,
+    isRefreshing: false,
+    onRefresh: () => {},
+    onPoll: () => {},
+    onSync: () => {},
+    onGoToSettings: () => {},
     ...overrides,
   }
-
-  return renderToStaticMarkup(React.createElement(DashboardHeader, props))
 }
 
-function shaLineCount(output: string): number {
-  return (output.match(/ sha /g) ?? []).length
+function renderHeader(overrides: Partial<DashboardHeaderProps>): string {
+  return renderToStaticMarkup(React.createElement(DashboardHeader, buildProps(overrides)))
 }
 
-describe('DashboardHeader SHA rendering', () => {
-  it('renders one SHA line when frontend and backend SHAs are equal', () => {
-    const output = renderHeader({})
+function renderHeaderText(overrides: Partial<DashboardHeaderProps>): string {
+  const html = renderHeader(overrides)
+  return normalizeWhitespace(html.replace(/<[^>]*>/g, ' '))
+}
 
-    expect(output).toContain('frontend v1.2.3 · backend v2.3.4 · sha 111111111111')
-    expect(shaLineCount(output)).toBe(1)
-    expect(output).toContain('text-[10px]')
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function collectButtons(node: ReactNode, acc: ReactElement<ButtonProps>[] = []): ReactElement<ButtonProps>[] {
+  if (!isValidElement(node)) {
+    return acc
+  }
+
+  if (typeof node.type === 'function') {
+    const rendered = (node.type as (props: unknown) => ReactNode)(node.props)
+    collectButtons(rendered, acc)
+    return acc
+  }
+
+  if (node.type === 'button') {
+    acc.push(node as ReactElement<ButtonProps>)
+  }
+
+  React.Children.forEach((node.props as { children?: ReactNode }).children, (child) => {
+    collectButtons(child, acc)
   })
 
-  it('renders one SHA line when one SHA is a prefix of the other', () => {
-    const output = renderHeader({
-      frontendGitSha: 'abcdef0123456789abcdef0123456789abcdef01',
-      backendGitSha: 'abcdef0',
-    })
+  return acc
+}
 
-    expect(output).toContain('frontend v1.2.3 · backend v2.3.4 · sha abcdef012345')
-    expect(shaLineCount(output)).toBe(1)
-  })
+function findButton(buttons: ReactElement<ButtonProps>[], label: string): ReactElement<ButtonProps> {
+  const button = buttons.find((entry) => entry.props['aria-label'] === label)
+  expect(button).toBeDefined()
+  return button as ReactElement<ButtonProps>
+}
 
-  it('renders separate frontend/backend SHA lines when commits differ', () => {
-    const output = renderHeader({
+describe('DashboardHeader', () => {
+  it('renders compact git stats with shared and split sha formatting', () => {
+    const sameShaText = renderHeaderText({})
+    expect(sameShaText).toContain('git v2.3.4 · 111111111111')
+
+    const splitShaText = renderHeaderText({
       frontendGitSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       backendGitSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     })
-
-    expect(output).toContain('frontend v1.2.3 · sha aaaaaaaaaaaa')
-    expect(output).toContain('backend v2.3.4 · sha bbbbbbbbbbbb')
-    expect(shaLineCount(output)).toBe(2)
+    expect(splitShaText).toContain('git fe aaaaaaaaaaaa / be bbbbbbbbbbbb')
   })
 
-  it('handles unknown/null SHAs consistently', () => {
-    const knownVsUnknown = renderHeader({
+  it('keeps unknown SHA handling stable in compact stats', () => {
+    const knownVsUnknown = renderHeaderText({
       frontendGitSha: 'cccccccccccccccccccccccccccccccccccccccc',
       backendGitSha: null,
     })
-    expect(shaLineCount(knownVsUnknown)).toBe(2)
-    expect(knownVsUnknown).toContain('backend v2.3.4 · sha unknown')
+    expect(knownVsUnknown).toContain('git fe cccccccccccc / be unknown')
 
-    const unknownVsUnknown = renderHeader({
+    const unknownVsUnknown = renderHeaderText({
       frontendGitSha: 'unknown',
       backendGitSha: null,
     })
-    expect(shaLineCount(unknownVsUnknown)).toBe(1)
-    expect(unknownVsUnknown).toContain('frontend v1.2.3 · backend v2.3.4 · sha unknown')
+    expect(unknownVsUnknown).toContain('git v2.3.4 · unknown')
+  })
+
+  it('wires action buttons to callbacks with accessible labels', () => {
+    const onRefresh = vi.fn<() => void>()
+    const onPoll = vi.fn<() => void>()
+    const onSync = vi.fn<() => void>()
+    const onGoToSettings = vi.fn<() => void>()
+
+    const buttons = collectButtons(
+      React.createElement(
+        DashboardHeader,
+        buildProps({
+          onRefresh,
+          onPoll,
+          onSync,
+          onGoToSettings,
+        }),
+      ),
+    )
+
+    findButton(buttons, 'Refresh data').props.onClick?.()
+    findButton(buttons, 'Trigger poll').props.onClick?.()
+    findButton(buttons, 'Run sync').props.onClick?.()
+    findButton(buttons, 'Open settings').props.onClick?.()
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    expect(onPoll).toHaveBeenCalledTimes(1)
+    expect(onSync).toHaveBeenCalledTimes(1)
+    expect(onGoToSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows busy/disabled action states while operations are active', () => {
+    const html = renderHeader({
+      isRefreshing: true,
+      activeOperation: 'sync',
+    })
+    const spinnerCount = (html.match(/loading-spinner/g) ?? []).length
+    expect(spinnerCount).toBe(2)
+
+    const buttons = collectButtons(
+      React.createElement(
+        DashboardHeader,
+        buildProps({
+          isRefreshing: true,
+          activeOperation: 'sync',
+        }),
+      ),
+    )
+
+    expect(findButton(buttons, 'Refreshing...').props.disabled).toBe(true)
+    expect(findButton(buttons, 'Trigger poll').props.disabled).toBe(true)
+    expect(findButton(buttons, 'Syncing...').props.disabled).toBe(true)
+    expect(findButton(buttons, 'Open settings').props.disabled).toBe(false)
   })
 })

--- a/test/web/dashboard-navigation.test.ts
+++ b/test/web/dashboard-navigation.test.ts
@@ -1,0 +1,100 @@
+import { type ReactElement, type ReactNode, isValidElement } from 'react'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DashboardNavigation } from '../../web/src/components/DashboardNavigation.js'
+
+type DashboardNavigationProps = React.ComponentProps<typeof DashboardNavigation>
+
+interface ButtonProps {
+  'aria-current'?: string
+  'aria-label'?: string
+  onClick?: () => void
+}
+
+function buildProps(overrides: Partial<DashboardNavigationProps>): DashboardNavigationProps {
+  return {
+    activePage: 'issues',
+    onPageChange: () => {},
+    ...overrides,
+  }
+}
+
+function collectButtons(node: ReactNode, acc: ReactElement<ButtonProps>[] = []): ReactElement<ButtonProps>[] {
+  if (!isValidElement(node)) {
+    return acc
+  }
+
+  if (typeof node.type === 'function') {
+    const rendered = (node.type as (props: unknown) => ReactNode)(node.props)
+    collectButtons(rendered, acc)
+    return acc
+  }
+
+  if (node.type === 'button') {
+    acc.push(node as ReactElement<ButtonProps>)
+  }
+
+  React.Children.forEach((node.props as { children?: ReactNode }).children, (child) => {
+    collectButtons(child, acc)
+  })
+
+  return acc
+}
+
+function findButton(buttons: ReactElement<ButtonProps>[], label: string): ReactElement<ButtonProps> {
+  const button = buttons.find((entry) => entry.props['aria-label'] === label)
+  expect(button).toBeDefined()
+  return button as ReactElement<ButtonProps>
+}
+
+describe('DashboardNavigation', () => {
+  it('renders accessible labels for icon-only and dock buttons', () => {
+    const buttons = collectButtons(
+      React.createElement(
+        DashboardNavigation,
+        buildProps({
+          activePage: 'projects',
+        }),
+      ),
+    )
+
+    expect(buttons).toHaveLength(8)
+    expect(buttons.every((button) => typeof button.props['aria-label'] === 'string')).toBe(true)
+
+    const activeButtons = buttons.filter((button) => button.props['aria-current'] === 'page')
+    expect(activeButtons).toHaveLength(2)
+    expect(activeButtons.every((button) => button.props['aria-label'] === 'projects')).toBe(true)
+  })
+
+  it('invokes onPageChange when a navigation button is clicked', () => {
+    const onPageChange = vi.fn<(page: DashboardNavigationProps['activePage']) => void>()
+
+    const buttons = collectButtons(
+      React.createElement(
+        DashboardNavigation,
+        buildProps({
+          onPageChange,
+        }),
+      ),
+    )
+
+    findButton(buttons, 'stats').props.onClick?.()
+    expect(onPageChange).toHaveBeenCalledWith('stats')
+  })
+
+  it('retains desktop label visibility and mobile dock markup', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        DashboardNavigation,
+        buildProps({
+          activePage: 'issues',
+        }),
+      ),
+    )
+
+    expect(html).toContain('hidden text-sm capitalize lg:inline')
+    expect(html).toContain('dock-label')
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, type ReactElement, useCallback, useEffect, useMemo, use
 import { BudgetOverridesPanel } from './components/BudgetOverridesPanel.js'
 import { DashboardHeader } from './components/DashboardHeader.js'
 import { DashboardMetrics } from './components/DashboardMetrics.js'
+import { DashboardNavigation } from './components/DashboardNavigation.js'
 import { OperationsPanel } from './components/OperationsPanel.js'
 import { ProjectsPage } from './components/ProjectsPage.js'
 import { RunEventStream } from './components/RunEventStream.js'
@@ -10,7 +11,7 @@ import { RunsPanel } from './components/RunsPanel.js'
 import { SettingsPage } from './components/SettingsPage.js'
 import { StatsPage } from './components/StatsPage.js'
 import { UpdateProgressModal } from './components/UpdateProgressModal.js'
-import { extractMessage, formatTimestamp } from './lib/format.js'
+import { extractMessage } from './lib/format.js'
 import { STATUS_BADGE_TONE } from './lib/run-tone.js'
 import { asRunEventsPayload, mergeRunEvents } from './lib/run-events.js'
 import { confirmSelfUpdate } from './lib/update-confirmation.js'
@@ -59,6 +60,7 @@ export function App(): ReactElement {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
   const [activeOperation, setActiveOperation] = useState<string | null>(null)
+  const [isHeaderRefreshing, setIsHeaderRefreshing] = useState(false)
   const [webMutationToken, setWebMutationToken] = useState<string | null>(null)
   const [operationsEnabled, setOperationsEnabled] = useState(true)
   const [settingsDrafts, setSettingsDrafts] = useState<Record<string, string>>({})
@@ -447,6 +449,33 @@ export function App(): ReactElement {
     }
   }, [loadDashboard, loadSettings, operationsEnabled, webMutationToken])
 
+  const refreshDashboardData = useCallback(async () => {
+    try {
+      setIsHeaderRefreshing(true)
+      setErrorMessage(null)
+      await Promise.all([loadDashboard(), loadProjects(), loadSettings()])
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ type: 'refresh' }))
+      }
+    } catch (err) {
+      setErrorMessage((err as Error).message)
+    } finally {
+      setIsHeaderRefreshing(false)
+    }
+  }, [loadDashboard, loadProjects, loadSettings])
+
+  const triggerPoll = useCallback(() => {
+    void runOperation('poll', '/api/operations/poll', {}, 'Manual poll requested')
+  }, [runOperation])
+
+  const triggerSync = useCallback(() => {
+    void runOperation('sync', '/api/operations/sync', {}, 'Sync completed')
+  }, [runOperation])
+
+  const triggerCleanup = useCallback(() => {
+    void runOperation('cleanup', '/api/operations/cleanup', {}, 'Cleanup completed')
+  }, [runOperation])
+
   const submitUpdate = useCallback(async () => {
     if (!confirmSelfUpdate((message) => window.confirm(message))) {
       return
@@ -668,17 +697,33 @@ export function App(): ReactElement {
   return (
     <main data-theme="black" className="min-h-screen bg-orch-admin">
       <DashboardHeader
-        activePage={activePage}
-        onPageChange={setActivePage}
         currentStateLabel={currentState.label}
         currentStateToneClass={currentState.toneClass}
+        socketConnected={socketConnected}
+        lastRefreshAt={snapshot?.generatedAt ?? null}
+        pollIntervalSeconds={snapshot?.config.pollIntervalSeconds ?? null}
+        reposCount={repos.length}
+        activeRuns={snapshot?.status.activeRuns ?? 0}
+        runningRuns={runningRuns}
+        queuedRuns={queuedRuns}
         frontendVersion={FRONTEND_BUILD_VERSION}
         frontendGitSha={FRONTEND_BUILD_GIT_SHA}
         backendVersion={snapshot?.build?.version ?? 'unknown'}
         backendGitSha={snapshot?.build?.gitSha ?? null}
+        operationsEnabled={operationsEnabled}
+        activeOperation={activeOperation}
+        isRefreshing={isHeaderRefreshing}
+        onRefresh={() => {
+          void refreshDashboardData()
+        }}
+        onPoll={triggerPoll}
+        onSync={triggerSync}
+        onGoToSettings={() => {
+          setActivePage('settings')
+        }}
       />
 
-      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-24 pt-5 sm:px-6 md:pb-6 lg:px-8">
         {errorMessage && (
           <div className="alert alert-error shadow-sm">
             <span>{errorMessage}</span>
@@ -690,166 +735,157 @@ export function App(): ReactElement {
           </div>
         )}
 
-        <section className="rounded-box border border-base-300/60 bg-base-200/50 px-4 py-2 text-xs text-base-content/75 shadow-panel backdrop-blur">
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
-            <span>Poll interval {snapshot?.config.pollIntervalSeconds ?? '-'}s</span>
-            <span>Last refresh {snapshot?.generatedAt ? formatTimestamp(snapshot.generatedAt) : '--'}</span>
-            <span>Stream {socketConnected ? 'online' : 'reconnecting'}</span>
-            <span>Repos {repos.length}</span>
-          </div>
-        </section>
+        <div className="grid gap-5 md:grid-cols-[auto_minmax(0,1fr)] md:items-start">
+          <DashboardNavigation activePage={activePage} onPageChange={setActivePage} />
 
-        {activePage === 'issues' && (
-          <div className="flex flex-col gap-5">
-            <DashboardMetrics snapshot={snapshot} />
+          <div className="flex min-w-0 flex-col gap-5">
+            {activePage === 'issues' && (
+              <div className="flex flex-col gap-5">
+                <DashboardMetrics snapshot={snapshot} />
 
-            <section className="grid gap-5 xl:grid-cols-[1.65fr_1fr]">
-              <RunsPanel
-                isLoading={isLoading}
-                repos={repos}
-                selectedRepo={selectedRepo}
-                onSelectedRepoChange={setSelectedRepo}
-                filteredRuns={filteredRuns}
-                selectedRunId={selectedRunId}
-                onSelectedRunChange={setSelectedRunId}
-                statusTone={STATUS_BADGE_TONE}
+                <section className="grid gap-5 xl:grid-cols-[1.65fr_1fr]">
+                  <RunsPanel
+                    isLoading={isLoading}
+                    repos={repos}
+                    selectedRepo={selectedRepo}
+                    onSelectedRepoChange={setSelectedRepo}
+                    filteredRuns={filteredRuns}
+                    selectedRunId={selectedRunId}
+                    onSelectedRunChange={setSelectedRunId}
+                    statusTone={STATUS_BADGE_TONE}
+                  />
+
+                  <OperationsPanel
+                    operationsEnabled={operationsEnabled}
+                    activeOperation={activeOperation}
+                    updateStatus={updateStatus}
+                    repos={repos}
+                    retryForm={{
+                      repo: retryRepo,
+                      issueNumber: retryIssueNumber,
+                      resetPlan: retryResetPlan,
+                      fresh: retryFresh,
+                    }}
+                    rebaseForm={{
+                      repo: rebaseRepo,
+                      issueNumber: rebaseIssueNumber,
+                    }}
+                    continueForm={{
+                      repo: continueRepo,
+                      issueNumber: continueIssueNumber,
+                    }}
+                    deleteEntryForm={{
+                      repo: deleteRepo,
+                      issueNumber: deleteIssueNumber,
+                      force: deleteForce,
+                    }}
+                    labelsInitForm={{
+                      repo: labelsInitRepo,
+                    }}
+                    onRetryFormChange={(patch) => {
+                      if (patch.repo !== undefined) setRetryRepo(patch.repo)
+                      if (patch.issueNumber !== undefined) setRetryIssueNumber(patch.issueNumber)
+                      if (patch.resetPlan !== undefined) setRetryResetPlan(patch.resetPlan)
+                      if (patch.fresh !== undefined) setRetryFresh(patch.fresh)
+                    }}
+                    onRebaseFormChange={(patch) => {
+                      if (patch.repo !== undefined) setRebaseRepo(patch.repo)
+                      if (patch.issueNumber !== undefined) setRebaseIssueNumber(patch.issueNumber)
+                    }}
+                    onContinueFormChange={(patch) => {
+                      if (patch.repo !== undefined) setContinueRepo(patch.repo)
+                      if (patch.issueNumber !== undefined) setContinueIssueNumber(patch.issueNumber)
+                    }}
+                    onDeleteEntryFormChange={(patch) => {
+                      if (patch.repo !== undefined) setDeleteRepo(patch.repo)
+                      if (patch.issueNumber !== undefined) setDeleteIssueNumber(patch.issueNumber)
+                      if (patch.force !== undefined) setDeleteForce(patch.force)
+                    }}
+                    onLabelsInitFormChange={(patch) => {
+                      if (patch.repo !== undefined) setLabelsInitRepo(patch.repo)
+                    }}
+                    onPoll={triggerPoll}
+                    onSync={triggerSync}
+                    onCleanup={triggerCleanup}
+                    onLabelsInitSubmit={(event) => {
+                      void submitLabelsInit(event)
+                    }}
+                    onRetrySubmit={(event) => {
+                      void submitRetry(event)
+                    }}
+                    onRebaseSubmit={(event) => {
+                      void submitRebase(event)
+                    }}
+                    onContinueSubmit={(event) => {
+                      void submitContinue(event)
+                    }}
+                    onDeleteEntrySubmit={(event) => {
+                      void submitDeleteEntry(event)
+                    }}
+                    onUpdate={() => {
+                      void submitUpdate()
+                    }}
+                  />
+                </section>
+
+                <RunEventStream selectedRunId={selectedRunId} selectedRun={selectedRun} runEvents={runEvents} />
+              </div>
+            )}
+
+            {activePage === 'stats' && <StatsPage snapshot={snapshot} socketConnected={socketConnected} />}
+
+            {activePage === 'projects' && (
+              <ProjectsPage
+                snapshot={projectsSnapshot}
+                isLoading={isProjectsLoading}
+                selectedRepo={selectedProjectRepo}
+                onSelectedRepoChange={setSelectedProjectRepo}
               />
+            )}
 
-              <OperationsPanel
-                operationsEnabled={operationsEnabled}
-                activeOperation={activeOperation}
-                updateStatus={updateStatus}
-                repos={repos}
-                retryForm={{
-                  repo: retryRepo,
-                  issueNumber: retryIssueNumber,
-                  resetPlan: retryResetPlan,
-                  fresh: retryFresh,
-                }}
-                rebaseForm={{
-                  repo: rebaseRepo,
-                  issueNumber: rebaseIssueNumber,
-                }}
-                continueForm={{
-                  repo: continueRepo,
-                  issueNumber: continueIssueNumber,
-                }}
-                deleteEntryForm={{
-                  repo: deleteRepo,
-                  issueNumber: deleteIssueNumber,
-                  force: deleteForce,
-                }}
-                labelsInitForm={{
-                  repo: labelsInitRepo,
-                }}
-                onRetryFormChange={(patch) => {
-                  if (patch.repo !== undefined) setRetryRepo(patch.repo)
-                  if (patch.issueNumber !== undefined) setRetryIssueNumber(patch.issueNumber)
-                  if (patch.resetPlan !== undefined) setRetryResetPlan(patch.resetPlan)
-                  if (patch.fresh !== undefined) setRetryFresh(patch.fresh)
-                }}
-                onRebaseFormChange={(patch) => {
-                  if (patch.repo !== undefined) setRebaseRepo(patch.repo)
-                  if (patch.issueNumber !== undefined) setRebaseIssueNumber(patch.issueNumber)
-                }}
-                onContinueFormChange={(patch) => {
-                  if (patch.repo !== undefined) setContinueRepo(patch.repo)
-                  if (patch.issueNumber !== undefined) setContinueIssueNumber(patch.issueNumber)
-                }}
-                onDeleteEntryFormChange={(patch) => {
-                  if (patch.repo !== undefined) setDeleteRepo(patch.repo)
-                  if (patch.issueNumber !== undefined) setDeleteIssueNumber(patch.issueNumber)
-                  if (patch.force !== undefined) setDeleteForce(patch.force)
-                }}
-                onLabelsInitFormChange={(patch) => {
-                  if (patch.repo !== undefined) setLabelsInitRepo(patch.repo)
-                }}
-                onPoll={() => {
-                  void runOperation('poll', '/api/operations/poll', {}, 'Manual poll requested')
-                }}
-                onSync={() => {
-                  void runOperation('sync', '/api/operations/sync', {}, 'Sync completed')
-                }}
-                onCleanup={() => {
-                  void runOperation('cleanup', '/api/operations/cleanup', {}, 'Cleanup completed')
-                }}
-                onLabelsInitSubmit={(event) => {
-                  void submitLabelsInit(event)
-                }}
-                onRetrySubmit={(event) => {
-                  void submitRetry(event)
-                }}
-                onRebaseSubmit={(event) => {
-                  void submitRebase(event)
-                }}
-                onContinueSubmit={(event) => {
-                  void submitContinue(event)
-                }}
-                onDeleteEntrySubmit={(event) => {
-                  void submitDeleteEntry(event)
-                }}
-                onUpdate={() => {
-                  void submitUpdate()
-                }}
-              />
-            </section>
-
-            <RunEventStream selectedRunId={selectedRunId} selectedRun={selectedRun} runEvents={runEvents} />
+            {activePage === 'settings' && (
+              <div className="flex flex-col gap-5">
+                <BudgetOverridesPanel
+                  baseDailyBudgetUsd={snapshot?.cost.dailyBudgetUsd ?? 0}
+                  dailyBudgetOverrideUsd={snapshot?.cost.dailyBudgetOverrideUsd ?? null}
+                  effectiveDailyBudgetUsd={snapshot?.cost.effectiveDailyBudgetUsd ?? snapshot?.cost.dailyBudgetUsd ?? 0}
+                  todayCostUsd={snapshot?.status.dailyCostUsd ?? 0}
+                  activeOperation={activeOperation}
+                  dailyDraft={dailyOverrideDraft}
+                  onDailyDraftChange={setDailyOverrideDraft}
+                  onDailySubmit={(event) => { void submitDailyCostOverride(event) }}
+                  onDailyClear={() => { void clearDailyCostOverride() }}
+                  issueDraft={costOverrideDraft}
+                  repos={repos}
+                  onIssueDraftChange={(patch) => {
+                    setCostOverrideDraft((current) => ({ ...current, ...patch }))
+                  }}
+                  onIssueSubmit={(event) => { void submitCostOverride(event) }}
+                  onIssueClear={() => { void clearCostOverride() }}
+                />
+                <SettingsPage
+                  settings={settingsSnapshot?.settings ?? []}
+                  generatedAt={settingsSnapshot?.generatedAt ?? null}
+                  isLoading={isSettingsLoading}
+                  activeOperation={activeOperation}
+                  drafts={settingsDrafts}
+                  onDraftChange={(key, value) => {
+                    setSettingsDrafts((current) => ({
+                      ...current,
+                      [key]: value,
+                    }))
+                  }}
+                  onApply={(key) => {
+                    void applySetting(key)
+                  }}
+                  onClear={(key) => {
+                    void clearSetting(key)
+                  }}
+                />
+              </div>
+            )}
           </div>
-        )}
-
-        {activePage === 'stats' && <StatsPage snapshot={snapshot} socketConnected={socketConnected} />}
-
-        {activePage === 'projects' && (
-          <ProjectsPage
-            snapshot={projectsSnapshot}
-            isLoading={isProjectsLoading}
-            selectedRepo={selectedProjectRepo}
-            onSelectedRepoChange={setSelectedProjectRepo}
-          />
-        )}
-
-        {activePage === 'settings' && (
-          <div className="flex flex-col gap-5">
-            <BudgetOverridesPanel
-              baseDailyBudgetUsd={snapshot?.cost.dailyBudgetUsd ?? 0}
-              dailyBudgetOverrideUsd={snapshot?.cost.dailyBudgetOverrideUsd ?? null}
-              effectiveDailyBudgetUsd={snapshot?.cost.effectiveDailyBudgetUsd ?? snapshot?.cost.dailyBudgetUsd ?? 0}
-              todayCostUsd={snapshot?.status.dailyCostUsd ?? 0}
-              activeOperation={activeOperation}
-              dailyDraft={dailyOverrideDraft}
-              onDailyDraftChange={setDailyOverrideDraft}
-              onDailySubmit={(event) => { void submitDailyCostOverride(event) }}
-              onDailyClear={() => { void clearDailyCostOverride() }}
-              issueDraft={costOverrideDraft}
-              repos={repos}
-              onIssueDraftChange={(patch) => {
-                setCostOverrideDraft((current) => ({ ...current, ...patch }))
-              }}
-              onIssueSubmit={(event) => { void submitCostOverride(event) }}
-              onIssueClear={() => { void clearCostOverride() }}
-            />
-            <SettingsPage
-              settings={settingsSnapshot?.settings ?? []}
-              generatedAt={settingsSnapshot?.generatedAt ?? null}
-              isLoading={isSettingsLoading}
-              activeOperation={activeOperation}
-              drafts={settingsDrafts}
-              onDraftChange={(key, value) => {
-                setSettingsDrafts((current) => ({
-                  ...current,
-                  [key]: value,
-                }))
-              }}
-              onApply={(key) => {
-                void applySetting(key)
-              }}
-              onClear={(key) => {
-                void clearSetting(key)
-              }}
-            />
-          </div>
-        )}
+        </div>
       </div>
 
       {updateInProgress && updateStatus && <UpdateProgressModal status={updateStatus} />}

--- a/web/src/components/DashboardHeader.tsx
+++ b/web/src/components/DashboardHeader.tsx
@@ -1,25 +1,27 @@
 import { type ReactElement } from 'react'
-import { ButtonWeb } from '../../../src/components/button/button.web.js'
-
-import { type DashboardPage } from '../types/dashboard.js'
 
 interface DashboardHeaderProps {
-  activePage: DashboardPage
-  onPageChange: (page: DashboardPage) => void
   currentStateLabel: string
   currentStateToneClass: string
+  socketConnected: boolean
+  lastRefreshAt: string | null
+  pollIntervalSeconds: number | null
+  reposCount: number
+  activeRuns: number
+  runningRuns: number
+  queuedRuns: number
   frontendVersion: string
   frontendGitSha: string
   backendVersion: string
   backendGitSha: string | null
+  operationsEnabled: boolean
+  activeOperation: string | null
+  isRefreshing: boolean
+  onRefresh: () => void
+  onPoll: () => void
+  onSync: () => void
+  onGoToSettings: () => void
 }
-
-const PAGES: Array<{ id: DashboardPage, label: string }> = [
-  { id: 'issues', label: 'issues' },
-  { id: 'stats', label: 'stats' },
-  { id: 'projects', label: 'projects' },
-  { id: 'settings', label: 'settings' },
-]
 
 function normalizeShaForCompare(sha: string | null): string {
   const normalized = (sha ?? 'unknown').trim().toLowerCase()
@@ -48,63 +50,211 @@ function shortSha(sha: string | null): string {
 }
 
 export function DashboardHeader({
-  activePage,
-  onPageChange,
   currentStateLabel,
   currentStateToneClass,
+  socketConnected,
+  lastRefreshAt,
+  pollIntervalSeconds,
+  reposCount,
+  activeRuns,
+  runningRuns,
+  queuedRuns,
   frontendVersion,
   frontendGitSha,
   backendVersion,
   backendGitSha,
+  operationsEnabled,
+  activeOperation,
+  isRefreshing,
+  onRefresh,
+  onPoll,
+  onSync,
+  onGoToSettings,
 }: DashboardHeaderProps): ReactElement {
   const frontendShortSha = shortSha(frontendGitSha)
   const backendShortSha = shortSha(backendGitSha)
   const shasMatch = shasRepresentSameCommit(frontendGitSha, backendGitSha)
+  const mutationBusy = activeOperation !== null
+  const canRunMutations = operationsEnabled && !mutationBusy
+  const lastRefreshLabel = formatLastRefresh(lastRefreshAt)
+  const buildLabel = shasMatch
+    ? `v${backendVersion} · ${backendShortSha}`
+    : `fe ${frontendShortSha} / be ${backendShortSha}`
 
   return (
-    <header className="sticky top-0 z-40 border-b border-base-300/60 bg-base-300/85 backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-base-300/60 bg-base-300/88 backdrop-blur">
       <div className="mx-auto w-full max-w-[1500px] px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between gap-3 py-3">
-          <div className="flex flex-col">
-            <p className="text-lg font-semibold tracking-wide text-base-content sm:text-xl">night-orch</p>
-            {shasMatch ? (
-              <p className="text-[10px] font-mono text-base-content/60">
-                frontend v{frontendVersion} · backend v{backendVersion} · sha {frontendShortSha}
-              </p>
-            ) : (
-              <>
-                <p className="text-[10px] font-mono text-base-content/70">frontend v{frontendVersion} · sha {frontendShortSha}</p>
-                <p className="text-[10px] font-mono text-base-content/50">backend v{backendVersion} · sha {backendShortSha}</p>
-              </>
-            )}
+        <div className="flex flex-col gap-3 py-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <p className="text-lg font-semibold tracking-wide text-base-content sm:text-xl">night-orch</p>
+              <span className="text-[11px] font-mono text-base-content/70">web v{frontendVersion} · api v{backendVersion}</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-base-content/75">
+              <span className="text-[10px] uppercase tracking-[0.22em] text-base-content/65">State</span>
+              <span className={`badge badge-sm capitalize ${currentStateToneClass}`}>{currentStateLabel}</span>
+              <span className={socketConnected ? 'text-success' : 'text-warning'}>
+                {socketConnected ? 'stream online' : 'stream reconnecting'}
+              </span>
+              <span>Last refresh {lastRefreshLabel}</span>
+              <span>Poll {pollIntervalSeconds ?? '--'}s</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-[11px]">
+              <StatPill label="active" value={activeRuns} />
+              <StatPill label="running" value={runningRuns} />
+              <StatPill label="queued" value={queuedRuns} />
+              <StatPill label="repos" value={reposCount} />
+              <StatPill label="git" value={buildLabel} monospace />
+            </div>
           </div>
-          <div className="flex flex-col items-end gap-1">
-            <span className="text-[10px] uppercase tracking-[0.22em] text-base-content/65">Current State</span>
-            <span className={`badge badge-sm capitalize ${currentStateToneClass}`}>{currentStateLabel}</span>
-          </div>
-        </div>
 
-        <div className="-mx-1 overflow-x-auto pb-3">
-          <nav className="flex min-w-max gap-2 px-1" aria-label="Dashboard pages">
-            {PAGES.map((page) => (
-              <ButtonWeb
-                key={page.id}
-                type="button"
-                onClick={() => onPageChange(page.id)}
-                tone={activePage === page.id ? 'info' : 'ghost'}
-                size="sm"
-                className={`rounded-full px-4 font-medium capitalize ${
-                  activePage === page.id
-                    ? 'text-info-content'
-                    : 'border border-base-100/40 bg-base-100/35 hover:bg-base-100/55'
-                }`}
-              >
-                {page.label}
-              </ButtonWeb>
-            ))}
-          </nav>
+          <div className="flex items-center gap-2 self-end lg:self-start">
+            <ActionIconButton
+              label={isRefreshing ? 'Refreshing...' : 'Refresh data'}
+              onClick={onRefresh}
+              disabled={isRefreshing}
+              busy={isRefreshing}
+            >
+              <RefreshIcon />
+            </ActionIconButton>
+            <ActionIconButton
+              label={activeOperation === 'poll' ? 'Polling...' : 'Trigger poll'}
+              onClick={onPoll}
+              disabled={!canRunMutations}
+              busy={activeOperation === 'poll'}
+            >
+              <BoltIcon />
+            </ActionIconButton>
+            <ActionIconButton
+              label={activeOperation === 'sync' ? 'Syncing...' : 'Run sync'}
+              onClick={onSync}
+              disabled={!canRunMutations}
+              busy={activeOperation === 'sync'}
+            >
+              <SyncIcon />
+            </ActionIconButton>
+            <ActionIconButton label="Open settings" onClick={onGoToSettings}>
+              <SettingsIcon />
+            </ActionIconButton>
+          </div>
         </div>
       </div>
     </header>
+  )
+}
+
+function formatLastRefresh(value: string | null): string {
+  if (!value) return '--'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleTimeString()
+}
+
+function StatPill({
+  label,
+  value,
+  monospace = false,
+}: {
+  label: string
+  value: number | string
+  monospace?: boolean
+}): ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-base-100/45 bg-base-100/35 px-2 py-1">
+      <span className="uppercase tracking-[0.18em] text-base-content/65">{label}</span>
+      <span className={monospace ? 'font-mono text-base-content' : 'font-semibold text-base-content'}>
+        {value}
+      </span>
+    </span>
+  )
+}
+
+function ActionIconButton({
+  label,
+  onClick,
+  disabled = false,
+  busy = false,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  busy?: boolean
+  children: ReactElement
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      className="btn btn-ghost btn-sm btn-circle border border-base-100/45 bg-base-100/30 hover:bg-base-100/50"
+      onClick={onClick}
+      disabled={disabled}
+      title={label}
+      aria-label={label}
+    >
+      {busy ? <span className="loading loading-spinner loading-xs" aria-hidden="true" /> : children}
+    </button>
+  )
+}
+
+function svgIcon(children: ReactElement): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-4"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+function RefreshIcon(): ReactElement {
+  return svgIcon(
+    <>
+      <path d="M20 11a8 8 0 0 0-13.8-5.4" />
+      <path d="M4 4v4h4" />
+      <path d="M4 13a8 8 0 0 0 13.8 5.4" />
+      <path d="M20 20v-4h-4" />
+    </>,
+  )
+}
+
+function BoltIcon(): ReactElement {
+  return svgIcon(
+    <>
+      <path d="m13 2-8 12h6l-1 8 8-12h-6z" />
+    </>,
+  )
+}
+
+function SyncIcon(): ReactElement {
+  return svgIcon(
+    <>
+      <path d="M3.5 12a8.5 8.5 0 0 1 14.9-5.7" />
+      <path d="M18.5 6.2v4.3h-4.3" />
+      <path d="M20.5 12a8.5 8.5 0 0 1-14.9 5.7" />
+      <path d="M5.5 17.8v-4.3h4.3" />
+    </>,
+  )
+}
+
+function SettingsIcon(): ReactElement {
+  return svgIcon(
+    <>
+      <circle cx="12" cy="12" r="2.75" />
+      <path d="M12 4.2v1.6" />
+      <path d="M12 18.2v1.6" />
+      <path d="m5.9 5.9 1.15 1.15" />
+      <path d="m16.95 16.95 1.15 1.15" />
+      <path d="M4.2 12h1.6" />
+      <path d="M18.2 12h1.6" />
+      <path d="m5.9 18.1 1.15-1.15" />
+      <path d="m16.95 7.05 1.15-1.15" />
+    </>,
   )
 }

--- a/web/src/components/DashboardNavigation.tsx
+++ b/web/src/components/DashboardNavigation.tsx
@@ -1,0 +1,160 @@
+import { type ReactElement } from 'react'
+
+import { type DashboardPage } from '../types/dashboard.js'
+
+interface DashboardNavigationProps {
+  activePage: DashboardPage
+  onPageChange: (page: DashboardPage) => void
+}
+
+interface IconProps {
+  className?: string
+}
+
+interface PageDefinition {
+  id: DashboardPage
+  label: string
+  shortLabel: string
+  Icon: (props: IconProps) => ReactElement
+}
+
+const PAGES: PageDefinition[] = [
+  { id: 'issues', label: 'issues', shortLabel: 'issues', Icon: IssuesIcon },
+  { id: 'stats', label: 'stats', shortLabel: 'stats', Icon: StatsIcon },
+  { id: 'projects', label: 'projects', shortLabel: 'projects', Icon: ProjectsIcon },
+  { id: 'settings', label: 'settings', shortLabel: 'settings', Icon: SettingsIcon },
+]
+
+export function DashboardNavigation({ activePage, onPageChange }: DashboardNavigationProps): ReactElement {
+  return (
+    <>
+      <aside className="hidden md:block">
+        <nav
+          className="sticky top-28 flex w-16 flex-col gap-1 rounded-box border border-base-300/70 bg-base-200/65 p-1.5 shadow-panel backdrop-blur lg:w-52"
+          aria-label="Dashboard pages"
+        >
+          {PAGES.map((page) => {
+            const isActive = activePage === page.id
+            return (
+              <button
+                key={page.id}
+                type="button"
+                onClick={() => onPageChange(page.id)}
+                aria-current={isActive ? 'page' : undefined}
+                aria-label={page.label}
+                title={page.label}
+                className={`btn btn-sm h-11 w-full rounded-lg border border-transparent px-2 ${
+                  isActive
+                    ? 'btn-info text-info-content'
+                    : 'btn-ghost bg-base-100/30 text-base-content/75 hover:bg-base-100/50 hover:text-base-content'
+                } justify-center lg:justify-start lg:gap-3 lg:px-3`}
+              >
+                <page.Icon className="size-4 shrink-0" />
+                <span className="hidden text-sm capitalize lg:inline">{page.label}</span>
+              </button>
+            )
+          })}
+        </nav>
+      </aside>
+
+      <nav
+        className="dock dock-sm z-40 border-t border-base-300/70 bg-base-200/95 backdrop-blur md:hidden"
+        aria-label="Dashboard pages"
+      >
+        {PAGES.map((page) => {
+          const isActive = activePage === page.id
+          return (
+            <button
+              key={page.id}
+              type="button"
+              onClick={() => onPageChange(page.id)}
+              aria-label={page.label}
+              title={page.label}
+              className={isActive ? 'dock-active text-info' : 'text-base-content/70'}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <page.Icon className="size-[1.1rem]" />
+              <span className="dock-label text-[11px] capitalize">{page.shortLabel}</span>
+            </button>
+          )
+        })}
+      </nav>
+    </>
+  )
+}
+
+function baseIcon({ className, children }: { className?: string, children: ReactElement }): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className ?? 'size-4'}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+function IssuesIcon({ className }: IconProps): ReactElement {
+  return baseIcon({
+    className,
+    children: (
+      <>
+        <rect x="3.5" y="4.5" width="17" height="15" rx="2.5" />
+        <path d="M7 9h10" />
+        <path d="M7 13h6.5" />
+      </>
+    ),
+  })
+}
+
+function StatsIcon({ className }: IconProps): ReactElement {
+  return baseIcon({
+    className,
+    children: (
+      <>
+        <path d="M4 19.5h16" />
+        <rect x="6.25" y="11.25" width="2.5" height="6.25" rx="1" />
+        <rect x="10.75" y="8.25" width="2.5" height="9.25" rx="1" />
+        <rect x="15.25" y="5.25" width="2.5" height="12.25" rx="1" />
+      </>
+    ),
+  })
+}
+
+function ProjectsIcon({ className }: IconProps): ReactElement {
+  return baseIcon({
+    className,
+    children: (
+      <>
+        <rect x="3.5" y="5" width="17" height="14" rx="2.5" />
+        <path d="M3.75 9.5h16.5" />
+        <path d="M8.25 5v4.5" />
+      </>
+    ),
+  })
+}
+
+function SettingsIcon({ className }: IconProps): ReactElement {
+  return baseIcon({
+    className,
+    children: (
+      <>
+        <circle cx="12" cy="12" r="2.75" />
+        <path d="M12 4.2v1.6" />
+        <path d="M12 18.2v1.6" />
+        <path d="m5.9 5.9 1.15 1.15" />
+        <path d="m16.95 16.95 1.15 1.15" />
+        <path d="M4.2 12h1.6" />
+        <path d="M18.2 12h1.6" />
+        <path d="m5.9 18.1 1.15-1.15" />
+        <path d="m16.95 7.05 1.15-1.15" />
+      </>
+    ),
+  })
+}


### PR DESCRIPTION
Closes #114

## Plan
**Objective:** Redesign the web header to include compact stats, connection info, action icons, and implement responsive navigation (bottom dock on mobile, left sidebar on tablet/desktop)

1. Install lucide-react for icon support. Run: pnpm add lucide-react
2. Create SideNav.tsx — left sidebar navigation for tablet/desktop (md+). Shows icon-only on tablet (md), icon+label on desktop (lg+). Uses lucide-react icons (LayoutDashboard for Issues, BarChart3 for Stats, FolderKanban for Projects, Settings for Settings). Receives activePage and onPageChange props. Styled as a fixed left column with DaisyUI menu classes.
3. Create MobileDock.tsx — bottom tab bar for mobile (<md). Uses DaisyUI dock component. Same 4 navigation items with lucide-react icons and short labels. Fixed at the bottom of the viewport. Receives activePage and onPageChange props.
4. Redesign DashboardHeader.tsx: (1) Move the info bar content (poll interval, last refresh, stream status, repos) into the header as compact connection info. (2) Add compact inline stats (Active, Running, Cost) from the snapshot — requires passing snapshot or stats summary as a new prop. (3) Show git SHA version prominently. (4) Add action icon buttons on the right: refresh (manual poll), sync, and a link to settings page. (5) Remove the tab navigation from the header (moved to sidebar/dock). (6) Show state badge with connection info. Keep the header sticky at top. On mobile, simplify to just logo + state + action icons.
5. Restructure App.tsx layout: (1) Remove the old info bar section (moved into header). (2) Pass snapshot/stats data to DashboardHeader for inline stats. (3) Change the main layout from single-column to a flex layout: hidden sidebar on mobile, icon-only sidebar on tablet (md), full sidebar on desktop (lg), with the main content area taking the remaining space. (4) Add MobileDock at the bottom, visible only on mobile (<md). (5) Add padding-bottom on mobile for dock clearance. (6) Pass poll/sync/cleanup action callbacks to the header for the action icon buttons. (7) Pass onPageChange to SideNav and MobileDock.
6. Update DashboardMetrics to work as-is but also export the stats derivation logic so the header can show a compact version. Alternatively, keep metrics on the Issues page and just pass raw numbers to the header — simpler approach. No changes needed if we just pass numbers directly from App.tsx to DashboardHeader.
7. Add any needed CSS utilities in index.css for the sidebar transitions or dock styling. The DaisyUI dock component should handle most mobile styling. May need a utility for sidebar width transitions.
8. Update DashboardPage type if needed (should stay the same: 'issues' | 'stats' | 'projects' | 'settings'). Add icon mapping type if useful.

## Implementation
Implemented the header/navigation redesign and addressed all listed review findings: updated `DashboardHeader` tests to the new props/UI and git-pill formats, added callback + busy/disabled assertions for header actions, fixed tablet/mobile nav accessibility with `aria-label`/`title` on icon-only buttons, and added a new `DashboardNavigation` test suite for active state and click behavior. Validation passes with `pnpm test test/web` (8 files, 38 tests).

**Changed files:**
- `web/src/App.tsx`
- `web/src/components/DashboardHeader.tsx`
- `web/src/components/DashboardNavigation.tsx`
- `test/web/dashboard-header.test.ts`
- `test/web/dashboard-navigation.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Previous review findings are resolved: `test/web/dashboard-header.test.ts` now targets the new header contract/markup and action states, `web/src/components/DashboardNavigation.tsx` includes accessible labels for icon-only states, and new tests cover navigation behavior plus header action callbacks. Validation runs are green (`pnpm test test/web`, `pnpm test`, `pnpm lint`, `pnpm typecheck`).

---

**Triage:** standard | **Iterations:** 3 | **Roles:** plan=claude code=codex review=codex