### PR TITLE
[CHORE] Web - basic stats take too much space on mobile (night-orch / #138)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -373,6 +373,7 @@ By default, `web` runs in attach mode: no poll loop, no metrics server, and no e
 Use `--standalone` to run poller + metrics + embedded MCP in the same process as the web server.
 
 The web UI includes an **Agent** page for interactive Claude/Codex sessions that run in the configured worktree root (`storage.worktreeRoot`). Sessions stream output live over websocket and expose REST routes under `/api/agent/sessions` (create/list/detail/events/send-message/close).
+On narrow mobile viewports, the top-line dashboard metric cards render in a compact 2-column layout so the runs list stays the primary focus on the Issues page.
 
 Default bind is `127.0.0.1:3200`. Use `--host` / `--port` to change this (for example when reverse-proxying through Caddy or nginx). Use `--allowed-host` (repeatable) to permit additional Host/Origin values when proxying.
 

--- a/web/src/components/DashboardMetrics.tsx
+++ b/web/src/components/DashboardMetrics.tsx
@@ -19,11 +19,12 @@ export function DashboardMetrics({ snapshot }: DashboardMetricsProps): ReactElem
     : `Budget $${formatMoney(snapshot?.cost.dailyBudgetUsd ?? 0)}`
 
   return (
-    <section className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+    <section className="grid grid-cols-2 gap-1.5 sm:gap-2 xl:grid-cols-4">
       <MetricCard
         label={usageFirst ? 'Daily Usage' : 'Daily Cost'}
         value={usageFirst ? formatTokenCount(snapshot?.stats.usage.todayTotalTokens ?? 0) : `$${formatMoney(dailyCost)}`}
         accent="emerald"
+        compactOnMobile
         subValue={usageFirst
           ? `Est. $${formatMoney(dailyCost)} today`
           : budgetLabel}
@@ -32,18 +33,21 @@ export function DashboardMetrics({ snapshot }: DashboardMetricsProps): ReactElem
         label="Budget Headroom"
         value={formatSignedUsd(budgetHeadroom)}
         accent={budgetHeadroom >= 0 ? 'cyan' : 'amber'}
+        compactOnMobile
         subValue={`Daily cap $${formatMoney(effectiveBudget)}`}
       />
       <MetricCard
         label="24h Throughput"
         value={snapshot?.stats.throughput.runs24h ?? 0}
         accent="cyan"
+        compactOnMobile
         subValue={`${(snapshot?.stats.throughput.successRate7d ?? 0).toFixed(1)}% success (7d)`}
       />
       <MetricCard
         label="Review Ready"
         value={snapshot?.stats.overview.reviewReadyRuns ?? 0}
         accent="sky"
+        compactOnMobile
         subValue={`${snapshot?.stats.overview.completedRuns ?? 0} completed`}
       />
     </section>

--- a/web/src/components/MetricCard.tsx
+++ b/web/src/components/MetricCard.tsx
@@ -5,9 +5,16 @@ interface MetricCardProps {
   value: number | string
   accent: 'cyan' | 'amber' | 'emerald' | 'sky'
   subValue?: string
+  compactOnMobile?: boolean
 }
 
-export function MetricCard({ label, value, accent, subValue }: MetricCardProps): ReactElement {
+export function MetricCard({
+  label,
+  value,
+  accent,
+  subValue,
+  compactOnMobile = false,
+}: MetricCardProps): ReactElement {
   const accentClass = accent === 'amber'
     ? 'border-warning/50 bg-warning/10'
     : accent === 'emerald'
@@ -15,12 +22,24 @@ export function MetricCard({ label, value, accent, subValue }: MetricCardProps):
       : accent === 'sky'
         ? 'border-accent/50 bg-accent/10'
         : 'border-info/50 bg-info/10'
+  const containerClass = compactOnMobile
+    ? 'gap-0.5 px-2 py-1.5 sm:gap-1 sm:px-3 sm:py-2'
+    : 'gap-1 px-3 py-2'
+  const titleClass = compactOnMobile
+    ? 'stat-title text-[9px] uppercase tracking-[0.12em] text-base-content/70 sm:text-[10px]'
+    : 'stat-title text-[10px] uppercase tracking-[0.12em] text-base-content/70'
+  const valueClass = compactOnMobile
+    ? 'stat-value text-base leading-tight text-base-content sm:text-xl'
+    : 'stat-value text-xl leading-tight text-base-content'
+  const subValueClass = compactOnMobile
+    ? 'stat-desc hidden text-[10px] text-base-content/70 sm:block'
+    : 'stat-desc text-[10px] text-base-content/70'
 
   return (
-    <article className={`stat min-h-0 gap-1 rounded-box border px-3 py-2 shadow-panel ${accentClass}`}>
-      <div className="stat-title text-[10px] uppercase tracking-[0.12em] text-base-content/70">{label}</div>
-      <div className="stat-value text-xl leading-tight text-base-content">{value}</div>
-      {subValue && <div className="stat-desc text-[10px] text-base-content/70">{subValue}</div>}
+    <article className={`stat min-h-0 rounded-box border shadow-panel ${containerClass} ${accentClass}`}>
+      <div className={titleClass}>{label}</div>
+      <div className={valueClass}>{value}</div>
+      {subValue && <div className={subValueClass}>{subValue}</div>}
     </article>
   )
 }


### PR DESCRIPTION
Closes #138

## Plan
**Objective:** Make the basic stats cards (DashboardMetrics) much smaller on mobile so the issues list (RunsPanel) is the focus

1. Change DashboardMetrics grid to always show 2 columns on mobile (grid-cols-2) instead of single column, and 4 columns from sm breakpoint up. Reduce gap to gap-1.5 on mobile.
2. Make MetricCard more compact on mobile: reduce padding (px-2 py-1.5 on mobile, px-3 py-2 from sm), shrink value text (text-base on mobile, text-xl from sm), shrink label and subValue text sizes. Remove min-h-0 stat class on mobile or use a lighter layout that avoids DaisyUI stat's built-in spacing.

## Implementation
Made `DashboardMetrics` compact on mobile by switching to a 2-column layout and adding a `compactOnMobile` mode in `MetricCard` (smaller spacing/typography with subtext hidden on small screens), so `RunsPanel` stays the focus on Issues. Also documented the responsive behavior in `docs/USAGE.md`. Validation passed with `pnpm test -- test/web/router-integration.test.ts`, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `web/src/components/DashboardMetrics.tsx`
- `web/src/components/MetricCard.tsx`
- `docs/USAGE.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The change set addresses the mobile-space issue by making dashboard metric cards compact and forcing a 2-column layout on narrow viewports, which shifts visual priority toward the runs list. I found no functional, security, or error-handling regressions in the updated components, and the provided verification results are consistent with a clean run.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex