### PR TITLE
[CHORE] Bug - Web - issue overflows/pushes content (night-orch / #135)

### DIFF
--- a/web/src/components/IssueDetailPage.tsx
+++ b/web/src/components/IssueDetailPage.tsx
@@ -38,16 +38,16 @@ export function IssueDetailPage({
   }, [runId])
 
   return (
-    <section className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+    <section className="card min-w-0 overflow-hidden border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
       <div className="card-body p-4 sm:p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
+          <div className="min-w-0">
             <h2 className="card-title text-lg">Issue Detail</h2>
-            <p className="text-xs text-base-content/70">
+            <p className="break-all text-xs text-base-content/70">
               {run ? `${run.repo} #${run.issue}` : `Run ${runId}`}
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
               className={`btn btn-sm ${autoScroll ? 'btn-primary' : 'btn-ghost'}`}
@@ -67,13 +67,13 @@ export function IssueDetailPage({
           </div>
         ) : (
           <div className="mt-4 space-y-4">
-            <section className="rounded-box border border-base-300/70 bg-base-100/70 px-3 py-3">
-              <p className="text-sm font-semibold text-base-content">
+            <section className="min-w-0 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-3">
+              <p className="break-words text-sm font-semibold text-base-content">
                 {truncate(resolveIssueTitle(run.issueTitle), 200)}
               </p>
               <div className="mt-2 flex flex-wrap gap-2 text-xs text-base-content/80">
                 <span className="badge badge-sm">{run.status.replaceAll('_', ' ')}</span>
-                <span className="badge badge-sm">phase {run.phase?.trim() || '-'}</span>
+                <span className="badge badge-sm">phase {truncate(run.phase?.trim() || '-', 28)}</span>
                 <span className="badge badge-sm">iter {run.iterations}</span>
                 <span className="badge badge-sm">${run.costUsd.toFixed(2)}</span>
                 <span className="badge badge-sm">
@@ -81,7 +81,7 @@ export function IssueDetailPage({
                 </span>
               </div>
               {run.lastError && (
-                <p className="mt-2 whitespace-pre-wrap rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
+                <p className="mt-2 whitespace-pre-wrap break-words rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
                   {truncate(run.lastError, 2000)}
                 </p>
               )}
@@ -101,7 +101,7 @@ export function IssueDetailPage({
                 <span>No events yet for this run.</span>
               </div>
             ) : (
-              <section className="rounded-box border border-base-300/70 bg-base-100/70 px-3 py-3">
+              <section className="min-w-0 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <h3 className="text-sm font-semibold text-base-content">Event Stream</h3>
                   <p className="text-xs text-base-content/65">
@@ -117,16 +117,18 @@ export function IssueDetailPage({
                     const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight
                     setAutoScroll(distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD_PX)
                   }}
-                  className="mt-3 max-h-[70vh] space-y-2 overflow-y-auto pr-1"
+                  className="mt-3 max-h-[70vh] min-w-0 space-y-2 overflow-x-hidden overflow-y-auto pr-1"
                 >
                   {visibleEvents.map((event) => (
-                    <div key={event.id} className="rounded-box border border-base-300/70 bg-base-200/70 px-3 py-2">
+                    <div key={event.id} className="min-w-0 rounded-box border border-base-300/70 bg-base-200/70 px-3 py-2">
                       <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/70">
                         <span>{formatTimestamp(event.timestamp)}</span>
-                        <span>{event.phase} / {event.role}</span>
+                        <span className="break-all">{event.phase} / {event.role}</span>
                       </div>
-                      <p className="mt-1 text-sm font-semibold text-info">{event.type}</p>
-                      <p className="mt-1 text-xs text-base-content/85">{describeEventData(event.data)}</p>
+                      <p className="mt-1 break-words text-sm font-semibold text-info">{event.type}</p>
+                      <p className="mt-1 whitespace-pre-wrap break-words text-xs text-base-content/85">
+                        {describeEventData(event.data)}
+                      </p>
                     </div>
                   ))}
                 </div>

--- a/web/src/components/RunsPanel.tsx
+++ b/web/src/components/RunsPanel.tsx
@@ -31,7 +31,7 @@ export function RunsPanel({
   statusTone,
 }: RunsPanelProps): ReactElement {
   return (
-    <div className="card border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
+    <div className="card min-w-0 overflow-hidden border border-base-300/60 bg-base-200/60 shadow-panel backdrop-blur">
       <div className="card-body p-4 sm:p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
@@ -67,7 +67,7 @@ export function RunsPanel({
             <span>No runs for the current filter.</span>
           </div>
         ) : (
-          <div className="mt-4 grid max-h-[540px] gap-3 overflow-y-auto pr-1">
+          <div className="mt-4 grid max-h-[540px] min-w-0 gap-3 overflow-x-hidden overflow-y-auto pr-1">
             {filteredRuns.map((run) => {
               const isRunning = run.status === 'running'
               return (
@@ -75,22 +75,22 @@ export function RunsPanel({
                   key={run.runId}
                   type="button"
                   onClick={() => onOpenRun(run.runId)}
-                  className={`card w-full border text-left transition-all ${
+                  className={`card w-full min-w-0 overflow-hidden border text-left transition-all ${
                     selectedRunId === run.runId
                       ? 'border-primary/65 bg-primary/10 shadow-md'
                       : 'border-base-300/70 bg-base-100/50 hover:border-primary/40 hover:bg-base-100/80'
                   } ${isRunning ? 'orch-running-card' : ''}`}
                 >
-                  <div className="card-body gap-2.5 p-3">
+                  <div className="card-body min-w-0 gap-2.5 p-3">
                     <div className="flex flex-wrap items-start justify-between gap-2">
-                      <div>
-                        <p className="text-xs font-medium uppercase tracking-wide text-base-content/70">
+                      <div className="min-w-0">
+                        <p className="break-all text-xs font-medium uppercase tracking-wide text-base-content/70">
                           {run.repo} #{run.issue}
                         </p>
-                        <p className="mt-0.5 text-sm font-semibold text-base-content">
+                        <p className="mt-0.5 break-words text-sm font-semibold text-base-content">
                           {truncate(resolveIssueTitle(run.issueTitle), 110)}
                         </p>
-                        <p className="mt-0.5 text-xs text-base-content/55">
+                        <p className="mt-0.5 break-all text-xs text-base-content/55">
                           {run.hasRun ? run.runId : 'Tracked issue (no run yet)'}
                         </p>
                       </div>
@@ -98,7 +98,7 @@ export function RunsPanel({
                         {run.status.replaceAll('_', ' ')}
                       </span>
                     </div>
-                    <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                    <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
                       <span className={`badge badge-xs ${badgeToneForPhase(run.phase)}`}>
                         phase {truncate(resolvePhaseLabel(run.phase), 18)}
                       </span>
@@ -111,10 +111,12 @@ export function RunsPanel({
                       <span className={`badge badge-xs ${badgeToneForPrNumber(run.prNumber)}`}>
                         {run.prNumber !== null ? `PR #${run.prNumber}` : 'no PR'}
                       </span>
-                      <span className="ml-auto text-[11px] text-base-content/65">{formatRunTime(run)}</span>
+                      <span className="max-w-full text-[11px] text-base-content/65 sm:ml-auto">
+                        {formatRunTime(run)}
+                      </span>
                     </div>
                     {run.lastError && (
-                      <p className="whitespace-pre-wrap rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
+                      <p className="whitespace-pre-wrap break-words rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
                         {truncate(run.lastError, 500)}
                       </p>
                     )}


### PR DESCRIPTION
Closes #135

## Plan
**Objective:** Fix horizontal overflow in the issue detail view and run cards that pushes the page out of bounds

1. Add overflow-hidden to the IssueDetailPage card container (line 41) to prevent card from expanding beyond its allocated grid space
2. Add break-words (Tailwind: break-words) to the error message paragraph (line 84) which uses whitespace-pre-wrap but lacks word-breaking for long unbroken strings
3. Add break-words to the event data text paragraph (line 129) to handle long URLs/paths/JSON in event descriptions
4. Add overflow-hidden to the issue title section (line 70) and min-w-0 to flex containers within the card to ensure proper flex shrinking
5. Add overflow-hidden to RunsPanel run card buttons (line 78) and break-words to the error text (line 117) to fix the same overflow pattern in the runs list
6. Run pnpm typecheck and pnpm lint in the web directory to verify no build errors were introduced

## Implementation
Fixed horizontal overflow in the web issue detail and run cards by making containers shrink-safe (`min-w-0`, `overflow-hidden`/`overflow-x-hidden`), allowing control rows to wrap, and adding word-breaking for long dynamic strings (repo/run IDs, event payloads, errors, phase/role text). Also truncated issue detail phase badge text to prevent badge-driven width expansion. Verified with `pnpm lint -- web/src/components/IssueDetailPage.tsx web/src/components/RunsPanel.tsx`, `pnpm test -- test/web/router-integration.test.ts`, and `pnpm typecheck`.

**Changed files:**
- `web/src/components/IssueDetailPage.tsx`
- `web/src/components/RunsPanel.tsx`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed the full updated files (`web/src/components/IssueDetailPage.tsx`, `web/src/components/RunsPanel.tsx`) plus adjacent layout and related integration tests. The changes consistently apply `min-w-0`, wrapping, and horizontal overflow containment to prevent page push-out from long unbroken strings. No functional, security, or error-handling regressions were found. Verification rerun passed: `pnpm typecheck`, `pnpm lint`, `pnpm test` (149 files, 1309 tests).

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex