### PR TITLE
[CHORE] Web/TUI - Settings - list all setting options always (night-orch / #142)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ Recommended deployment uses a dedicated non-root user (for example `orch`) with:
 
 ## Runtime Settings Overrides (DB-backed)
 
-Night-orch supports a curated set of runtime overrides stored in SQLite (`settings_overrides` table).  
+Night-orch supports DB-backed runtime overrides stored in SQLite (`settings_overrides` table).  
 Effective config precedence is:
 
 1. YAML value (or schema default when omitted)
@@ -33,16 +33,28 @@ Effective config precedence is:
 
 Overrides are persisted in DB and survive process restarts. They are not written back to YAML.
 
-Curated runtime keys:
+Runtime settings registry scope:
 
-| Key | Type | Accepted Range |
-| --- | --- | --- |
-| `github.pollIntervalSeconds` | integer | `5..3600` |
-| `security.maxDailyCostUsd` | number | `1..10000` |
-| `security.maxCostPerRunUsd` | number | `0.1..1000` |
-| `loop.maxReviewIterations` | integer | `1..20` |
-| `loop.maxTotalAgentPasses` | integer | `1..50` |
-| `observability.agentStreaming` | boolean | `true`/`false` |
+- Includes all non-project-specific config keys used at runtime.
+- Excludes project-scoped `repos[*]` settings and schema marker `version`.
+- `storage.dbPath` is listed for visibility but is read-only at runtime (DB bootstraps before overrides load).
+- Sensitive fields are redacted in settings read surfaces (for example `workerProfiles.*.env` values).
+- JSON setting overrides are schema-validated per key before persistence.
+
+Registered keys are visible via `night-orch settings list` (or Web/TUI Settings/MCP `night-orch-list-settings`). Current key groups:
+
+- `github`: `tokenEnv`, `apiBaseUrl`, `pollIntervalSeconds`, `appMentions`
+- `storage`: `dbPath` (read-only), `worktreeRoot`, `logsRoot`, `autoCleanup.enabled`, `autoCleanup.intervalMinutes`, `retention.worktreeAgeDays`, `retention.detailDays`, `retention.archiveDays`
+- `notifications`: `channels`, `events.onRunStarted`, `events.onBlocked`, `events.onPrReady`, `events.onPrUpdated`, `events.onError`, `events.onRetryExhausted`
+- `loop`: `maxReviewIterations`, `maxTotalAgentPasses`, `stopOnPlannerFailure`, `requireVerificationPass`, `reviewApprovalKeyword`, `reviewNeedsChangesKeyword`, `blockOnAmbiguousReview`, `maxAutoRetries`, `decompose`, `maxSubtasks`, `maxConcurrentSubtasks`
+- `security`: `maxChangedFiles`, `maxChangedLines`, `maxDailyCostUsd`, `maxCostPerRunUsd`
+- `cost`: `model`, `pricing.defaultModel`, `pricing.models`
+- `workerProfiles`
+- `metrics`: `enabled`, `port`, `host`
+- `observability`: `agentStreaming`, `eventRetention`, `sessionLogs`, `sessionLogRetention`
+- `mcp`: `enabled`, `transport`, `authTokenEnv`, `httpPort`, `httpHost`
+- `commentCommands`: `enabled`, `requireCollaborator`
+- `workflows`
 
 Update surfaces:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -399,15 +399,17 @@ Show current state: active runs, active leases, daily cost against budget, recen
 
 ### `night-orch tui`
 
-Live-updating terminal dashboard. Refreshes every 2 seconds. Shows active runs, merge queue, cost bar, recent history, issue actions (`poll`, `sync`, `cleanup`, `retry`, `retry fresh`, `continue`, `rebase`, `delete entry`), and a Settings tab (`5`) for curated runtime overrides. Press Ctrl+C to exit.
+Live-updating terminal dashboard. Refreshes every 2 seconds. Shows active runs, merge queue, cost bar, recent history, issue actions (`poll`, `sync`, `cleanup`, `retry`, `retry fresh`, `continue`, `rebase`, `delete entry`), and a Settings tab (`5`) for runtime overrides (read-only keys are listed but cannot be changed). Press Ctrl+C to exit.
 
 ### `night-orch settings`
 
-Manage DB-backed runtime overrides for curated config keys.
+Manage DB-backed runtime overrides for all non-project-specific config keys. Read-only keys (for example `storage.dbPath`) are listed but cannot be overridden at runtime. Sensitive values are redacted in list output.
 
 - `night-orch settings list [--json]`
 - `night-orch settings set <key> <value>`
 - `night-orch settings unset <key>`
+
+JSON runtime settings require schema-valid structure; syntactically valid but malformed payloads are rejected.
 
 ### `night-orch sync`
 
@@ -532,7 +534,7 @@ Night-orch exposes an MCP server for integration with Claude Code and other MCP 
 
 | Tool | Description |
 |------|-------------|
-| `night-orch-list-settings` | List curated runtime settings, overrides, and effective values |
+| `night-orch-list-settings` | List runtime settings, overrides, and effective values (sensitive fields redacted) |
 | `night-orch-set-setting` | Set one DB-backed runtime override |
 | `night-orch-clear-setting` | Clear one DB-backed runtime override |
 | `night-orch-status` | Operational snapshot |

--- a/src/cli/commands/settings.ts
+++ b/src/cli/commands/settings.ts
@@ -29,9 +29,13 @@ export async function settingsListCommand(
 
     console.log('\nRuntime Settings (base + DB override)\n')
     for (const setting of settings) {
-      const bounds = setting.type === 'number'
+      const accepted = setting.type === 'number'
         ? `${setting.min ?? '-'}..${setting.max ?? '-'} step=${setting.step ?? '-'}`
-        : 'true|false'
+        : setting.type === 'boolean'
+          ? 'true|false'
+          : setting.type === 'string'
+            ? resolveAcceptedString(setting.options, setting.allowNull ?? false)
+            : 'json'
       const overrideDisplay = setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)
       const updated = setting.updatedAt ?? '-'
 
@@ -40,7 +44,8 @@ export async function settingsListCommand(
       console.log(`  base:       ${formatSettingValue(setting.baseValue)}`)
       console.log(`  override:   ${overrideDisplay}`)
       console.log(`  effective:  ${formatSettingValue(setting.effectiveValue)} (${setting.source})`)
-      console.log(`  accepted:   ${bounds}`)
+      console.log(`  accepted:   ${accepted}`)
+      console.log(`  mode:       ${setting.mutable ? 'mutable' : 'read-only'}${setting.sensitive ? ' (sensitive values redacted)' : ''}`)
       console.log(`  updated:    ${updated}`)
     }
     console.log('')
@@ -116,9 +121,41 @@ function loadSettingsResources(
   }
 }
 
-function formatSettingValue(value: string | number | boolean): string {
+function formatSettingValue(value: unknown): string {
+  if (value === null) {
+    return 'null'
+  }
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number') {
+    return String(value)
+  }
+  if (typeof value === 'bigint') {
+    return `${value}n`
+  }
   if (typeof value === 'boolean') {
     return value ? 'true' : 'false'
   }
-  return String(value)
+  if (typeof value === 'undefined') {
+    return 'undefined'
+  }
+  if (typeof value === 'symbol') {
+    return value.toString()
+  }
+  if (typeof value === 'function') {
+    return '[function]'
+  }
+  return JSON.stringify(value)
+}
+
+function resolveAcceptedString(options: string[] | undefined, allowNull: boolean): string {
+  if (options && options.length > 0) {
+    const values = allowNull ? [...options, 'null'] : options
+    return values.join('|')
+  }
+  return allowNull ? 'string|null' : 'string'
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -254,7 +254,7 @@ const settingsCommand = program
 
 settingsCommand
   .command('list')
-  .description('List curated runtime settings and active overrides')
+  .description('List runtime settings and active overrides')
   .option('--json', 'Output JSON')
   .action((opts: { json?: boolean }, cmd) => {
     const globalOpts = resolveRootGlobalOpts(cmd)

--- a/src/cli/tui/app.tsx
+++ b/src/cli/tui/app.tsx
@@ -55,9 +55,19 @@ const EXIT_GRACE_TIMEOUT_MS = 15_000
 const CLEANUP_CONFIRM_TIMEOUT_MS = 5_000
 const BUILD_INFO = getBuildInfo()
 
-function formatSettingValue(value: string | number | boolean): string {
+function formatSettingValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'bigint') return `${value}n`
   if (typeof value === 'boolean') return value ? 'true' : 'false'
-  return String(value)
+  if (typeof value === 'undefined') return 'undefined'
+  if (typeof value === 'symbol') return value.toString()
+  if (typeof value === 'function') return '[function]'
+  return JSON.stringify(value)
 }
 
 export function resolveTabHotkey(input: string): TabId | null {
@@ -805,10 +815,14 @@ export function App({
     })
   }, [config, db, runAction])
 
-  const runSetSetting = useCallback(async (nextValue: string | number | boolean) => {
+  const runSetSetting = useCallback(async (nextValue: unknown) => {
     const target = runtimeSettings[selectedSettingIndex]
     if (!target) {
       setStatusLine('No setting selected')
+      return
+    }
+    if (!target.mutable) {
+      setStatusLine(`"${target.key}" is read-only at runtime`)
       return
     }
 
@@ -824,6 +838,10 @@ export function App({
       setStatusLine('No setting selected')
       return
     }
+    if (!target.mutable) {
+      setStatusLine(`"${target.key}" is read-only at runtime`)
+      return
+    }
 
     await runAction('setting-unset', async () => {
       const result = clearRuntimeSettingOverride(config, db, target.key)
@@ -837,8 +855,18 @@ export function App({
       setStatusLine('No setting selected')
       return
     }
+    if (!target.mutable) {
+      setStatusLine(`"${target.key}" is read-only at runtime`)
+      return
+    }
     if (target.type !== 'number') {
-      setStatusLine(`"${target.key}" is boolean. Use space to toggle.`)
+      if (target.type === 'boolean') {
+        setStatusLine(`"${target.key}" is boolean. Use space to toggle.`)
+      } else if (target.type === 'json') {
+        setStatusLine(`"${target.key}" is JSON. Use CLI/Web/MCP to set a value.`)
+      } else {
+        setStatusLine(`"${target.key}" is text. Use CLI/Web/MCP to set a value.`)
+      }
       return
     }
 
@@ -865,8 +893,18 @@ export function App({
       setStatusLine('No setting selected')
       return
     }
+    if (!target.mutable) {
+      setStatusLine(`"${target.key}" is read-only at runtime`)
+      return
+    }
     if (target.type !== 'boolean') {
-      setStatusLine(`"${target.key}" is numeric. Use +/- to adjust.`)
+      if (target.type === 'number') {
+        setStatusLine(`"${target.key}" is numeric. Use +/- to adjust.`)
+      } else if (target.type === 'json') {
+        setStatusLine(`"${target.key}" is JSON. Use CLI/Web/MCP to set a value.`)
+      } else {
+        setStatusLine(`"${target.key}" is text. Use CLI/Web/MCP to set a value.`)
+      }
       return
     }
 

--- a/src/cli/tui/settings-view.tsx
+++ b/src/cli/tui/settings-view.tsx
@@ -15,7 +15,7 @@ export function SettingsView({
     return (
       <Box flexDirection="column" borderStyle="round" borderColor="blue" paddingX={1}>
         <Text bold color="cyan">Settings</Text>
-        <Text dimColor>No curated runtime settings available.</Text>
+        <Text dimColor>No runtime settings available.</Text>
       </Box>
     )
   }
@@ -26,13 +26,14 @@ export function SettingsView({
   return (
     <Box flexDirection="column" borderStyle="round" borderColor="blue" paddingX={1}>
       <Text bold color="cyan">Runtime Settings</Text>
-      <Text dimColor>Use j/k to select, +/- to adjust numeric values, space to toggle booleans, u to clear override.</Text>
+      <Text dimColor>Use j/k to select, +/- for numbers, space for booleans, u to clear override (read-only keys cannot be changed).</Text>
 
       <Box flexDirection="column" marginTop={1}>
         {settings.map((setting, index) => {
           const selectedRow = index === clampedIndex
           const override = setting.overrideValue === null ? '-' : formatSettingValue(setting.overrideValue)
-          const line = `${setting.key} | effective=${formatSettingValue(setting.effectiveValue)} | override=${override} | source=${setting.source}`
+          const mode = setting.mutable ? 'mutable' : 'read-only'
+          const line = `${setting.key} | effective=${formatSettingValue(setting.effectiveValue)} | override=${override} | source=${setting.source} | ${mode}`
           return (
             <Text key={setting.key} color={selectedRow ? 'white' : 'gray'} inverse={selectedRow}>
               {selectedRow ? '▸ ' : '  '}
@@ -46,6 +47,7 @@ export function SettingsView({
         <Text color="white">Selected</Text>
         <Text>{selected.label}</Text>
         <Text dimColor>{selected.description}</Text>
+        <Text dimColor>{selected.mutable ? 'mutable' : 'read-only at runtime'}</Text>
         <Text>
           base={formatSettingValue(selected.baseValue)} override={
             selected.overrideValue === null ? '-' : formatSettingValue(selected.overrideValue)
@@ -56,7 +58,15 @@ export function SettingsView({
   )
 }
 
-function formatSettingValue(value: string | number | boolean): string {
+function formatSettingValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) return JSON.stringify(value)
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'bigint') return `${value}n`
   if (typeof value === 'boolean') return value ? 'true' : 'false'
-  return String(value)
+  if (typeof value === 'undefined') return 'undefined'
+  if (typeof value === 'symbol') return value.toString()
+  if (typeof value === 'function') return '[function]'
+  return JSON.stringify(value)
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -26,7 +26,7 @@ const SmtpChannelSchema = z.object({
   passEnv: z.string(),
 })
 
-const NotificationChannelSchema = z.discriminatedUnion('type', [
+export const NotificationChannelSchema = z.discriminatedUnion('type', [
   ConsoleChannelSchema,
   WebhookChannelSchema,
   DiscordChannelSchema,
@@ -44,14 +44,14 @@ const NotificationEventsSchema = z.object({
 
 // --- App mention schemas ---
 
-const AppMentionSchema = z.object({
+export const AppMentionSchema = z.object({
   enabled: z.boolean().default(false),
   commentTemplate: z.string(),
 })
 
 // --- Worker profile schema ---
 
-const WorkerProfileSchema = z.object({
+export const WorkerProfileSchema = z.object({
   type: z.string().min(1, 'Worker type must not be empty'),
   pricingModel: z.string().min(1).optional(),
   command: z.string(),
@@ -209,7 +209,7 @@ const WorkflowRoleOverridesSchema = z.object({
   reviewer: z.enum(['claude', 'codex', 'opencode']).optional(),
 })
 
-const WorkflowSchema = z.object({
+export const WorkflowSchema = z.object({
   steps: z.array(WorkflowStepSchema).min(1),
   roles: WorkflowRoleOverridesSchema.optional(),
   agents: z.record(z.string()).optional(),
@@ -284,7 +284,7 @@ const SecuritySchema = z.object({
 
 const CostModelSchema = z.enum(['pay-per-use', 'subscription'])
 
-const CostPricingModelSchema = z.object({
+export const CostPricingModelSchema = z.object({
   inputUsdPerMillionTokens: z.number().nonnegative().default(3),
   outputUsdPerMillionTokens: z.number().nonnegative().default(15),
   minuteUsd: z.number().nonnegative().default(0.008),

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -393,7 +393,7 @@ async function handleSetSetting(
     changed: result.changed,
     setting: result.setting,
     message: result.changed
-      ? `Updated ${result.setting.key} to ${String(result.setting.effectiveValue)}`
+      ? `Updated ${result.setting.key} to ${formatRuntimeSettingValue(result.setting.effectiveValue)}`
       : `${result.setting.key} unchanged`,
   }
 }
@@ -416,6 +416,21 @@ async function handleClearSetting(
       ? `Cleared override for ${result.setting.key}`
       : `No override found for ${result.setting.key}`,
   }
+}
+
+function formatRuntimeSettingValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'bigint') return `${value}n`
+  if (typeof value === 'undefined') return 'undefined'
+  if (typeof value === 'symbol') return value.toString()
+  if (typeof value === 'function') return '[function]'
+  return JSON.stringify(value)
 }
 
 async function handleStatus(args: { repo?: string }, deps: MCPDependencies): Promise<unknown> {

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -1,15 +1,25 @@
-import type { Config } from '../config/schema.js'
+import { z } from 'zod'
+import {
+  AppMentionSchema,
+  CostPricingModelSchema,
+  NotificationChannelSchema,
+  type Config,
+  WorkerProfileSchema,
+  WorkflowSchema,
+} from '../config/schema.js'
 
-export type SettingKey =
-  | 'github.pollIntervalSeconds'
-  | 'security.maxDailyCostUsd'
-  | 'security.maxCostPerRunUsd'
-  | 'loop.maxReviewIterations'
-  | 'loop.maxTotalAgentPasses'
-  | 'observability.agentStreaming'
+export type SettingKey = string
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+export type SettingValue = JsonValue
+export type SettingType = 'number' | 'boolean' | 'string' | 'json'
 
-export type SettingValue = number | boolean
-export type SettingType = 'number' | 'boolean'
+type SettingPath = readonly [string, ...string[]]
 
 interface SettingDefinitionBase<K extends SettingKey, V extends SettingValue> {
   key: K
@@ -17,13 +27,16 @@ interface SettingDefinitionBase<K extends SettingKey, V extends SettingValue> {
   description: string
   details: string
   type: SettingType
-  defaultValue: V
-  yamlPath: readonly [string, ...string[]]
+  mutable: boolean
+  sensitive: boolean
+  defaultValue: V | null
+  yamlPath: SettingPath
   read: (config: Config) => V
   apply: (config: Config, value: V) => Config
   parseInput: (raw: unknown) => V
   parseStored: (raw: string) => V
   serialize: (value: V) => string
+  sanitizeForDisplay: (value: V) => SettingValue
 }
 
 export interface NumberSettingDefinition<K extends SettingKey = SettingKey>
@@ -39,209 +52,49 @@ export interface BooleanSettingDefinition<K extends SettingKey = SettingKey>
   type: 'boolean'
 }
 
-export type SettingDefinition = NumberSettingDefinition | BooleanSettingDefinition
+export interface StringSettingDefinition<K extends SettingKey = SettingKey>
+  extends SettingDefinitionBase<K, string | null> {
+  type: 'string'
+  options?: readonly string[]
+  allowNull?: boolean
+}
+
+export interface JsonSettingDefinition<K extends SettingKey = SettingKey>
+  extends SettingDefinitionBase<K, JsonValue> {
+  type: 'json'
+}
+
+export type SettingDefinition =
+  | NumberSettingDefinition
+  | BooleanSettingDefinition
+  | StringSettingDefinition
+  | JsonSettingDefinition
 
 export interface SettingYamlValue {
   hasYamlValue: boolean
   yamlValue: SettingValue | null
 }
 
-const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
-  'github.pollIntervalSeconds': {
-    key: 'github.pollIntervalSeconds',
-    label: 'Poll Interval (seconds)',
-    description: 'Delay between automatic poll cycles.',
-    details: 'Controls how often night-orch checks configured repos for work. Lower values react faster but increase API traffic; higher values reduce background load.',
-    type: 'number',
-    defaultValue: 300,
-    yamlPath: ['github', 'pollIntervalSeconds'],
-    min: 5,
-    max: 3600,
-    step: 5,
-    read: (config) => config.github.pollIntervalSeconds,
-    apply: (config, value) => ({
-      ...config,
-      github: {
-        ...config.github,
-        pollIntervalSeconds: value,
-      },
-    }),
-    parseInput: (raw) => parseNumberInput(raw, {
-      key: 'github.pollIntervalSeconds',
-      integer: true,
-      min: 5,
-      max: 3600,
-    }),
-    parseStored: (raw) => parseStoredNumber(raw, {
-      key: 'github.pollIntervalSeconds',
-      integer: true,
-      min: 5,
-      max: 3600,
-    }),
-    serialize: (value) => JSON.stringify(value),
-  },
-  'security.maxDailyCostUsd': {
-    key: 'security.maxDailyCostUsd',
-    label: 'Daily Cost Budget (USD)',
-    description: 'Maximum allowed spend per UTC day before new runs are blocked.',
-    details: 'Sets the global daily spend cap for pay-per-use mode. When the cap is reached, new runs are blocked until the next UTC day or until you raise the limit.',
-    type: 'number',
-    defaultValue: 50,
-    yamlPath: ['security', 'maxDailyCostUsd'],
-    min: 1,
-    max: 10000,
-    step: 1,
-    read: (config) => config.security.maxDailyCostUsd,
-    apply: (config, value) => ({
-      ...config,
-      security: {
-        ...config.security,
-        maxDailyCostUsd: value,
-      },
-    }),
-    parseInput: (raw) => parseNumberInput(raw, {
-      key: 'security.maxDailyCostUsd',
-      integer: false,
-      min: 1,
-      max: 10000,
-    }),
-    parseStored: (raw) => parseStoredNumber(raw, {
-      key: 'security.maxDailyCostUsd',
-      integer: false,
-      min: 1,
-      max: 10000,
-    }),
-    serialize: (value) => JSON.stringify(value),
-  },
-  'security.maxCostPerRunUsd': {
-    key: 'security.maxCostPerRunUsd',
-    label: 'Per-Run Cost Budget (USD)',
-    description: 'Maximum allowed spend for a single run before it is blocked.',
-    details: 'Sets the per-issue run cost ceiling. Useful for preventing one expensive issue from consuming most of the daily budget.',
-    type: 'number',
-    defaultValue: 10,
-    yamlPath: ['security', 'maxCostPerRunUsd'],
-    min: 0.1,
-    max: 1000,
-    step: 0.5,
-    read: (config) => config.security.maxCostPerRunUsd,
-    apply: (config, value) => ({
-      ...config,
-      security: {
-        ...config.security,
-        maxCostPerRunUsd: value,
-      },
-    }),
-    parseInput: (raw) => parseNumberInput(raw, {
-      key: 'security.maxCostPerRunUsd',
-      integer: false,
-      min: 0.1,
-      max: 1000,
-    }),
-    parseStored: (raw) => parseStoredNumber(raw, {
-      key: 'security.maxCostPerRunUsd',
-      integer: false,
-      min: 0.1,
-      max: 1000,
-    }),
-    serialize: (value) => JSON.stringify(value),
-  },
-  'loop.maxReviewIterations': {
-    key: 'loop.maxReviewIterations',
-    label: 'Max Review Iterations',
-    description: 'Maximum review correction loops per run.',
-    details: 'Limits how many review-fix-review cycles a run can execute before stopping. Higher values can improve completion rate, but may increase runtime and cost.',
-    type: 'number',
-    defaultValue: 4,
-    yamlPath: ['loop', 'maxReviewIterations'],
-    min: 1,
-    max: 20,
-    step: 1,
-    read: (config) => config.loop.maxReviewIterations,
-    apply: (config, value) => ({
-      ...config,
-      loop: {
-        ...config.loop,
-        maxReviewIterations: value,
-      },
-    }),
-    parseInput: (raw) => parseNumberInput(raw, {
-      key: 'loop.maxReviewIterations',
-      integer: true,
-      min: 1,
-      max: 20,
-    }),
-    parseStored: (raw) => parseStoredNumber(raw, {
-      key: 'loop.maxReviewIterations',
-      integer: true,
-      min: 1,
-      max: 20,
-    }),
-    serialize: (value) => JSON.stringify(value),
-  },
-  'loop.maxTotalAgentPasses': {
-    key: 'loop.maxTotalAgentPasses',
-    label: 'Max Total Agent Passes',
-    description: 'Hard cap on planner/coder/reviewer passes in one run.',
-    details: 'Caps total planner/coder/reviewer passes across the full run. This is a safety guard against long loops and runaway spend.',
-    type: 'number',
-    defaultValue: 10,
-    yamlPath: ['loop', 'maxTotalAgentPasses'],
-    min: 1,
-    max: 50,
-    step: 1,
-    read: (config) => config.loop.maxTotalAgentPasses,
-    apply: (config, value) => ({
-      ...config,
-      loop: {
-        ...config.loop,
-        maxTotalAgentPasses: value,
-      },
-    }),
-    parseInput: (raw) => parseNumberInput(raw, {
-      key: 'loop.maxTotalAgentPasses',
-      integer: true,
-      min: 1,
-      max: 50,
-    }),
-    parseStored: (raw) => parseStoredNumber(raw, {
-      key: 'loop.maxTotalAgentPasses',
-      integer: true,
-      min: 1,
-      max: 50,
-    }),
-    serialize: (value) => JSON.stringify(value),
-  },
-  'observability.agentStreaming': {
-    key: 'observability.agentStreaming',
-    label: 'Agent Streaming',
-    description: 'Enable in-flight agent event streaming to TUI/Web.',
-    details: 'Turns live agent event streaming on or off for terminal and web views. Disable this if you want quieter live output while runs are active.',
-    type: 'boolean',
-    defaultValue: true,
-    yamlPath: ['observability', 'agentStreaming'],
-    read: (config) => config.observability?.agentStreaming ?? true,
-    apply: (config, value) => ({
-      ...config,
-      observability: {
-        ...buildDefaultObservability(config),
-        agentStreaming: value,
-      },
-    }),
-    parseInput: (raw) => parseBooleanInput(raw, 'observability.agentStreaming'),
-    parseStored: (raw) => parseStoredBoolean(raw, 'observability.agentStreaming'),
-    serialize: (value) => JSON.stringify(value),
-  },
-}
-
-const SETTING_KEYS = Object.keys(SETTING_DEFINITIONS) as SettingKey[]
+const SETTING_DEFINITIONS: Record<string, SettingDefinition> = buildSettingDefinitions()
+const SETTING_KEYS = Object.keys(SETTING_DEFINITIONS)
 
 export function listSettingDefinitions(): SettingDefinition[] {
-  return SETTING_KEYS.map((key) => SETTING_DEFINITIONS[key])
+  return SETTING_KEYS.map((key) => SETTING_DEFINITIONS[key]!)
 }
 
 export function getSettingDefinition(key: string): SettingDefinition | null {
-  return SETTING_DEFINITIONS[key as SettingKey] ?? null
+  return SETTING_DEFINITIONS[key] ?? null
+}
+
+export function sanitizeSettingValueForDisplay(
+  definition: SettingDefinition,
+  value: SettingValue | null,
+): SettingValue | null {
+  if (value === null) {
+    return null
+  }
+  const sanitize = definition.sanitizeForDisplay as (input: SettingValue) => SettingValue
+  return sanitize(value)
 }
 
 export function resolveSettingYamlValue(
@@ -262,9 +115,727 @@ export function resolveSettingYamlValue(
   }
 }
 
+const GithubAppMentionsOverrideSchema = z.record(AppMentionSchema)
+const NotificationsChannelsOverrideSchema = z.array(NotificationChannelSchema)
+const CostPricingModelsOverrideSchema = z.record(CostPricingModelSchema)
+const WorkerProfilesOverrideSchema = z.record(WorkerProfileSchema)
+const WorkflowsOverrideSchema = z.record(WorkflowSchema)
+
+function buildSettingDefinitions(): Record<string, SettingDefinition> {
+  const definitions: SettingDefinition[] = [
+    stringSetting({
+      key: 'github.tokenEnv',
+      label: 'GitHub Token Env Var',
+      description: 'Environment variable name used for GitHub authentication.',
+      details: 'Set the env var name that stores the GitHub token. This must be a variable name, not a literal token value.',
+      defaultValue: null,
+      yamlPath: ['github', 'tokenEnv'],
+      minLength: 1,
+      validate: (value) => {
+        if (value.startsWith('ghp_') || value.startsWith('ghs_') || value.startsWith('github_pat_')) {
+          return 'github.tokenEnv should be an environment variable name, not a literal token'
+        }
+        return null
+      },
+    }),
+    stringSetting({
+      key: 'github.apiBaseUrl',
+      label: 'GitHub API Base URL',
+      description: 'Base URL for GitHub API requests.',
+      details: 'Override the API base URL used for GitHub repos. Useful for GitHub Enterprise deployments.',
+      defaultValue: 'https://api.github.com',
+      yamlPath: ['github', 'apiBaseUrl'],
+      minLength: 1,
+      url: true,
+    }),
+    numberSetting({
+      key: 'github.pollIntervalSeconds',
+      label: 'Poll Interval (seconds)',
+      description: 'Delay between automatic poll cycles.',
+      details: 'Controls how often night-orch checks configured repos for work. Lower values react faster but increase API traffic.',
+      defaultValue: 300,
+      yamlPath: ['github', 'pollIntervalSeconds'],
+      integer: true,
+      min: 5,
+      max: 3600,
+      step: 5,
+    }),
+    jsonSetting({
+      key: 'github.appMentions',
+      label: 'GitHub App Mentions',
+      description: 'Mention template map used for app-trigger comments.',
+      details: 'Record keyed by mention alias with enabled flag and comment template payloads.',
+      defaultValue: {},
+      yamlPath: ['github', 'appMentions'],
+      normalize: (value) => validateJsonSettingShape(value, GithubAppMentionsOverrideSchema, 'github.appMentions'),
+    }),
+
+    stringSetting({
+      key: 'storage.dbPath',
+      label: 'State DB Path',
+      description: 'SQLite database file path.',
+      details: 'Location of the runtime state database file. Read-only at runtime because DB opens before overrides are loaded.',
+      defaultValue: '~/.config/night-orch/state.db',
+      yamlPath: ['storage', 'dbPath'],
+      minLength: 1,
+      mutable: false,
+    }),
+    stringSetting({
+      key: 'storage.worktreeRoot',
+      label: 'Worktree Root',
+      description: 'Root directory used for issue worktrees.',
+      details: 'Base path where dedicated issue worktrees are created.',
+      defaultValue: '~/code/.night-orch/worktrees',
+      yamlPath: ['storage', 'worktreeRoot'],
+      minLength: 1,
+    }),
+    stringSetting({
+      key: 'storage.logsRoot',
+      label: 'Logs Root',
+      description: 'Root directory used for run/session logs.',
+      details: 'Base path where runtime log files are written.',
+      defaultValue: '~/code/.night-orch/logs',
+      yamlPath: ['storage', 'logsRoot'],
+      minLength: 1,
+    }),
+    booleanSetting({
+      key: 'storage.autoCleanup.enabled',
+      label: 'Auto Cleanup Enabled',
+      description: 'Enable periodic cleanup jobs.',
+      details: 'When enabled, stale worktrees and old logs are cleaned up automatically on schedule.',
+      defaultValue: true,
+      yamlPath: ['storage', 'autoCleanup', 'enabled'],
+    }),
+    numberSetting({
+      key: 'storage.autoCleanup.intervalMinutes',
+      label: 'Auto Cleanup Interval (minutes)',
+      description: 'How often automatic cleanup runs.',
+      details: 'Interval between automatic cleanup runs.',
+      defaultValue: 60,
+      yamlPath: ['storage', 'autoCleanup', 'intervalMinutes'],
+      integer: true,
+      min: 1,
+      step: 5,
+    }),
+    numberSetting({
+      key: 'storage.retention.worktreeAgeDays',
+      label: 'Worktree Retention (days)',
+      description: 'Retention window for stale worktrees.',
+      details: 'Completed/error worktrees older than this threshold may be removed during cleanup.',
+      defaultValue: 7,
+      yamlPath: ['storage', 'retention', 'worktreeAgeDays'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'storage.retention.detailDays',
+      label: 'Detail Retention (days)',
+      description: 'Retention window for detailed run data.',
+      details: 'Detailed run artifacts are retained for this many days before archival/cleanup.',
+      defaultValue: 30,
+      yamlPath: ['storage', 'retention', 'detailDays'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'storage.retention.archiveDays',
+      label: 'Archive Retention (days)',
+      description: 'Retention window for archived run data.',
+      details: 'Archived records older than this threshold can be removed.',
+      defaultValue: 90,
+      yamlPath: ['storage', 'retention', 'archiveDays'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+
+    jsonSetting({
+      key: 'notifications.channels',
+      label: 'Notification Channels',
+      description: 'Configured notification channel list.',
+      details: 'Array of notification channel definitions (console/webhook/discord/smtp).',
+      defaultValue: [{ type: 'console' }],
+      yamlPath: ['notifications', 'channels'],
+      normalize: (value) => validateJsonSettingShape(value, NotificationsChannelsOverrideSchema, 'notifications.channels'),
+    }),
+
+    booleanSetting({
+      key: 'notifications.events.onRunStarted',
+      label: 'Notify: Run Started',
+      description: 'Send notifications when runs start.',
+      details: 'Controls whether run-started notifications are dispatched.',
+      defaultValue: false,
+      yamlPath: ['notifications', 'events', 'onRunStarted'],
+    }),
+    booleanSetting({
+      key: 'notifications.events.onBlocked',
+      label: 'Notify: Blocked',
+      description: 'Send notifications when runs become blocked.',
+      details: 'Controls whether blocked-run notifications are dispatched.',
+      defaultValue: true,
+      yamlPath: ['notifications', 'events', 'onBlocked'],
+    }),
+    booleanSetting({
+      key: 'notifications.events.onPrReady',
+      label: 'Notify: PR Ready',
+      description: 'Send notifications when PRs are ready.',
+      details: 'Controls whether ready-for-review PR notifications are dispatched.',
+      defaultValue: true,
+      yamlPath: ['notifications', 'events', 'onPrReady'],
+    }),
+    booleanSetting({
+      key: 'notifications.events.onPrUpdated',
+      label: 'Notify: PR Updated',
+      description: 'Send notifications when PRs are updated.',
+      details: 'Controls whether PR update notifications are dispatched.',
+      defaultValue: true,
+      yamlPath: ['notifications', 'events', 'onPrUpdated'],
+    }),
+    booleanSetting({
+      key: 'notifications.events.onError',
+      label: 'Notify: Error',
+      description: 'Send notifications on orchestration errors.',
+      details: 'Controls whether error notifications are dispatched.',
+      defaultValue: true,
+      yamlPath: ['notifications', 'events', 'onError'],
+    }),
+    booleanSetting({
+      key: 'notifications.events.onRetryExhausted',
+      label: 'Notify: Retry Exhausted',
+      description: 'Send notifications when retries are exhausted.',
+      details: 'Controls whether retry-exhausted notifications are dispatched.',
+      defaultValue: true,
+      yamlPath: ['notifications', 'events', 'onRetryExhausted'],
+    }),
+
+    numberSetting({
+      key: 'loop.maxReviewIterations',
+      label: 'Max Review Iterations',
+      description: 'Maximum review correction loops per run.',
+      details: 'Limits how many review-fix-review cycles a run can execute before stopping.',
+      defaultValue: 4,
+      yamlPath: ['loop', 'maxReviewIterations'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'loop.maxTotalAgentPasses',
+      label: 'Max Total Agent Passes',
+      description: 'Hard cap on planner/coder/reviewer passes in one run.',
+      details: 'Caps total planner/coder/reviewer passes across the full run.',
+      defaultValue: 10,
+      yamlPath: ['loop', 'maxTotalAgentPasses'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+    booleanSetting({
+      key: 'loop.stopOnPlannerFailure',
+      label: 'Stop On Planner Failure',
+      description: 'Stop run when planner output fails validation.',
+      details: 'If enabled, planner failure ends the run early instead of proceeding.',
+      defaultValue: true,
+      yamlPath: ['loop', 'stopOnPlannerFailure'],
+    }),
+    booleanSetting({
+      key: 'loop.requireVerificationPass',
+      label: 'Require Verification Pass',
+      description: 'Require verify commands to pass before completion.',
+      details: 'If enabled, failed verification blocks completion.',
+      defaultValue: true,
+      yamlPath: ['loop', 'requireVerificationPass'],
+    }),
+    stringSetting({
+      key: 'loop.reviewApprovalKeyword',
+      label: 'Review Approval Keyword',
+      description: 'Reviewer keyword interpreted as approval.',
+      details: 'Expected keyword emitted by reviewer agent for approval.',
+      defaultValue: 'APPROVED',
+      yamlPath: ['loop', 'reviewApprovalKeyword'],
+      minLength: 1,
+    }),
+    stringSetting({
+      key: 'loop.reviewNeedsChangesKeyword',
+      label: 'Review Needs-Changes Keyword',
+      description: 'Reviewer keyword interpreted as changes required.',
+      details: 'Expected keyword emitted by reviewer agent for change requests.',
+      defaultValue: 'CHANGES_REQUIRED',
+      yamlPath: ['loop', 'reviewNeedsChangesKeyword'],
+      minLength: 1,
+    }),
+    booleanSetting({
+      key: 'loop.blockOnAmbiguousReview',
+      label: 'Block On Ambiguous Review',
+      description: 'Block run if review output is ambiguous.',
+      details: 'If enabled, unparseable reviewer output results in blocked status.',
+      defaultValue: true,
+      yamlPath: ['loop', 'blockOnAmbiguousReview'],
+    }),
+    numberSetting({
+      key: 'loop.maxAutoRetries',
+      label: 'Max Auto Retries',
+      description: 'Automatic retry attempts for infrastructure failures.',
+      details: 'Maximum number of automatic retries after transient failures.',
+      defaultValue: 3,
+      yamlPath: ['loop', 'maxAutoRetries'],
+      integer: true,
+      min: 0,
+      step: 1,
+    }),
+    booleanSetting({
+      key: 'loop.decompose',
+      label: 'Enable Decomposition',
+      description: 'Allow issue decomposition into sub-tasks.',
+      details: 'If enabled, eligible issues can be split into dependent sub-tasks.',
+      defaultValue: false,
+      yamlPath: ['loop', 'decompose'],
+    }),
+    numberSetting({
+      key: 'loop.maxSubtasks',
+      label: 'Max Subtasks',
+      description: 'Maximum sub-tasks per decomposition.',
+      details: 'Upper bound for generated decomposition sub-tasks.',
+      defaultValue: 5,
+      yamlPath: ['loop', 'maxSubtasks'],
+      integer: true,
+      min: 1,
+      max: 10,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'loop.maxConcurrentSubtasks',
+      label: 'Max Concurrent Subtasks',
+      description: 'Maximum parallel sub-task executions.',
+      details: 'Upper bound for concurrently running sub-task worktrees.',
+      defaultValue: 3,
+      yamlPath: ['loop', 'maxConcurrentSubtasks'],
+      integer: true,
+      min: 1,
+      max: 10,
+      step: 1,
+    }),
+
+    numberSetting({
+      key: 'security.maxChangedFiles',
+      label: 'Max Changed Files',
+      description: 'Diff guard threshold for changed files.',
+      details: 'Runs are blocked when changed-file count exceeds this threshold.',
+      defaultValue: 50,
+      yamlPath: ['security', 'maxChangedFiles'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'security.maxChangedLines',
+      label: 'Max Changed Lines',
+      description: 'Diff guard threshold for changed lines.',
+      details: 'Runs are blocked when changed-line count exceeds this threshold.',
+      defaultValue: 5000,
+      yamlPath: ['security', 'maxChangedLines'],
+      integer: true,
+      min: 1,
+      step: 50,
+    }),
+    numberSetting({
+      key: 'security.maxDailyCostUsd',
+      label: 'Daily Cost Budget (USD)',
+      description: 'Maximum allowed spend per UTC day before new runs are blocked.',
+      details: 'Sets the global daily spend cap for pay-per-use mode.',
+      defaultValue: 50,
+      yamlPath: ['security', 'maxDailyCostUsd'],
+      integer: false,
+      min: 0.01,
+      step: 1,
+    }),
+    numberSetting({
+      key: 'security.maxCostPerRunUsd',
+      label: 'Per-Run Cost Budget (USD)',
+      description: 'Maximum allowed spend for a single run before it is blocked.',
+      details: 'Sets the per-issue run cost ceiling for pay-per-use mode.',
+      defaultValue: 10,
+      yamlPath: ['security', 'maxCostPerRunUsd'],
+      integer: false,
+      min: 0.01,
+      step: 0.5,
+    }),
+
+    stringSetting({
+      key: 'cost.model',
+      label: 'Cost Model',
+      description: 'Cost enforcement model.',
+      details: 'pay-per-use enforces spend caps; subscription treats USD as advisory.',
+      defaultValue: 'pay-per-use',
+      yamlPath: ['cost', 'model'],
+      options: ['pay-per-use', 'subscription'],
+    }),
+    stringSetting({
+      key: 'cost.pricing.defaultModel',
+      label: 'Default Pricing Model',
+      description: 'Fallback model key for pricing lookups.',
+      details: 'Used when a worker profile does not specify a pricing model.',
+      defaultValue: 'default',
+      yamlPath: ['cost', 'pricing', 'defaultModel'],
+      minLength: 1,
+    }),
+    jsonSetting({
+      key: 'cost.pricing.models',
+      label: 'Pricing Models Map',
+      description: 'Model-specific pricing table.',
+      details: 'Record keyed by model name with token/minute pricing values.',
+      defaultValue: {},
+      yamlPath: ['cost', 'pricing', 'models'],
+      normalize: (value) => validateJsonSettingShape(value, CostPricingModelsOverrideSchema, 'cost.pricing.models'),
+    }),
+
+    jsonSetting({
+      key: 'workerProfiles',
+      label: 'Worker Profiles',
+      description: 'Global worker profile definitions.',
+      details: 'Record of worker profile definitions keyed by profile name.',
+      defaultValue: {},
+      yamlPath: ['workerProfiles'],
+      sensitive: true,
+      normalize: (value) => validateJsonSettingShape(value, WorkerProfilesOverrideSchema, 'workerProfiles'),
+      sanitizeForDisplay: (value) => redactWorkerProfiles(value),
+    }),
+
+    booleanSetting({
+      key: 'metrics.enabled',
+      label: 'Metrics Enabled',
+      description: 'Enable Prometheus metrics export.',
+      details: 'Turns `/metrics` export on or off.',
+      defaultValue: true,
+      yamlPath: ['metrics', 'enabled'],
+    }),
+    numberSetting({
+      key: 'metrics.port',
+      label: 'Metrics Port',
+      description: 'TCP port for Prometheus metrics endpoint.',
+      details: 'Port used when metrics exporter is enabled.',
+      defaultValue: 9090,
+      yamlPath: ['metrics', 'port'],
+      integer: true,
+      min: 1,
+      max: 65535,
+      step: 1,
+    }),
+    stringSetting({
+      key: 'metrics.host',
+      label: 'Metrics Host',
+      description: 'Bind address for Prometheus metrics endpoint.',
+      details: 'Network interface/address used by metrics exporter.',
+      defaultValue: '0.0.0.0',
+      yamlPath: ['metrics', 'host'],
+      minLength: 1,
+    }),
+
+    booleanSetting({
+      key: 'observability.agentStreaming',
+      label: 'Agent Streaming',
+      description: 'Enable in-flight agent event streaming to TUI/Web.',
+      details: 'Turns live agent event streaming on or off for terminal and web views.',
+      defaultValue: true,
+      yamlPath: ['observability', 'agentStreaming'],
+    }),
+    numberSetting({
+      key: 'observability.eventRetention',
+      label: 'Event Retention',
+      description: 'Maximum in-memory event backlog per run/session.',
+      details: 'Controls event retention window for stream history.',
+      defaultValue: 1000,
+      yamlPath: ['observability', 'eventRetention'],
+      integer: true,
+      min: 100,
+      max: 10000,
+      step: 100,
+    }),
+    booleanSetting({
+      key: 'observability.sessionLogs',
+      label: 'Session Logs Enabled',
+      description: 'Persist interactive agent session logs to disk.',
+      details: 'If enabled, interactive session logs are written and retained.',
+      defaultValue: true,
+      yamlPath: ['observability', 'sessionLogs'],
+    }),
+    numberSetting({
+      key: 'observability.sessionLogRetention',
+      label: 'Session Log Retention (days)',
+      description: 'Retention period for interactive session logs.',
+      details: 'Session logs older than this many days may be deleted by cleanup.',
+      defaultValue: 7,
+      yamlPath: ['observability', 'sessionLogRetention'],
+      integer: true,
+      min: 1,
+      step: 1,
+    }),
+
+    booleanSetting({
+      key: 'mcp.enabled',
+      label: 'MCP Enabled',
+      description: 'Enable MCP server exposure.',
+      details: 'Turns MCP server availability on or off for applicable commands/modes.',
+      defaultValue: false,
+      yamlPath: ['mcp', 'enabled'],
+    }),
+    stringSetting({
+      key: 'mcp.transport',
+      label: 'MCP Transport',
+      description: 'Transport protocol used by MCP server.',
+      details: 'Currently only stdio transport is supported.',
+      defaultValue: 'stdio',
+      yamlPath: ['mcp', 'transport'],
+      options: ['stdio'],
+    }),
+    stringSetting({
+      key: 'mcp.authTokenEnv',
+      label: 'MCP Auth Token Env Var',
+      description: 'Optional env var name containing MCP mutation auth token.',
+      details: 'Set to null (or clear in YAML) to disable MCP mutation token checks.',
+      defaultValue: null,
+      yamlPath: ['mcp', 'authTokenEnv'],
+      allowNull: true,
+      minLength: 1,
+    }),
+    numberSetting({
+      key: 'mcp.httpPort',
+      label: 'MCP HTTP Port',
+      description: 'TCP port for embedded MCP HTTP transport.',
+      details: 'Port used when running embedded MCP HTTP/SSE mode.',
+      defaultValue: 3100,
+      yamlPath: ['mcp', 'httpPort'],
+      integer: true,
+      min: 1,
+      max: 65535,
+      step: 1,
+    }),
+    stringSetting({
+      key: 'mcp.httpHost',
+      label: 'MCP HTTP Host',
+      description: 'Bind address for embedded MCP HTTP transport.',
+      details: 'Network interface/address used for MCP HTTP endpoint binding.',
+      defaultValue: '127.0.0.1',
+      yamlPath: ['mcp', 'httpHost'],
+      minLength: 1,
+    }),
+
+    booleanSetting({
+      key: 'commentCommands.enabled',
+      label: 'Comment Commands Enabled',
+      description: 'Enable issue comment command processing.',
+      details: 'If enabled, `/orch` comment commands are parsed and processed.',
+      defaultValue: true,
+      yamlPath: ['commentCommands', 'enabled'],
+    }),
+    booleanSetting({
+      key: 'commentCommands.requireCollaborator',
+      label: 'Require Collaborator For Commands',
+      description: 'Require collaborator permission for comment commands.',
+      details: 'When enabled, only collaborators can run issue comment commands.',
+      defaultValue: true,
+      yamlPath: ['commentCommands', 'requireCollaborator'],
+    }),
+    jsonSetting({
+      key: 'workflows',
+      label: 'Workflow Definitions',
+      description: 'Named workflow definitions.',
+      details: 'Record of named workflow graphs (steps/roles/agents) used by workflow selection.',
+      defaultValue: {},
+      yamlPath: ['workflows'],
+      normalize: (value) => validateJsonSettingShape(value, WorkflowsOverrideSchema, 'workflows'),
+    }),
+  ]
+
+  const entries = new Map<string, SettingDefinition>()
+  for (const definition of definitions) {
+    if (entries.has(definition.key)) {
+      throw new Error(`Duplicate runtime setting key: ${definition.key}`)
+    }
+    entries.set(definition.key, definition)
+  }
+
+  return Object.fromEntries(entries)
+}
+
+interface NumberSettingOptions {
+  key: string
+  label: string
+  description: string
+  details: string
+  defaultValue: number
+  yamlPath: SettingPath
+  integer: boolean
+  min?: number
+  max?: number
+  step?: number
+  mutable?: boolean
+  sensitive?: boolean
+  sanitizeForDisplay?: (value: number) => SettingValue
+}
+
+function numberSetting(options: NumberSettingOptions): NumberSettingDefinition {
+  return {
+    key: options.key,
+    label: options.label,
+    description: options.description,
+    details: options.details,
+    type: 'number',
+    mutable: options.mutable ?? true,
+    sensitive: options.sensitive ?? false,
+    defaultValue: options.defaultValue,
+    yamlPath: options.yamlPath,
+    ...(options.min !== undefined ? { min: options.min } : {}),
+    ...(options.max !== undefined ? { max: options.max } : {}),
+    ...(options.step !== undefined ? { step: options.step } : {}),
+    read: (config) => readNumberValue(config, options.yamlPath, options.defaultValue),
+    apply: (config, value) => setConfigValue(config, options.yamlPath, value),
+    parseInput: (raw) => parseNumberInput(raw, {
+      key: options.key,
+      integer: options.integer,
+      min: options.min,
+      max: options.max,
+    }),
+    parseStored: (raw) => parseStoredNumber(raw, {
+      key: options.key,
+      integer: options.integer,
+      min: options.min,
+      max: options.max,
+    }),
+    serialize: (value) => JSON.stringify(value),
+    sanitizeForDisplay: options.sanitizeForDisplay ?? identitySanitize,
+  }
+}
+
+interface BooleanSettingOptions {
+  key: string
+  label: string
+  description: string
+  details: string
+  defaultValue: boolean
+  yamlPath: SettingPath
+  mutable?: boolean
+  sensitive?: boolean
+  sanitizeForDisplay?: (value: boolean) => SettingValue
+}
+
+function booleanSetting(options: BooleanSettingOptions): BooleanSettingDefinition {
+  return {
+    key: options.key,
+    label: options.label,
+    description: options.description,
+    details: options.details,
+    type: 'boolean',
+    mutable: options.mutable ?? true,
+    sensitive: options.sensitive ?? false,
+    defaultValue: options.defaultValue,
+    yamlPath: options.yamlPath,
+    read: (config) => readBooleanValue(config, options.yamlPath, options.defaultValue),
+    apply: (config, value) => setConfigValue(config, options.yamlPath, value),
+    parseInput: (raw) => parseBooleanInput(raw, options.key),
+    parseStored: (raw) => parseStoredBoolean(raw, options.key),
+    serialize: (value) => JSON.stringify(value),
+    sanitizeForDisplay: options.sanitizeForDisplay ?? identitySanitize,
+  }
+}
+
+interface StringSettingOptions {
+  key: string
+  label: string
+  description: string
+  details: string
+  defaultValue: string | null
+  yamlPath: SettingPath
+  options?: readonly string[]
+  allowNull?: boolean
+  minLength?: number
+  url?: boolean
+  validate?: (value: string) => string | null
+  mutable?: boolean
+  sensitive?: boolean
+  sanitizeForDisplay?: (value: string | null) => SettingValue
+}
+
+function stringSetting(options: StringSettingOptions): StringSettingDefinition {
+  return {
+    key: options.key,
+    label: options.label,
+    description: options.description,
+    details: options.details,
+    type: 'string',
+    mutable: options.mutable ?? true,
+    sensitive: options.sensitive ?? false,
+    defaultValue: options.defaultValue,
+    yamlPath: options.yamlPath,
+    ...(options.options ? { options: options.options } : {}),
+    ...(options.allowNull ? { allowNull: true } : {}),
+    read: (config) => readStringValue(config, options.yamlPath, options.defaultValue, options.allowNull ?? false),
+    apply: (config, value) => setConfigValue(config, options.yamlPath, value),
+    parseInput: (raw) => parseStringInput(raw, {
+      key: options.key,
+      allowNull: options.allowNull,
+      options: options.options,
+      minLength: options.minLength,
+      url: options.url,
+      validate: options.validate,
+    }),
+    parseStored: (raw) => parseStoredString(raw, {
+      key: options.key,
+      allowNull: options.allowNull,
+      options: options.options,
+      minLength: options.minLength,
+      url: options.url,
+      validate: options.validate,
+    }),
+    serialize: (value) => JSON.stringify(value),
+    sanitizeForDisplay: options.sanitizeForDisplay ?? identitySanitize,
+  }
+}
+
+interface JsonSettingOptions {
+  key: string
+  label: string
+  description: string
+  details: string
+  defaultValue: JsonValue
+  yamlPath: SettingPath
+  mutable?: boolean
+  sensitive?: boolean
+  normalize?: (value: JsonValue) => JsonValue
+  sanitizeForDisplay?: (value: JsonValue) => SettingValue
+}
+
+function jsonSetting(options: JsonSettingOptions): JsonSettingDefinition {
+  return {
+    key: options.key,
+    label: options.label,
+    description: options.description,
+    details: options.details,
+    type: 'json',
+    mutable: options.mutable ?? true,
+    sensitive: options.sensitive ?? false,
+    defaultValue: options.defaultValue,
+    yamlPath: options.yamlPath,
+    read: (config) => readJsonValue(config, options.yamlPath, options.defaultValue),
+    apply: (config, value) => setConfigValue(config, options.yamlPath, value),
+    parseInput: (raw) => {
+      const parsed = parseJsonInput(raw, options.key)
+      return options.normalize ? options.normalize(parsed) : parsed
+    },
+    parseStored: (raw) => {
+      const parsed = parseStoredJson(raw, options.key)
+      return options.normalize ? options.normalize(parsed) : parsed
+    },
+    serialize: (value) => JSON.stringify(value),
+    sanitizeForDisplay: options.sanitizeForDisplay ?? identitySanitize,
+  }
+}
+
 function parseNumberInput(
   raw: unknown,
-  options: { key: SettingKey; integer: boolean; min: number; max: number },
+  options: { key: string; integer: boolean; min?: number; max?: number },
 ): number {
   const parsed = typeof raw === 'number'
     ? raw
@@ -277,7 +848,7 @@ function parseNumberInput(
 
 function parseStoredNumber(
   raw: string,
-  options: { key: SettingKey; integer: boolean; min: number; max: number },
+  options: { key: string; integer: boolean; min?: number; max?: number },
 ): number {
   try {
     const parsed = JSON.parse(raw) as unknown
@@ -292,7 +863,7 @@ function parseStoredNumber(
 
 function validateNumber(
   value: number,
-  options: { key: SettingKey; integer: boolean; min: number; max: number },
+  options: { key: string; integer: boolean; min?: number; max?: number },
 ): number {
   if (!Number.isFinite(value)) {
     throw new Error(`${options.key} must be a finite number`)
@@ -302,8 +873,12 @@ function validateNumber(
     throw new Error(`${options.key} must be an integer`)
   }
 
-  if (value < options.min || value > options.max) {
-    throw new Error(`${options.key} must be between ${options.min} and ${options.max}`)
+  if (options.min !== undefined && value < options.min) {
+    throw new Error(`${options.key} must be >= ${options.min}`)
+  }
+
+  if (options.max !== undefined && value > options.max) {
+    throw new Error(`${options.key} must be <= ${options.max}`)
   }
 
   return value
@@ -323,7 +898,7 @@ function parseStrictNumberString(raw: string): number {
   return parsed
 }
 
-function parseBooleanInput(raw: unknown, key: SettingKey): boolean {
+function parseBooleanInput(raw: unknown, key: string): boolean {
   if (typeof raw === 'boolean') {
     return raw
   }
@@ -341,7 +916,7 @@ function parseBooleanInput(raw: unknown, key: SettingKey): boolean {
   throw new Error(`${key} must be true/false`)
 }
 
-function parseStoredBoolean(raw: string, key: SettingKey): boolean {
+function parseStoredBoolean(raw: string, key: string): boolean {
   try {
     const parsed = JSON.parse(raw) as unknown
     if (typeof parsed !== 'boolean') {
@@ -353,12 +928,207 @@ function parseStoredBoolean(raw: string, key: SettingKey): boolean {
   }
 }
 
-function buildDefaultObservability(config: Config): Config['observability'] {
+interface StringParseOptions {
+  key: string
+  allowNull?: boolean
+  options?: readonly string[]
+  minLength?: number
+  url?: boolean
+  validate?: (value: string) => string | null
+}
+
+function parseStringInput(raw: unknown, options: StringParseOptions): string | null {
+  if (raw === null) {
+    if (options.allowNull) {
+      return null
+    }
+    throw new Error(`${options.key} must be a string`)
+  }
+
+  if (typeof raw !== 'string') {
+    throw new Error(`${options.key} must be a string`)
+  }
+
+  if (options.allowNull && raw.trim().toLowerCase() === 'null') {
+    return null
+  }
+
+  const value = raw
+
+  if (options.minLength !== undefined && value.trim().length < options.minLength) {
+    throw new Error(`${options.key} must be at least ${options.minLength} character(s)`)
+  }
+
+  if (options.options && !options.options.includes(value)) {
+    throw new Error(`${options.key} must be one of: ${options.options.join(', ')}`)
+  }
+
+  if (options.url) {
+    try {
+      void new URL(value)
+    } catch {
+      throw new Error(`${options.key} must be a valid URL`)
+    }
+  }
+
+  const validationError = options.validate?.(value)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+
+  return value
+}
+
+function parseStoredString(raw: string, options: StringParseOptions): string | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'string' && parsed !== null) {
+      throw new Error(`Stored value for ${options.key} is not string/null`)
+    }
+    return parseStringInput(parsed, options)
+  } catch (err) {
+    throw new Error(`Invalid stored value for ${options.key}: ${(err as Error).message}`)
+  }
+}
+
+function parseJsonInput(raw: unknown, key: string): JsonValue {
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (!isJsonValue(parsed)) {
+        throw new Error('must be valid JSON')
+      }
+      return parsed
+    } catch (err) {
+      throw new Error(`${key} must be valid JSON: ${(err as Error).message}`)
+    }
+  }
+
+  if (!isJsonValue(raw)) {
+    throw new Error(`${key} must be valid JSON`)
+  }
+
+  return raw
+}
+
+function parseStoredJson(raw: string, key: string): JsonValue {
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!isJsonValue(parsed)) {
+      throw new Error(`Stored value for ${key} is not valid JSON`)
+    }
+    return parsed
+  } catch (err) {
+    throw new Error(`Invalid stored value for ${key}: ${(err as Error).message}`)
+  }
+}
+
+function validateJsonSettingShape<T>(value: JsonValue, schema: z.ZodType<T>, key: string): JsonValue {
+  const result = schema.safeParse(value)
+  if (result.success) {
+    return result.data as JsonValue
+  }
+
+  const issue = result.error.issues[0]
+  const path = issue?.path.length ? issue.path.join('.') : key
+  const message = issue?.message ?? 'invalid structure'
+  throw new Error(`${key} has invalid structure (${path}): ${message}`)
+}
+
+function identitySanitize<T extends SettingValue>(value: T): T {
+  return value
+}
+
+function redactWorkerProfiles(value: JsonValue): JsonValue {
+  if (!isRecord(value)) {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([profileName, profile]) => {
+      if (!isRecord(profile) || !isRecord(profile['env'])) {
+        return [profileName, profile]
+      }
+
+      const redactedEnv = Object.fromEntries(
+        Object.keys(profile['env']).map((envKey) => [envKey, '[redacted]']),
+      )
+      return [profileName, { ...profile, env: redactedEnv }]
+    }),
+  )
+}
+
+function readNumberValue(config: Config, path: SettingPath, fallback: number): number {
+  const value = readPathValue(config, path)
+  return typeof value === 'number' ? value : fallback
+}
+
+function readBooleanValue(config: Config, path: SettingPath, fallback: boolean): boolean {
+  const value = readPathValue(config, path)
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function readStringValue(
+  config: Config,
+  path: SettingPath,
+  fallback: string | null,
+  allowNull: boolean,
+): string | null {
+  const value = readPathValue(config, path)
+  if (typeof value === 'string') {
+    return value
+  }
+  if (allowNull && value === null) {
+    return null
+  }
+  return fallback
+}
+
+function readJsonValue(config: Config, path: SettingPath, fallback: JsonValue): JsonValue {
+  const value = readPathValue(config, path)
+  return isJsonValue(value) ? value : fallback
+}
+
+function setConfigValue(config: Config, path: SettingPath, value: unknown): Config {
+  return setPathValue(config, path, value) as Config
+}
+
+function readPathValue(source: unknown, path: readonly string[]): unknown {
+  let current: unknown = source
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return undefined
+    }
+    current = current[segment]
+  }
+  return current
+}
+
+function setPathValue(
+  source: unknown,
+  path: readonly string[],
+  value: unknown,
+): Record<string, unknown> {
+  if (path.length === 0) {
+    return isRecord(source) ? { ...source } : {}
+  }
+
+  const [segment, ...rest] = path
+  if (segment === undefined) {
+    return isRecord(source) ? { ...source } : {}
+  }
+  const current = isRecord(source) ? source : {}
+
+  if (rest.length === 0) {
+    return {
+      ...current,
+      [segment]: value,
+    }
+  }
+
   return {
-    agentStreaming: config.observability?.agentStreaming ?? true,
-    eventRetention: config.observability?.eventRetention ?? 1000,
-    sessionLogs: config.observability?.sessionLogs ?? true,
-    sessionLogRetention: config.observability?.sessionLogRetention ?? 7,
+    ...current,
+    [segment]: setPathValue(current[segment], rest, value),
   }
 }
 
@@ -380,4 +1150,25 @@ function hasValueAtPath(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return true
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => isJsonValue(entry))
+  }
+
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return Object.values(value).every((entry) => isJsonValue(entry))
 }

--- a/src/settings/runtime.ts
+++ b/src/settings/runtime.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js'
 import {
   getSettingDefinition,
   listSettingDefinitions,
+  sanitizeSettingValueForDisplay,
   type SettingDefinition,
   type SettingKey,
   type SettingType,
@@ -17,10 +18,14 @@ export interface RuntimeSettingSnapshot {
   description: string
   details: string
   type: SettingType
+  mutable: boolean
+  sensitive: boolean
   min?: number
   max?: number
   step?: number
-  defaultValue: SettingValue
+  options?: string[]
+  allowNull?: boolean
+  defaultValue: SettingValue | null
   baseValue: SettingValue
   overrideValue: SettingValue | null
   effectiveValue: SettingValue
@@ -57,8 +62,13 @@ export function listRuntimeSettings(
   return listSettingDefinitions().map((definition) => {
     const override = parsedOverrides.get(definition.key)
     const baseValue = definition.read(baseConfig)
-    const overrideValue = override?.value ?? null
-    const effectiveValue = overrideValue ?? baseValue
+    const hasOverride = override !== undefined
+    const overrideValue = hasOverride ? override.value : null
+    const effectiveValue = hasOverride ? override.value : baseValue
+    const displayDefaultValue = sanitizeSettingValueForDisplay(definition, definition.defaultValue)
+    const displayBaseValue = sanitizeSettingValueForDisplay(definition, baseValue)
+    const displayOverrideValue = sanitizeSettingValueForDisplay(definition, overrideValue)
+    const displayEffectiveValue = sanitizeSettingValueForDisplay(definition, effectiveValue)
 
     return {
       key: definition.key,
@@ -66,6 +76,8 @@ export function listRuntimeSettings(
       description: definition.description,
       details: definition.details,
       type: definition.type,
+      mutable: definition.mutable,
+      sensitive: definition.sensitive,
       ...(definition.type === 'number'
         ? {
             ...(definition.min !== undefined ? { min: definition.min } : {}),
@@ -73,11 +85,17 @@ export function listRuntimeSettings(
             ...(definition.step !== undefined ? { step: definition.step } : {}),
           }
         : {}),
-      defaultValue: definition.defaultValue,
-      baseValue,
-      overrideValue,
-      effectiveValue,
-      source: overrideValue === null ? 'base' : 'override',
+      ...(definition.type === 'string'
+        ? {
+            ...(definition.options ? { options: [...definition.options] } : {}),
+            ...(definition.allowNull ? { allowNull: true } : {}),
+          }
+        : {}),
+      defaultValue: displayDefaultValue,
+      baseValue: displayBaseValue,
+      overrideValue: displayOverrideValue,
+      effectiveValue: displayEffectiveValue,
+      source: hasOverride ? 'override' : 'base',
       updatedBy: override?.row.updatedBy ?? null,
       updatedAt: override?.row.updatedAt ?? null,
     }
@@ -99,7 +117,16 @@ export function resolveConfigWithRuntimeSettings(
       effectiveConfig = definition.apply(effectiveConfig, override.value)
       continue
     }
-    if (typeof override.value !== 'boolean') continue
+    if (definition.type === 'boolean') {
+      if (typeof override.value !== 'boolean') continue
+      effectiveConfig = definition.apply(effectiveConfig, override.value)
+      continue
+    }
+    if (definition.type === 'string') {
+      if (typeof override.value !== 'string' && override.value !== null) continue
+      effectiveConfig = definition.apply(effectiveConfig, override.value)
+      continue
+    }
     effectiveConfig = definition.apply(effectiveConfig, override.value)
   }
 
@@ -114,9 +141,18 @@ export function setRuntimeSettingOverride(
   updatedBy: string | null = null,
 ): RuntimeSettingMutationResult {
   const definition = requireSettingDefinition(key)
+  if (!definition.mutable) {
+    throw new RuntimeSettingInputError(`${definition.key} is read-only at runtime and cannot be overridden`)
+  }
   let serialized: string
   try {
     if (definition.type === 'number') {
+      const parsedValue = definition.parseInput(rawValue)
+      serialized = definition.serialize(parsedValue)
+    } else if (definition.type === 'boolean') {
+      const parsedValue = definition.parseInput(rawValue)
+      serialized = definition.serialize(parsedValue)
+    } else if (definition.type === 'string') {
       const parsedValue = definition.parseInput(rawValue)
       serialized = definition.serialize(parsedValue)
     } else {
@@ -152,6 +188,9 @@ export function clearRuntimeSettingOverride(
   key: string,
 ): RuntimeSettingMutationResult {
   const definition = requireSettingDefinition(key)
+  if (!definition.mutable) {
+    throw new RuntimeSettingInputError(`${definition.key} is read-only at runtime and cannot be overridden`)
+  }
   const store = new SettingOverrideStore(db)
   const changed = store.delete(definition.key)
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -26,7 +26,12 @@ import {
   type RuntimeSettingSnapshot,
   RuntimeSettingInputError,
 } from '../settings/runtime.js'
-import { getSettingDefinition, resolveSettingYamlValue, type SettingValue } from '../settings/registry.js'
+import {
+  getSettingDefinition,
+  resolveSettingYamlValue,
+  sanitizeSettingValueForDisplay,
+  type SettingValue,
+} from '../settings/registry.js'
 
 export interface WebServerOptions {
   host: string
@@ -1463,7 +1468,7 @@ function buildSettingsSnapshot(deps: MCPDependencies, rawConfig: unknown): Setti
       return {
         ...setting,
         hasYamlValue,
-        yamlValue,
+        yamlValue: sanitizeSettingValueForDisplay(definition, yamlValue),
       }
     }),
   }

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -68,7 +68,7 @@ describe('MCP Tools', () => {
 
   it('settings tools list/set/clear runtime overrides', async () => {
     const listedBefore = await handleToolCall('night-orch-list-settings', {}, deps) as {
-      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean | string | null }>
     }
     const pollSettingBefore = listedBefore.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
     expect(pollSettingBefore).toBeDefined()
@@ -85,7 +85,7 @@ describe('MCP Tools', () => {
     expect(setResult.setting.source).toBe('override')
 
     const listedAfter = await handleToolCall('night-orch-list-settings', {}, deps) as {
-      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean | string | null }>
     }
     const pollSettingAfter = listedAfter.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
     expect(pollSettingAfter?.effectiveValue).toBe(120)
@@ -100,6 +100,50 @@ describe('MCP Tools', () => {
     expect(clearResult.setting.key).toBe('github.pollIntervalSeconds')
     expect(clearResult.setting.effectiveValue).toBe(300)
     expect(clearResult.setting.source).toBe('base')
+  })
+
+  it('redacts sensitive worker profile env values in settings list output', async () => {
+    deps.config.workerProfiles = {
+      codexCli: {
+        type: 'codex',
+        command: 'codex',
+        args: ['exec'],
+        workerTimeoutSeconds: 900,
+        minimalEnv: true,
+        runtimeWrapper: null,
+        env: {
+          OPENAI_API_KEY: 'top-secret',
+          MODE: 'dev',
+        },
+      },
+    }
+
+    const listed = await handleToolCall('night-orch-list-settings', {}, deps) as {
+      settings: Array<{ key: string; effectiveValue: unknown }>
+    }
+    const workerProfiles = listed.settings.find((setting) => setting.key === 'workerProfiles')
+    expect(workerProfiles?.effectiveValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
+      },
+    })
+  })
+
+  it('rejects malformed json structures and read-only runtime setting mutations', async () => {
+    await expect(handleToolCall(
+      'night-orch-set-setting',
+      { key: 'notifications.channels', value: '{}' },
+      deps,
+    )).rejects.toThrow('notifications.channels has invalid structure')
+
+    await expect(handleToolCall(
+      'night-orch-set-setting',
+      { key: 'storage.dbPath', value: '/tmp/other.db' },
+      deps,
+    )).rejects.toThrow('storage.dbPath is read-only at runtime and cannot be overridden')
   })
 
   it('status tool returns summary', async () => {

--- a/test/settings/runtime.test.ts
+++ b/test/settings/runtime.test.ts
@@ -156,10 +156,12 @@ describe('runtime settings', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('lists curated settings with base values by default', () => {
+  it('lists non-project runtime settings with base values by default', () => {
     const settings = listRuntimeSettings(baseConfig, db)
-    expect(settings).toHaveLength(6)
+    expect(settings).toHaveLength(53)
     expect(settings.map((s) => s.key)).toContain('security.maxCostPerRunUsd')
+    expect(settings.map((s) => s.key)).toContain('github.tokenEnv')
+    expect(settings.map((s) => s.key)).toContain('workerProfiles')
 
     const poll = settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
     expect(poll).toMatchObject({
@@ -223,5 +225,108 @@ describe('runtime settings', () => {
         'test',
       )
     }).toThrow('security.maxDailyCostUsd must be a finite number')
+  })
+
+  it('supports nullable string overrides', () => {
+    const setResult = setRuntimeSettingOverride(
+      baseConfig,
+      db,
+      'mcp.authTokenEnv',
+      'MCP_TOKEN',
+      'test',
+    )
+    expect(setResult.changed).toBe(true)
+    expect(setResult.setting.effectiveValue).toBe('MCP_TOKEN')
+    expect(setResult.setting.source).toBe('override')
+
+    const nullResult = setRuntimeSettingOverride(
+      baseConfig,
+      db,
+      'mcp.authTokenEnv',
+      'null',
+      'test',
+    )
+    expect(nullResult.changed).toBe(true)
+    expect(nullResult.setting.effectiveValue).toBeNull()
+    expect(nullResult.setting.source).toBe('override')
+  })
+
+  it('redacts sensitive worker profile env values in runtime settings snapshots', () => {
+    baseConfig.workerProfiles = {
+      codexCli: {
+        type: 'codex',
+        command: 'codex',
+        args: ['exec'],
+        workerTimeoutSeconds: 900,
+        minimalEnv: true,
+        runtimeWrapper: null,
+        env: {
+          OPENAI_API_KEY: 'top-secret',
+          MODE: 'dev',
+        },
+      },
+    }
+
+    const settings = listRuntimeSettings(baseConfig, db)
+    const workerProfiles = settings.find((setting) => setting.key === 'workerProfiles')
+    expect(workerProfiles).toBeDefined()
+    expect(workerProfiles?.baseValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
+      },
+    })
+    expect(workerProfiles?.effectiveValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
+      },
+    })
+  })
+
+  it('rejects malformed JSON structure for json runtime settings', () => {
+    expect(() => {
+      setRuntimeSettingOverride(
+        baseConfig,
+        db,
+        'notifications.channels',
+        '{}',
+        'test',
+      )
+    }).toThrow('notifications.channels has invalid structure')
+
+    expect(() => {
+      setRuntimeSettingOverride(
+        baseConfig,
+        db,
+        'workerProfiles',
+        '{"codexCli":{"type":"codex"}}',
+        'test',
+      )
+    }).toThrow('workerProfiles has invalid structure')
+  })
+
+  it('marks storage.dbPath as read-only for runtime overrides', () => {
+    const settings = listRuntimeSettings(baseConfig, db)
+    const dbPath = settings.find((setting) => setting.key === 'storage.dbPath')
+    expect(dbPath?.mutable).toBe(false)
+
+    expect(() => {
+      setRuntimeSettingOverride(
+        baseConfig,
+        db,
+        'storage.dbPath',
+        '/tmp/alternate.db',
+        'test',
+      )
+    }).toThrow('storage.dbPath is read-only at runtime and cannot be overridden')
+
+    expect(() => {
+      clearRuntimeSettingOverride(baseConfig, db, 'storage.dbPath')
+    }).toThrow('storage.dbPath is read-only at runtime and cannot be overridden')
   })
 })

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -266,10 +266,10 @@ describe('startWebServer', () => {
       settings: Array<{
         key: string
         source: string
-        effectiveValue: number | boolean
-        defaultValue: number | boolean
+        effectiveValue: number | boolean | string | null
+        defaultValue: number | boolean | string | null
         hasYamlValue: boolean
-        yamlValue: number | boolean | null
+        yamlValue: number | boolean | string | null
       }>
     }
     const pollBefore = initialPayload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
@@ -307,7 +307,7 @@ describe('startWebServer', () => {
 
     const afterSet = await fetch(`${baseUrl}/api/settings`)
     const afterSetPayload = await afterSet.json() as {
-      settings: Array<{ key: string; source: string; effectiveValue: number | boolean }>
+      settings: Array<{ key: string; source: string; effectiveValue: number | boolean | string | null }>
     }
     const pollAfterSet = afterSetPayload.settings.find((setting) => setting.key === 'github.pollIntervalSeconds')
     expect(pollAfterSet?.source).toBe('override')
@@ -331,6 +331,93 @@ describe('startWebServer', () => {
         key: 'github.pollIntervalSeconds',
         effectiveValue: 300,
         source: 'base',
+      },
+    })
+  })
+
+  it('redacts sensitive worker profile env values in /api/settings', async () => {
+    deps.config.workerProfiles = {
+      codexCli: {
+        type: 'codex',
+        command: 'codex',
+        args: ['exec'],
+        workerTimeoutSeconds: 900,
+        minimalEnv: true,
+        runtimeWrapper: null,
+        env: {
+          OPENAI_API_KEY: 'top-secret',
+          MODE: 'dev',
+        },
+      },
+    }
+
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+        rawConfig: {
+          workerProfiles: {
+            codexCli: {
+              type: 'codex',
+              command: 'codex',
+              args: ['exec'],
+              workerTimeoutSeconds: 900,
+              minimalEnv: true,
+              runtimeWrapper: null,
+              env: {
+                OPENAI_API_KEY: 'top-secret',
+                MODE: 'dev',
+              },
+            },
+          },
+        },
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    const response = await fetch(`${baseUrl}/api/settings`)
+    expect(response.status).toBe(200)
+    const payload = await response.json() as {
+      settings: Array<{
+        key: string
+        hasYamlValue: boolean
+        yamlValue: unknown
+        baseValue: unknown
+        effectiveValue: unknown
+      }>
+    }
+
+    const workerProfiles = payload.settings.find((setting) => setting.key === 'workerProfiles')
+    expect(workerProfiles?.hasYamlValue).toBe(true)
+    expect(workerProfiles?.baseValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
+      },
+    })
+    expect(workerProfiles?.effectiveValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
+      },
+    })
+    expect(workerProfiles?.yamlValue).toMatchObject({
+      codexCli: {
+        env: {
+          OPENAI_API_KEY: '[redacted]',
+          MODE: '[redacted]',
+        },
       },
     })
   })
@@ -365,11 +452,11 @@ describe('startWebServer', () => {
     const payload = await response.json() as {
       settings: Array<{
         key: string
-        baseValue: number | boolean
-        effectiveValue: number | boolean
-        defaultValue: number | boolean
+        baseValue: number | boolean | string | null
+        effectiveValue: number | boolean | string | null
+        defaultValue: number | boolean | string | null
         hasYamlValue: boolean
-        yamlValue: number | boolean | null
+        yamlValue: number | boolean | string | null
       }>
     }
 
@@ -432,6 +519,40 @@ describe('startWebServer', () => {
     expect(invalidValueSet.status).toBe(400)
     await expect(invalidValueSet.json()).resolves.toMatchObject({
       error: 'github.pollIntervalSeconds must be a finite number',
+    })
+
+    const invalidJsonStructure = await fetch(`${baseUrl}/api/operations/settings/set`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'notifications.channels',
+        value: '{}',
+      }),
+    })
+    expect(invalidJsonStructure.status).toBe(400)
+    await expect(invalidJsonStructure.json()).resolves.toMatchObject({
+      error: expect.stringContaining('notifications.channels has invalid structure'),
+    })
+
+    const readOnlySet = await fetch(`${baseUrl}/api/operations/settings/set`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({
+        key: 'storage.dbPath',
+        value: '/tmp/other.db',
+      }),
+    })
+    expect(readOnlySet.status).toBe(400)
+    await expect(readOnlySet.json()).resolves.toMatchObject({
+      error: 'storage.dbPath is read-only at runtime and cannot be overridden',
     })
 
     const invalidKeyClear = await fetch(`${baseUrl}/api/operations/settings/clear`, {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ import {
   type InteractiveAgentSessionsSnapshot,
   type InteractiveAgentType,
   type ProjectsSnapshot,
+  type RuntimeSettingValue,
   type RunEvent,
   type SettingsSnapshot,
   type SessionResponse,
@@ -68,6 +69,15 @@ function decodeDetailId(value: string | null | undefined): string | null {
   } catch {
     return value
   }
+}
+
+function formatRuntimeSettingDraft(value: RuntimeSettingValue): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    return JSON.stringify(value)
+  }
+  return String(value)
 }
 
 export function App({
@@ -248,7 +258,7 @@ export function App({
     setSettingsSnapshot(payload)
     setSettingsDrafts(
       Object.fromEntries(
-        payload.settings.map((setting) => [setting.key, String(setting.effectiveValue)]),
+        payload.settings.map((setting) => [setting.key, formatRuntimeSettingDraft(setting.effectiveValue)]),
       ),
     )
   }, [])

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, useEffect, useMemo, useState } from 'react'
 import { ButtonWeb } from '../../../src/components/button/button.web.js'
 import { ModalWeb } from '../../../src/components/modal/modal.web.js'
-import type { RuntimeSettingSnapshot } from '../types/dashboard.js'
+import type { RuntimeSettingSnapshot, RuntimeSettingValue } from '../types/dashboard.js'
 
 interface SettingsPageProps {
   settings: RuntimeSettingSnapshot[]
@@ -40,6 +40,7 @@ export function SettingsPage({
   const selectedBusy = selectedSetting
     ? isSettingBusy(activeOperation, selectedSetting.key)
     : false
+  const selectedReadOnly = selectedSetting ? !selectedSetting.mutable : false
 
   useEffect(() => {
     setOverwriteEnabled(
@@ -65,7 +66,7 @@ export function SettingsPage({
         {isLoading ? (
           <p className="text-sm text-base-content/70">Loading settings…</p>
         ) : settings.length === 0 ? (
-          <p className="text-sm text-base-content/70">No curated settings available.</p>
+          <p className="text-sm text-base-content/70">No runtime settings available.</p>
         ) : (
           <ul className="mt-2 grid gap-3">
             {settings.map((setting) => (
@@ -86,6 +87,7 @@ export function SettingsPage({
                         >
                           {setting.source === 'override' ? 'overwritten' : 'default/yaml'}
                         </span>
+                        {!setting.mutable ? <span className="badge badge-xs badge-warning">read-only</span> : null}
                       </div>
                       <p className="mt-1 break-all font-mono text-[11px] text-base-content/55">{setting.key}</p>
                       <p className="mt-2 text-sm text-base-content/75">{setting.description}</p>
@@ -131,15 +133,20 @@ export function SettingsPage({
                 if (!selectedSetting) {
                   return
                 }
+                if (!selectedSetting.mutable) {
+                  return
+                }
                 if (selectedOverwriteEnabled) {
                   onApply(selectedSetting.key)
                   return
                 }
                 onClear(selectedSetting.key)
               }}
-              disabled={selectedBusy}
+              disabled={selectedBusy || selectedReadOnly}
             >
-              {selectedBusy
+              {selectedReadOnly
+                ? 'read-only'
+                : selectedBusy
                 ? 'saving...'
                 : selectedOverwriteEnabled
                   ? 'apply override'
@@ -176,7 +183,7 @@ export function SettingsPage({
                 type="checkbox"
                 className="checkbox checkbox-sm checkbox-info"
                 checked={selectedOverwriteEnabled}
-                disabled={selectedBusy}
+                disabled={selectedBusy || selectedReadOnly}
                 onChange={(event) => {
                   setOverwriteEnabled((current) => ({
                     ...current,
@@ -187,7 +194,9 @@ export function SettingsPage({
               <div>
                 <p className="text-sm font-medium text-base-content">Overwrite this value</p>
                 <p className="text-xs text-base-content/65">
-                  Disable to use YAML/default value. Enable to set a DB runtime override.
+                  {selectedSetting.mutable
+                    ? 'Disable to use YAML/default value. Enable to set a DB runtime override.'
+                    : 'This key is read-only at runtime and cannot be overridden from settings.'}
                 </p>
               </div>
             </label>
@@ -203,12 +212,12 @@ export function SettingsPage({
                   onChange={(event) => {
                     onDraftChange(selectedSetting.key, event.target.value)
                   }}
-                  disabled={!selectedOverwriteEnabled || selectedBusy}
+                  disabled={!selectedOverwriteEnabled || selectedBusy || selectedReadOnly}
                 >
                   <option value="true">true</option>
                   <option value="false">false</option>
                 </select>
-              ) : (
+              ) : selectedSetting.type === 'number' ? (
                 <input
                   className="input input-bordered w-full max-w-xs font-mono"
                   type="number"
@@ -219,7 +228,42 @@ export function SettingsPage({
                   onChange={(event) => {
                     onDraftChange(selectedSetting.key, event.target.value)
                   }}
-                  disabled={!selectedOverwriteEnabled || selectedBusy}
+                  disabled={!selectedOverwriteEnabled || selectedBusy || selectedReadOnly}
+                />
+              ) : selectedSetting.options && selectedSetting.options.length > 0 ? (
+                <select
+                  className="select select-bordered w-full max-w-xs font-mono"
+                  value={selectedDraft}
+                  onChange={(event) => {
+                    onDraftChange(selectedSetting.key, event.target.value)
+                  }}
+                  disabled={!selectedOverwriteEnabled || selectedBusy || selectedReadOnly}
+                >
+                  {selectedSetting.options.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                  {selectedSetting.allowNull ? (
+                    <option value="null">null</option>
+                  ) : null}
+                </select>
+              ) : selectedSetting.type === 'json' ? (
+                <textarea
+                  className="textarea textarea-bordered min-h-[160px] w-full font-mono text-xs"
+                  value={selectedDraft}
+                  onChange={(event) => {
+                    onDraftChange(selectedSetting.key, event.target.value)
+                  }}
+                  disabled={!selectedOverwriteEnabled || selectedBusy || selectedReadOnly}
+                />
+              ) : (
+                <input
+                  className="input input-bordered w-full max-w-xs font-mono"
+                  type="text"
+                  value={selectedDraft}
+                  onChange={(event) => {
+                    onDraftChange(selectedSetting.key, event.target.value)
+                  }}
+                  disabled={!selectedOverwriteEnabled || selectedBusy || selectedReadOnly}
                 />
               )}
             </div>
@@ -243,7 +287,13 @@ function isSettingBusy(activeOperation: string | null, key: string): boolean {
   return activeOperation === `setting:set:${key}` || activeOperation === `setting:clear:${key}`
 }
 
-function formatSettingValue(value: string | number | boolean): string {
+function formatSettingValue(value: RuntimeSettingValue): string {
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+    return JSON.stringify(value)
+  }
+  if (value === null) {
+    return 'null'
+  }
   if (typeof value === 'boolean') {
     return value ? 'true' : 'false'
   }

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -262,7 +262,15 @@ export interface SessionResponse {
   operationsEnabled?: boolean
 }
 
-export type RuntimeSettingType = 'number' | 'boolean'
+export type RuntimeSettingType = 'number' | 'boolean' | 'string' | 'json'
+
+export type RuntimeSettingValue =
+  | string
+  | number
+  | boolean
+  | null
+  | RuntimeSettingValue[]
+  | { [key: string]: RuntimeSettingValue }
 
 export interface RuntimeSettingSnapshot {
   key: string
@@ -270,15 +278,19 @@ export interface RuntimeSettingSnapshot {
   description: string
   details: string
   type: RuntimeSettingType
+  mutable: boolean
+  sensitive: boolean
   min?: number
   max?: number
   step?: number
-  defaultValue: number | boolean
+  options?: string[]
+  allowNull?: boolean
+  defaultValue: RuntimeSettingValue
   hasYamlValue: boolean
-  yamlValue: number | boolean | null
-  baseValue: number | boolean
-  overrideValue: number | boolean | null
-  effectiveValue: number | boolean
+  yamlValue: RuntimeSettingValue | null
+  baseValue: RuntimeSettingValue
+  overrideValue: RuntimeSettingValue | null
+  effectiveValue: RuntimeSettingValue
   source: 'base' | 'override'
   updatedBy: string | null
   updatedAt: string | null


### PR DESCRIPTION
Closes #142

## Plan
**Objective:** Register all non-project-specific config settings in the runtime settings registry so they appear in TUI, Web, and MCP settings surfaces

1. Add 'string' to SettingType and SettingValue unions in registry.ts. Add StringSettingDefinition interface (with optional 'options' field for enum-like constraints and optional 'maxLength'). Extend SettingKey union with all missing global scalar setting keys.
2. Register all missing settings in SETTING_DEFINITIONS. New number settings: security.maxChangedFiles (1-1000, step 1, default 50), security.maxChangedLines (100-100000, step 100, default 5000), loop.maxAutoRetries (0-10, step 1, default 3), loop.maxSubtasks (1-10, step 1, default 5), loop.maxConcurrentSubtasks (1-10, step 1, default 3), observability.eventRetention (100-10000, step 100, default 1000), observability.sessionLogRetention (1-90, step 1, default 7), metrics.port (1024-65535, step 1, default 9090), mcp.httpPort (1024-65535, step 1, default 3100). New boolean settings: loop.stopOnPlannerFailure (default true), loop.requireVerificationPass (default true), loop.blockOnAmbiguousReview (default true), loop.decompose (default false), observability.sessionLogs (default true), metrics.enabled (default true), mcp.enabled (default false), commentCommands.enabled (default true), commentCommands.requireCollaborator (default true). New string settings: loop.reviewApprovalKeyword (default 'APPROVED'), loop.reviewNeedsChangesKeyword (default 'CHANGES_REQUIRED'), metrics.host (default '0.0.0.0'), mcp.httpHost (default '127.0.0.1'), cost.model (options: ['pay-per-use', 'subscription'], default 'pay-per-use'). Add parseStringInput, parseStoredString, and serialize helpers for string settings.
3. Update RuntimeSettingSnapshot interface to include 'string' in type union and optional 'options' field for enum constraints. Update resolveConfigWithRuntimeSettings to handle string type. Update setRuntimeSettingOverride to handle string type branch.
4. Update web dashboard types: add 'string' to RuntimeSettingType union, add 'options' to RuntimeSettingSnapshot interface, add 'string' to value type unions (defaultValue, baseValue, overrideValue, effectiveValue, yamlValue).
5. Update SettingsPage.tsx web component to render string settings: for string with options use a <select> dropdown, for free-form strings use a <input type='text'>. The existing number/boolean branches need a third branch for type === 'string'.
6. Update TUI settings-view.tsx to format string values correctly in the display. Update TUI app.tsx: string settings with options should cycle through options on +/- or space; free-form strings should show a message directing users to CLI/MCP (TUI text input is impractical). Adjust the hint text to mention string settings.
7. Update existing tests for registry and runtime to cover new settings and string type support. Verify all new settings have correct read/apply/parse round-trips.
8. Run pnpm typecheck && pnpm lint && pnpm test to verify everything compiles and passes.

## Implementation
Implemented the review fixes for runtime settings hardening: added per-setting mutability/sensitivity metadata, made `storage.dbPath` runtime read-only, added key-specific structural validation for JSON settings (`github.appMentions`, `notifications.channels`, `cost.pricing.models`, `workerProfiles`, `workflows`), and redacted sensitive `workerProfiles.*.env` values across settings read surfaces (CLI/TUI/Web/MCP), including YAML-value reporting in `/api/settings`. Updated Settings UI/TUI behavior to reflect read-only keys, updated docs, and added regression tests for redaction, JSON-shape rejection, and read-only enforcement. Validation passed with `pnpm test test/settings/runtime.test.ts test/mcp/tools.test.ts test/web/server.test.ts`, `pnpm typecheck`, and `pnpm lint`.

**Changed files:**
- `src/config/schema.ts`
- `src/settings/registry.ts`
- `src/settings/runtime.ts`
- `src/web/server.ts`
- `web/src/types/dashboard.ts`
- `web/src/components/SettingsPage.tsx`
- `src/cli/tui/app.tsx`
- `src/cli/tui/settings-view.tsx`
- `src/cli/commands/settings.ts`
- `test/settings/runtime.test.ts`
- `test/mcp/tools.test.ts`
- `test/web/server.test.ts`
- `docs/CONFIGURATION.md`
- `docs/USAGE.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
The previously reported issues are resolved in this iteration: `workerProfiles` values are redacted on settings read surfaces, JSON settings are structurally validated per key before persistence/application, and `storage.dbPath` is now treated as read-only at runtime. Coverage was added in runtime, MCP, and web server tests for these paths. Verification run: `pnpm test test/settings/runtime.test.ts test/mcp/tools.test.ts test/web/server.test.ts`, `pnpm typecheck`, and `pnpm lint` all passed.

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex