### PR TITLE
[CHORE] Apply MIT license (night-orch / #146)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 night-orch contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ night-orch labels-init              # create/update required labels
 ## Contributing
 
 Development setup, architecture guardrails, and contribution workflow live in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the MIT License. See [`LICENSE`](LICENSE).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "night-orch",
   "version": "0.3.2",
   "description": "Nightly GitHub/Forgejo issue orchestrator — autonomous AI agent coding tool",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/shllg/night-orch"


### PR DESCRIPTION
Closes #146

## Plan
**Objective:** Apply the MIT license to the night-orch project

1. Create LICENSE file in the repo root with the standard MIT license text, copyright 'night-orch contributors'
2. Add "license": "MIT" field to package.json (after the 'description' or 'repository' field)
3. Add a 'License' section at the bottom of README.md with a brief note and link to the LICENSE file, plus optionally a license badge near the top badges

## Implementation
Applied the MIT license across the project by adding a standard MIT LICENSE file, declaring "license": "MIT" in package.json, and adding a License section to README.md that points to the license file.

**Changed files:**
- `LICENSE`
- `package.json`
- `README.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed `LICENSE`, `README.md`, and `package.json` in full, plus adjacent docs/test surface. The MIT license text is correctly added (`LICENSE:1-21`), referenced from the README (`README.md:75-77`), and declared in package metadata (`package.json:5`). A dry-run package check also confirms `LICENSE` is included in publish artifacts. No runtime/code-path behavior changed, so no additional targeted tests are required; provided verification results (`pnpm typecheck`, `pnpm lint`, `pnpm test`) are sufficient for this scope.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex