### PR TITLE
[CHORE] Web - tunnel shell session to browser (night-orch / #150)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -372,7 +372,7 @@ Start the embedded web control surface. Serves the React/Tailwind frontend, a RE
 By default, `web` runs in attach mode: no poll loop, no metrics server, and no embedded MCP server are started in the web process. Manual web operations (`poll`, `sync`, `cleanup`, `retry`, `continue`, `rebase`, `delete entry`, runtime settings set/clear) remain available and execute in the web process.
 Use `--standalone` to run poller + metrics + embedded MCP in the same process as the web server.
 
-The web UI includes an **Agent** page for interactive Claude/Codex sessions that run in the configured worktree root (`storage.worktreeRoot`). Sessions stream output live over websocket and expose REST routes under `/api/agent/sessions` (create/list/detail/events/send-message/close).
+The web UI includes a **Shell** page for real browser terminal access backed by PTY sessions. Shells start in the current user's home directory (or a home subdirectory you choose), stream output live over websocket, and expose REST routes under `/api/shell/sessions` (create/list/detail/events/close).
 On narrow mobile viewports, the top-line dashboard metric cards render in a compact 2-column layout so the runs list stays the primary focus on the Issues page.
 
 Default bind is `127.0.0.1:3200`. Use `--host` / `--port` to change this (for example when reverse-proxying through Caddy or nginx). Use `--allowed-host` (repeatable) to permit additional Host/Origin values when proxying.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@octokit/rest": "^22.0.1",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "acpx": "^0.4.0",
     "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
@@ -56,6 +58,7 @@
     "execa": "^9.6.1",
     "ink": "^6.8.0",
     "nanoid": "^5.1.7",
+    "node-pty": "^1.1.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0",
     "prom-client": "^15.1.3",
@@ -82,6 +85,7 @@
     "daisyui": "^5.5.19",
     "eslint": "^9.20.0",
     "jsdom": "^29.0.1",
+    "node-gyp": "^12.2.0",
     "react-dom": "^19.2.4",
     "storybook": "^10.3.4",
     "tailwindcss": "^4.2.2",
@@ -109,7 +113,8 @@
     },
     "onlyBuiltDependencies": [
       "better-sqlite3",
-      "esbuild"
+      "esbuild",
+      "node-pty"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       acpx:
         specifier: ^0.4.0
         version: 0.4.0(zod@3.25.76)
@@ -44,6 +50,9 @@ importers:
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -117,6 +126,9 @@ importers:
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
+      node-gyp:
+        specifier: ^12.2.0
+        version: 12.2.0
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
@@ -609,6 +621,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
@@ -636,6 +652,10 @@ packages:
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -671,6 +691,18 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -1414,6 +1446,16 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1432,6 +1474,10 @@ packages:
     resolution: {integrity: sha512-JyMw9+loIEuy+jUyv7Irx+qNDhrL0ToR+wAfX3ucBACrSBfsWKFmGJWewH+c1gr+MuzTG1Jd/0kIM6/+ZL67OA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1621,6 +1667,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1667,6 +1717,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -1865,6 +1919,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1991,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
     engines: {node: '>= 16'}
@@ -2073,6 +2134,10 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2165,9 +2230,20 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -2294,6 +2370,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2477,6 +2557,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  make-fetch-happen@15.0.5:
+    resolution: {integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
@@ -2543,12 +2627,40 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
@@ -2583,8 +2695,24 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp@12.2.0:
+    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
@@ -2634,6 +2762,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2735,6 +2867,10 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
@@ -2976,6 +3112,18 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -2997,6 +3145,10 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -3108,6 +3260,10 @@ packages:
 
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -3406,6 +3562,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3451,6 +3612,13 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -3928,6 +4096,8 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@hono/node-server@1.19.11(hono@4.12.8)':
     dependencies:
       hono: 4.12.8
@@ -3948,6 +4118,10 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -3997,6 +4171,22 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@npmcli/agent@4.0.0':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.2.7
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.7.4
+
+  '@npmcli/redact@4.0.0': {}
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -4767,6 +4957,12 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
+  abbrev@4.0.0: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4789,6 +4985,8 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - zod
+
+  agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -4976,6 +5174,19 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 13.0.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5016,6 +5227,8 @@ snapshots:
   check-error@2.1.3: {}
 
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   cli-boxes@3.0.0: {}
 
@@ -5168,6 +5381,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
@@ -5331,6 +5546,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -5432,6 +5649,10 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fsevents@2.3.3:
     optional: true
 
@@ -5528,6 +5749,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5535,6 +5758,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@8.0.1: {}
 
@@ -5642,6 +5879,8 @@ snapshots:
   isbot@5.1.37: {}
 
   isexe@2.0.0: {}
+
+  isexe@4.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -5800,6 +6039,23 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  make-fetch-happen@15.0.5:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.0
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   mark.js@8.11.1: {}
 
   math-intrinsics@1.1.0: {}
@@ -5861,9 +6117,41 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
   minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mitt@3.0.1: {}
 
@@ -5885,7 +6173,32 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@7.1.1: {}
+
+  node-gyp@12.2.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 15.0.5
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.13
+      tinyglobby: 0.2.15
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
   node-releases@2.0.36: {}
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   npm-run-path@6.0.0:
     dependencies:
@@ -5941,6 +6254,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@7.0.4: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -6053,6 +6368,8 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  proc-log@6.1.0: {}
 
   process-warning@5.0.0: {}
 
@@ -6353,6 +6670,21 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -6366,6 +6698,10 @@ snapshots:
   speakingurl@14.0.1: {}
 
   split2@4.2.0: {}
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.3
 
   stack-utils@2.0.6:
     dependencies:
@@ -6493,6 +6829,14 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tdigest@0.1.2:
     dependencies:
@@ -6801,6 +7145,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -6831,6 +7179,10 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -15,6 +15,10 @@ import {
   type InteractiveAgentSessionEventList,
   type InteractiveAgentType,
 } from './agent-session.js'
+import {
+  ShellSessionManager,
+  type ShellSessionEventList,
+} from './shell-session.js'
 import { loadTuiStats } from '../state/stats.js'
 import { getBuildInfo } from '../utils/build-info.js'
 import { logger } from '../utils/logger.js'
@@ -39,8 +43,10 @@ export interface WebServerOptions {
 }
 
 interface WsClientState {
+  isAuthenticated: boolean
   runSubscriptions: Map<string, number>
   agentSessionSubscriptions: Map<string, number>
+  shellSessionSubscriptions: Map<string, number>
 }
 
 interface DashboardSnapshot {
@@ -214,6 +220,10 @@ type WebSocketCommand =
   | { type: 'unsubscribe-run-events'; runId: string }
   | { type: 'subscribe-agent-session-events'; sessionId: string; since?: number }
   | { type: 'unsubscribe-agent-session-events'; sessionId: string }
+  | { type: 'subscribe-shell-session-events'; sessionId: string; since?: number }
+  | { type: 'unsubscribe-shell-session-events'; sessionId: string }
+  | { type: 'shell-input'; sessionId: string; data: string }
+  | { type: 'shell-resize'; sessionId: string; cols: number; rows: number }
   | { type: 'refresh' }
 
 const ONE_MEGABYTE = 1024 * 1024
@@ -274,6 +284,7 @@ export async function startWebServer(
   const agentSessionManager = new InteractiveAgentSessionManager(deps.config, {
     workspacePath: resolveAgentSessionWorkspacePath(deps),
   })
+  const shellSessionManager = new ShellSessionManager()
   const frontendDistPath = resolveWebFrontendDistPath(options.frontendDistPath)
   const hasFrontendAssets = existsSync(resolve(frontendDistPath, 'index.html'))
 
@@ -305,6 +316,7 @@ export async function startWebServer(
           operationsEnabled,
           options.rawConfig,
           agentSessionManager,
+          shellSessionManager,
         )
         return
       }
@@ -358,14 +370,17 @@ export async function startWebServer(
     }
 
     wsServer.handleUpgrade(req, socket, head, (ws) => {
-      wsServer.emit('connection', ws)
+      wsServer.emit('connection', ws, req)
     })
   })
 
-  wsServer.on('connection', (ws) => {
+  wsServer.on('connection', (ws, req) => {
+    const isAuthenticated = resolveWebSocketAuthenticationState(req, security)
     const state: WsClientState = {
+      isAuthenticated,
       runSubscriptions: new Map(),
       agentSessionSubscriptions: new Map(),
+      shellSessionSubscriptions: new Map(),
     }
     clients.set(ws, state)
 
@@ -380,7 +395,7 @@ export async function startWebServer(
         sendWebsocket(ws, { type: 'error', error: 'Unsupported websocket payload type' })
         return
       }
-      void handleWsMessage(ws, state, decoded, deps, agentSessionManager)
+      void handleWsMessage(ws, state, decoded, deps, agentSessionManager, shellSessionManager)
     })
 
     ws.on('close', () => {
@@ -407,6 +422,7 @@ export async function startWebServer(
         if (ws.readyState !== WebSocket.OPEN) continue
         await publishRunSubscriptions(ws, state, deps)
         publishAgentSessionSubscriptions(ws, state, agentSessionManager)
+        publishShellSessionSubscriptions(ws, state, shellSessionManager)
       }
     } catch (err) {
       logger.warn({ err }, 'Failed to publish websocket snapshot tick')
@@ -427,9 +443,18 @@ export async function startWebServer(
       publishAgentSessionSubscriptions(ws, state, agentSessionManager)
     }
   })
+  const stopShellSessionStreaming = shellSessionManager.onSessionEvent((sessionId) => {
+    for (const [ws, state] of clients.entries()) {
+      if (ws.readyState !== WebSocket.OPEN) continue
+      if (!state.shellSessionSubscriptions.has(sessionId)) continue
+      publishShellSessionSubscriptions(ws, state, shellSessionManager)
+    }
+  })
 
   httpServer.on('close', () => {
     stopAgentSessionStreaming()
+    stopShellSessionStreaming()
+    shellSessionManager.closeAll()
     clearInterval(interval)
     for (const ws of wsServer.clients) {
       ws.close()
@@ -460,6 +485,7 @@ async function handleApiRequest(
   operationsEnabled: boolean,
   rawConfig: unknown,
   agentSessionManager: InteractiveAgentSessionManager,
+  shellSessionManager: ShellSessionManager,
 ): Promise<void> {
   const method = req.method ?? 'GET'
   const { pathname, searchParams } = requestUrl
@@ -468,8 +494,18 @@ async function handleApiRequest(
     config: resolveConfigWithRuntimeSettings(deps.config, deps.db),
   }
 
+  if (method === 'GET' && pathname.startsWith('/api/shell/')) {
+    const shellReadGuardFailure = validateShellReadRequest(req, security)
+    if (shellReadGuardFailure) {
+      writeJson(res, shellReadGuardFailure.statusCode, { error: shellReadGuardFailure.error })
+      return
+    }
+  }
+
   if ((method === 'POST' || method === 'DELETE')
-    && (pathname.startsWith('/api/operations/') || pathname.startsWith('/api/agent/'))) {
+    && (pathname.startsWith('/api/operations/')
+      || pathname.startsWith('/api/agent/')
+      || pathname.startsWith('/api/shell/'))) {
     // Update is a supervisor operation — always allowed regardless of attach/standalone mode.
     if (!operationsEnabled && pathname !== '/api/operations/update') {
       writeJson(res, 409, { error: 'Web operations are disabled by server policy.' })
@@ -520,6 +556,11 @@ async function handleApiRequest(
 
   if (method === 'GET' && pathname === '/api/agent/sessions') {
     writeJson(res, 200, agentSessionManager.listSessions())
+    return
+  }
+
+  if (method === 'GET' && pathname === '/api/shell/sessions') {
+    writeJson(res, 200, shellSessionManager.listSessions())
     return
   }
 
@@ -577,6 +618,33 @@ async function handleApiRequest(
     if (agentSessionDetailMatch) {
       const sessionId = decodeURIComponent(agentSessionDetailMatch[1] ?? '')
       const session = agentSessionManager.getSession(sessionId)
+      if (!session) {
+        writeJson(res, 404, { error: `Session not found: ${sessionId}` })
+        return
+      }
+      writeJson(res, 200, { session })
+      return
+    }
+
+    const shellSessionEventsMatch = pathname.match(/^\/api\/shell\/sessions\/([^/]+)\/events$/)
+    if (shellSessionEventsMatch) {
+      const sessionId = decodeURIComponent(shellSessionEventsMatch[1] ?? '')
+      const since = toBoundedInt(searchParams.get('since'), 0, 0, Number.MAX_SAFE_INTEGER)
+      const limit = toBoundedInt(searchParams.get('limit'), 200, 1, 1_000)
+      try {
+        writeJson(res, 200, shellSessionManager.getEvents(sessionId, since, limit))
+      } catch (err) {
+        const message = (err as Error).message
+        const statusCode = message.startsWith('Session not found:') ? 404 : 400
+        writeJson(res, statusCode, { error: message })
+      }
+      return
+    }
+
+    const shellSessionDetailMatch = pathname.match(/^\/api\/shell\/sessions\/([^/]+)$/)
+    if (shellSessionDetailMatch) {
+      const sessionId = decodeURIComponent(shellSessionDetailMatch[1] ?? '')
+      const session = shellSessionManager.getSession(sessionId)
       if (!session) {
         writeJson(res, 404, { error: `Session not found: ${sessionId}` })
         return
@@ -1013,6 +1081,43 @@ async function handleApiRequest(
     return
   }
 
+  if (method === 'POST' && pathname === '/api/shell/sessions') {
+    const body = await readJsonBody(req)
+    const cwd = toNonEmptyString(body['cwd'])
+    const cols = toBoundedInt(body['cols'], NaN, 40, 400)
+    const rows = toBoundedInt(body['rows'], NaN, 10, 240)
+
+    try {
+      const session = shellSessionManager.createSession({
+        cwd,
+        cols: Number.isNaN(cols) ? undefined : cols,
+        rows: Number.isNaN(rows) ? undefined : rows,
+      })
+      writeJson(res, 200, { session })
+    } catch (err) {
+      writeJson(res, 400, { error: (err as Error).message })
+    }
+    return
+  }
+
+  const shellSessionCloseMatch = pathname.match(/^\/api\/shell\/sessions\/([^/]+)$/)
+  if (method === 'DELETE' && shellSessionCloseMatch) {
+    const sessionId = decodeURIComponent(shellSessionCloseMatch[1] ?? '')
+    try {
+      const session = shellSessionManager.closeSession(sessionId)
+      writeJson(res, 200, { session })
+    } catch (err) {
+      const message = (err as Error).message
+      const statusCode = message.startsWith('Session not found:')
+        ? 404
+        : message.includes('running')
+          ? 409
+          : 400
+      writeJson(res, statusCode, { error: message })
+    }
+    return
+  }
+
   writeJson(res, 404, { error: `Unknown API route: ${method} ${pathname}` })
 }
 
@@ -1151,6 +1256,22 @@ function validateMutationRequest(
     return { statusCode: 415, error: 'Content-Type must be application/json' }
   }
 
+  const webToken = getSingleHeaderValue(req.headers[WEB_AUTH_TOKEN_HEADER])
+  if (!webToken) {
+    return { statusCode: 401, error: `Missing required header: ${WEB_AUTH_TOKEN_HEADER}` }
+  }
+
+  if (!isMatchingToken(webToken, security.webMutationToken)) {
+    return { statusCode: 403, error: 'Invalid web auth token' }
+  }
+
+  return null
+}
+
+function validateShellReadRequest(
+  req: IncomingMessage,
+  security: WebSecurityContext,
+): { statusCode: number; error: string } | null {
   const webToken = getSingleHeaderValue(req.headers[WEB_AUTH_TOKEN_HEADER])
   if (!webToken) {
     return { statusCode: 401, error: `Missing required header: ${WEB_AUTH_TOKEN_HEADER}` }
@@ -1645,12 +1766,17 @@ async function handleWsMessage(
   rawMessage: string,
   deps: MCPDependencies,
   agentSessionManager: InteractiveAgentSessionManager,
+  shellSessionManager: ShellSessionManager,
 ): Promise<void> {
   let command: WebSocketCommand
   try {
     command = JSON.parse(rawMessage) as WebSocketCommand
   } catch {
     sendWebsocket(ws, { type: 'error', error: 'Invalid JSON message' })
+    return
+  }
+
+  if (!ensureWebSocketShellAuthorized(ws, state, command.type)) {
     return
   }
 
@@ -1702,6 +1828,78 @@ async function handleWsMessage(
 
     state.agentSessionSubscriptions.delete(sessionId)
     sendWebsocket(ws, { type: 'unsubscribed', payload: { sessionId } })
+    return
+  }
+
+  if (command.type === 'subscribe-shell-session-events') {
+    const sessionId = typeof command.sessionId === 'string' ? command.sessionId : ''
+    if (!sessionId) {
+      sendWebsocket(ws, { type: 'error', error: 'sessionId is required for subscribe-shell-session-events' })
+      return
+    }
+
+    const cursor = Number.isFinite(command.since) ? Math.max(0, Math.floor(command.since ?? 0)) : 0
+    state.shellSessionSubscriptions.set(sessionId, cursor)
+    sendWebsocket(ws, { type: 'subscribed', payload: { sessionId, since: cursor } })
+    publishShellSessionSubscriptions(ws, state, shellSessionManager)
+    return
+  }
+
+  if (command.type === 'unsubscribe-shell-session-events') {
+    const sessionId = typeof command.sessionId === 'string' ? command.sessionId : ''
+    if (!sessionId) {
+      sendWebsocket(ws, { type: 'error', error: 'sessionId is required for unsubscribe-shell-session-events' })
+      return
+    }
+
+    state.shellSessionSubscriptions.delete(sessionId)
+    sendWebsocket(ws, { type: 'unsubscribed', payload: { sessionId } })
+    return
+  }
+
+  if (command.type === 'shell-input') {
+    const sessionId = typeof command.sessionId === 'string' ? command.sessionId : ''
+    const data = typeof command.data === 'string' ? command.data : ''
+    if (!sessionId) {
+      sendWebsocket(ws, { type: 'error', error: 'sessionId is required for shell-input' })
+      return
+    }
+    if (!data) {
+      sendWebsocket(ws, { type: 'error', error: 'data is required for shell-input' })
+      return
+    }
+    try {
+      shellSessionManager.writeInput(sessionId, data)
+    } catch (err) {
+      sendWebsocket(ws, {
+        type: 'error',
+        error: `Failed to write shell input for ${sessionId}: ${(err as Error).message}`,
+      })
+    }
+    return
+  }
+
+  if (command.type === 'shell-resize') {
+    const sessionId = typeof command.sessionId === 'string' ? command.sessionId : ''
+    if (!sessionId) {
+      sendWebsocket(ws, { type: 'error', error: 'sessionId is required for shell-resize' })
+      return
+    }
+
+    const cols = typeof command.cols === 'number' ? command.cols : NaN
+    const rows = typeof command.rows === 'number' ? command.rows : NaN
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) {
+      sendWebsocket(ws, { type: 'error', error: 'cols and rows are required for shell-resize' })
+      return
+    }
+    try {
+      shellSessionManager.resize(sessionId, cols, rows)
+    } catch (err) {
+      sendWebsocket(ws, {
+        type: 'error',
+        error: `Failed to resize shell session ${sessionId}: ${(err as Error).message}`,
+      })
+    }
     return
   }
 
@@ -1790,6 +1988,41 @@ function publishAgentSessionSubscriptions(
   }
 }
 
+function publishShellSessionSubscriptions(
+  ws: WebSocket,
+  state: WsClientState,
+  manager: ShellSessionManager,
+): void {
+  for (const [sessionId, since] of state.shellSessionSubscriptions.entries()) {
+    let result: ShellSessionEventList
+    try {
+      result = manager.getEvents(sessionId, since, 500)
+    } catch (err) {
+      sendWebsocket(ws, {
+        type: 'error',
+        error: `Failed to stream shell-session events for ${sessionId}: ${(err as Error).message}`,
+      })
+      continue
+    }
+
+    state.shellSessionSubscriptions.set(sessionId, result.lastEventId)
+
+    if (result.events.length === 0) {
+      continue
+    }
+
+    sendWebsocket(ws, {
+      type: 'shell-session-events',
+      payload: {
+        sessionId,
+        status: result.status,
+        events: result.events,
+        lastEventId: result.lastEventId,
+      },
+    })
+  }
+}
+
 function toRunEventPayload(input: unknown): { events: unknown[]; lastEventId: number } | null {
   if (!input || typeof input !== 'object') return null
 
@@ -1803,6 +2036,51 @@ function toRunEventPayload(input: unknown): { events: unknown[]; lastEventId: nu
     events: maybeEvents,
     lastEventId: Math.max(0, Math.floor(maybeLastEventId)),
   }
+}
+
+function resolveWebSocketAuthenticationState(request: IncomingMessage, security: WebSecurityContext): boolean {
+  let requestUrl: URL
+  try {
+    requestUrl = getRequestUrl(request)
+  } catch {
+    return false
+  }
+
+  const queryToken = requestUrl.searchParams.get('token')
+  const headerToken = getSingleHeaderValue(request.headers[WEB_AUTH_TOKEN_HEADER])
+  const providedToken = toNonEmptyString(queryToken) ?? headerToken
+  if (!providedToken) {
+    return false
+  }
+
+  return isMatchingToken(providedToken, security.webMutationToken)
+}
+
+function requiresWebSocketShellAuth(commandType: WebSocketCommand['type']): boolean {
+  return commandType === 'subscribe-shell-session-events'
+    || commandType === 'unsubscribe-shell-session-events'
+    || commandType === 'shell-input'
+    || commandType === 'shell-resize'
+}
+
+function ensureWebSocketShellAuthorized(
+  ws: WebSocket,
+  state: WsClientState,
+  commandType: WebSocketCommand['type'],
+): boolean {
+  if (!requiresWebSocketShellAuth(commandType)) {
+    return true
+  }
+
+  if (state.isAuthenticated) {
+    return true
+  }
+
+  sendWebsocket(ws, {
+    type: 'error',
+    error: `Unauthorized websocket command: ${commandType}`,
+  })
+  return false
 }
 
 function sendWebsocket(ws: WebSocket, payload: unknown): void {

--- a/src/web/shell-session.ts
+++ b/src/web/shell-session.ts
@@ -1,0 +1,389 @@
+import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
+import { resolve, sep } from 'node:path'
+import * as nodePty from 'node-pty'
+import type { IPty } from 'node-pty'
+import { logger } from '../utils/logger.js'
+import { nowUtcIso } from '../utils/time.js'
+
+export type ShellSessionStatus = 'running' | 'closed'
+export type ShellSessionEventType = 'status' | 'output' | 'exit'
+
+export interface ShellSessionSummary {
+  id: string
+  status: ShellSessionStatus
+  shell: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: string
+  updatedAt: string
+  exitCode: number | null
+  exitSignal: number | null
+}
+
+export type ShellSessionDetail = ShellSessionSummary
+
+export interface ShellSessionEvent {
+  id: number
+  sessionId: string
+  timestamp: string
+  type: ShellSessionEventType
+  data: Record<string, unknown>
+}
+
+interface ShellSessionState {
+  id: string
+  status: ShellSessionStatus
+  shell: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: string
+  updatedAt: string
+  exitCode: number | null
+  exitSignal: number | null
+  closeRequested: boolean
+  events: ShellSessionEvent[]
+  ptyProcess: IPty | null
+}
+
+export interface ShellSessionList {
+  generatedAt: string
+  homePath: string
+  sessions: ShellSessionSummary[]
+}
+
+export interface ShellSessionEventList {
+  sessionId: string
+  status: ShellSessionStatus
+  events: ShellSessionEvent[]
+  lastEventId: number
+}
+
+interface CreateShellSessionInput {
+  cwd?: string | null
+  cols?: number
+  rows?: number
+}
+
+interface SessionEventListener {
+  (sessionId: string): void
+}
+
+interface ManagerOptions {
+  homePath?: string
+  maxEventsPerSession?: number
+  defaultCols?: number
+  defaultRows?: number
+}
+
+const DEFAULT_MAX_EVENTS_PER_SESSION = 8_000
+const DEFAULT_COLS = 120
+const DEFAULT_ROWS = 30
+const MAX_INPUT_CHARS = 32_000
+
+export class ShellSessionManager {
+  private readonly sessions = new Map<string, ShellSessionState>()
+  private readonly listeners = new Set<SessionEventListener>()
+  private readonly homePath: string
+  private readonly maxEventsPerSession: number
+  private readonly defaultCols: number
+  private readonly defaultRows: number
+  private nextEventId = 1
+
+  constructor(options: ManagerOptions = {}) {
+    this.homePath = resolve(options.homePath ?? homedir())
+    this.maxEventsPerSession = clampInt(
+      options.maxEventsPerSession ?? DEFAULT_MAX_EVENTS_PER_SESSION,
+      500,
+      30_000,
+    )
+    this.defaultCols = clampInt(options.defaultCols ?? DEFAULT_COLS, 40, 400)
+    this.defaultRows = clampInt(options.defaultRows ?? DEFAULT_ROWS, 10, 240)
+  }
+
+  listSessions(): ShellSessionList {
+    const sessions = [...this.sessions.values()]
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .map((session) => this.toSummary(session))
+
+    return {
+      generatedAt: nowUtcIso(),
+      homePath: this.homePath,
+      sessions,
+    }
+  }
+
+  createSession(input: CreateShellSessionInput = {}): ShellSessionDetail {
+    const cwd = this.resolveSessionCwd(input.cwd ?? null)
+    const cols = clampInt(input.cols ?? this.defaultCols, 40, 400)
+    const rows = clampInt(input.rows ?? this.defaultRows, 10, 240)
+    const shell = resolveDefaultShell()
+
+    let ptyProcess: IPty
+    try {
+      ptyProcess = nodePty.spawn(shell, [], {
+        name: 'xterm-256color',
+        cols,
+        rows,
+        cwd,
+        env: buildShellEnv(cwd),
+      })
+    } catch (err) {
+      throw new Error(`Failed to start shell: ${(err as Error).message}`)
+    }
+
+    const now = nowUtcIso()
+    const id = randomUUID()
+
+    const session: ShellSessionState = {
+      id,
+      status: 'running',
+      shell,
+      cwd,
+      cols,
+      rows,
+      createdAt: now,
+      updatedAt: now,
+      exitCode: null,
+      exitSignal: null,
+      closeRequested: false,
+      events: [],
+      ptyProcess,
+    }
+
+    this.sessions.set(id, session)
+    this.appendEvent(session, 'status', {
+      message: `Started shell session (${shell})`,
+      cwd,
+      cols,
+      rows,
+    })
+
+    ptyProcess.onData((chunk) => {
+      if (!chunk) return
+      this.appendEvent(session, 'output', { text: chunk })
+    })
+
+    ptyProcess.onExit((exit) => {
+      session.status = 'closed'
+      session.exitCode = typeof exit.exitCode === 'number' ? exit.exitCode : null
+      session.exitSignal = typeof exit.signal === 'number' ? exit.signal : null
+      session.ptyProcess = null
+      session.updatedAt = nowUtcIso()
+      this.appendEvent(session, 'exit', {
+        exitCode: session.exitCode,
+        signal: session.exitSignal,
+        byRequest: session.closeRequested,
+      })
+    })
+
+    return this.toDetail(session)
+  }
+
+  getSession(sessionId: string): ShellSessionDetail | null {
+    const session = this.sessions.get(sessionId)
+    if (!session) return null
+    return this.toDetail(session)
+  }
+
+  closeSession(sessionId: string): ShellSessionDetail {
+    const session = this.requireSession(sessionId)
+    if (session.status === 'closed') {
+      return this.toDetail(session)
+    }
+
+    session.closeRequested = true
+    session.status = 'closed'
+    session.updatedAt = nowUtcIso()
+    this.appendEvent(session, 'status', { message: 'Closing shell session' })
+    try {
+      session.ptyProcess?.kill()
+    } catch (err) {
+      logger.warn({ err, sessionId: session.id }, 'Failed to kill shell session PTY')
+      session.status = 'closed'
+      session.updatedAt = nowUtcIso()
+      this.appendEvent(session, 'exit', {
+        exitCode: session.exitCode,
+        signal: session.exitSignal,
+        byRequest: true,
+      })
+    }
+
+    return this.toDetail(session)
+  }
+
+  closeAll(): void {
+    for (const sessionId of this.sessions.keys()) {
+      try {
+        this.closeSession(sessionId)
+      } catch (err) {
+        logger.warn({ err, sessionId }, 'Failed to close shell session during shutdown')
+      }
+    }
+  }
+
+  writeInput(sessionId: string, data: string): void {
+    const session = this.requireSession(sessionId)
+    if (session.status !== 'running' || !session.ptyProcess) {
+      throw new Error('Session is not running')
+    }
+    if (data.length > MAX_INPUT_CHARS) {
+      throw new Error(`input exceeds ${MAX_INPUT_CHARS} characters`)
+    }
+
+    session.ptyProcess.write(data)
+  }
+
+  resize(sessionId: string, cols: number, rows: number): void {
+    const session = this.requireSession(sessionId)
+    if (session.status !== 'running' || !session.ptyProcess) {
+      throw new Error('Session is not running')
+    }
+
+    const boundedCols = clampInt(cols, 40, 400)
+    const boundedRows = clampInt(rows, 10, 240)
+
+    session.cols = boundedCols
+    session.rows = boundedRows
+    session.updatedAt = nowUtcIso()
+    session.ptyProcess.resize(boundedCols, boundedRows)
+  }
+
+  getEvents(sessionId: string, since = 0, limit = 200): ShellSessionEventList {
+    const session = this.requireSession(sessionId)
+    const boundedSince = Math.max(0, Math.floor(since))
+    const boundedLimit = clampInt(limit, 1, 1_000)
+    const events = session.events
+      .filter((event) => event.id > boundedSince)
+      .slice(0, boundedLimit)
+
+    return {
+      sessionId,
+      status: session.status,
+      events,
+      lastEventId: events.length > 0 ? events[events.length - 1]!.id : boundedSince,
+    }
+  }
+
+  onSessionEvent(listener: SessionEventListener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private appendEvent(
+    session: ShellSessionState,
+    type: ShellSessionEventType,
+    data: Record<string, unknown>,
+  ): void {
+    const event: ShellSessionEvent = {
+      id: this.nextEventId++,
+      sessionId: session.id,
+      timestamp: nowUtcIso(),
+      type,
+      data,
+    }
+
+    session.events.push(event)
+    if (session.events.length > this.maxEventsPerSession) {
+      session.events.splice(0, session.events.length - this.maxEventsPerSession)
+    }
+    session.updatedAt = event.timestamp
+    this.notify(session.id)
+  }
+
+  private notify(sessionId: string): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(sessionId)
+      } catch (err) {
+        logger.warn({ err, sessionId }, 'Shell-session listener failed')
+      }
+    }
+  }
+
+  private requireSession(sessionId: string): ShellSessionState {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+    return session
+  }
+
+  private resolveSessionCwd(rawCwd: string | null): string {
+    if (!rawCwd) return this.homePath
+
+    const trimmed = rawCwd.trim()
+    if (!trimmed) return this.homePath
+
+    const expanded = trimmed === '~'
+      ? this.homePath
+      : trimmed.startsWith('~/')
+        ? resolve(this.homePath, trimmed.slice(2))
+        : trimmed
+
+    const resolved = resolve(expanded.startsWith(sep) ? expanded : resolve(this.homePath, expanded))
+    if (resolved !== this.homePath && !resolved.startsWith(this.homePath + sep)) {
+      throw new Error('cwd must be inside the user home directory')
+    }
+
+    return resolved
+  }
+
+  private toSummary(session: ShellSessionState): ShellSessionSummary {
+    return {
+      id: session.id,
+      status: session.status,
+      shell: session.shell,
+      cwd: session.cwd,
+      cols: session.cols,
+      rows: session.rows,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      exitCode: session.exitCode,
+      exitSignal: session.exitSignal,
+    }
+  }
+
+  private toDetail(session: ShellSessionState): ShellSessionDetail {
+    return this.toSummary(session)
+  }
+}
+
+function resolveDefaultShell(): string {
+  const envShell = process.env['SHELL']
+  if (typeof envShell === 'string' && envShell.trim().length > 0) {
+    return envShell.trim()
+  }
+  return '/bin/sh'
+}
+
+function buildShellEnv(cwd: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value !== 'string') continue
+    env[key] = value
+  }
+
+  if (!env['TERM']) {
+    env['TERM'] = 'xterm-256color'
+  }
+
+  if (!env['HOME']) {
+    env['HOME'] = homedir()
+  }
+
+  env['PWD'] = cwd
+  return env
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  const floor = Math.floor(value)
+  if (floor < min) return min
+  if (floor > max) return max
+  return floor
+}

--- a/test/web/router-integration.test.ts
+++ b/test/web/router-integration.test.ts
@@ -8,10 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createDashboardRouter } from '../../web/src/router.js'
 import {
   type DashboardSnapshot,
-  type InteractiveAgentSessionsSnapshot,
   type ProjectsSnapshot,
   type SettingsSnapshot,
   type SessionResponse,
+  type ShellSessionsSnapshot,
 } from '../../web/src/types/dashboard.js'
 
 const SESSION_RESPONSE: SessionResponse = {
@@ -147,10 +147,9 @@ const SETTINGS_SNAPSHOT: SettingsSnapshot = {
   settings: [],
 }
 
-const AGENT_SESSIONS_SNAPSHOT: InteractiveAgentSessionsSnapshot = {
+const SHELL_SESSIONS_SNAPSHOT: ShellSessionsSnapshot = {
   generatedAt: '2026-04-06T10:00:00.000Z',
-  workspacePath: '/tmp/night-orch',
-  profiles: [],
+  homePath: '/home/test',
   sessions: [],
 }
 
@@ -198,7 +197,7 @@ function buildFetchMock() {
     if (pathname === '/api/session') return createJsonResponse(SESSION_RESPONSE)
     if (pathname === '/api/projects') return createJsonResponse(PROJECTS_SNAPSHOT)
     if (pathname === '/api/settings') return createJsonResponse(SETTINGS_SNAPSHOT)
-    if (pathname === '/api/agent/sessions') return createJsonResponse(AGENT_SESSIONS_SNAPSHOT)
+    if (pathname === '/api/shell/sessions') return createJsonResponse(SHELL_SESSIONS_SNAPSHOT)
     if (pathname === '/api/update-status') return createJsonResponse({}, 404)
 
     return createJsonResponse({ error: `Unhandled endpoint: ${pathname}` }, 404)
@@ -212,7 +211,7 @@ function renderDashboard(pathname: string) {
   return { ...rendered, router }
 }
 
-function expectPageActive(label: 'issues' | 'stats' | 'projects' | 'agent' | 'settings'): void {
+function expectPageActive(label: 'issues' | 'stats' | 'projects' | 'shell' | 'settings'): void {
   const pageButtons = screen
     .getAllByRole('button', { name: new RegExp(`^${label}$`, 'i') })
     .filter((button) => button.getAttribute('aria-label') === label)
@@ -256,15 +255,15 @@ describe('dashboard router integration (real App)', () => {
     expectPageActive('settings')
   })
 
-  it('renders /agent with interactive session workspace controls', async () => {
+  it('renders /agent with browser shell controls', async () => {
     const { router } = renderDashboard('/agent')
 
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/agent')
     })
 
-    expect(screen.getByText('Interactive Agent')).toBeDefined()
-    expectPageActive('agent')
+    expect(screen.getByText('Browser Shell')).toBeDefined()
+    expectPageActive('shell')
   })
 
   it('redirects invalid routes to /issues', async () => {

--- a/test/web/server.test.ts
+++ b/test/web/server.test.ts
@@ -990,6 +990,16 @@ describe('startWebServer', () => {
     await expect(agentCreate.json()).resolves.toMatchObject({
       error: 'Web operations are disabled by server policy.',
     })
+
+    const shellCreate = await fetch(`${baseUrl}/api/shell/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(shellCreate.status).toBe(409)
+    await expect(shellCreate.json()).resolves.toMatchObject({
+      error: 'Web operations are disabled by server policy.',
+    })
   })
 
   it('requires application/json for mutating API requests', async () => {
@@ -1327,6 +1337,210 @@ describe('startWebServer', () => {
         status: 'closed',
       },
     })
+  })
+
+  it('creates shell sessions and streams PTY output over websocket', async () => {
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+        snapshotIntervalMs: 50,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+    const mutationToken = await getMutationToken(baseUrl)
+
+    const create = await fetch(`${baseUrl}/api/shell/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({ cwd: '~' }),
+    })
+    expect(create.status).toBe(200)
+    const createPayload = await create.json() as {
+      session: { id: string; status: string; cwd: string }
+    }
+    const sessionId = createPayload.session.id
+    expect(createPayload.session.status).toBe('running')
+    expect(createPayload.session.cwd).toBeTruthy()
+
+    const wsOrigin = `http://127.0.0.1:${address.port}`
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${address.port}/ws?token=${encodeURIComponent(mutationToken)}`,
+      { origin: wsOrigin },
+    )
+    await once(ws, 'open')
+    ws.send(JSON.stringify({ type: 'subscribe-shell-session-events', sessionId, since: 0 }))
+    ws.send(JSON.stringify({ type: 'shell-input', sessionId, data: "printf 'night-orch-shell-test\\n'\\n" }))
+
+    const shellEvents = await waitForWsMessage<{
+      type: string
+      payload: {
+        sessionId: string
+        events: Array<{ type: string; data?: { text?: unknown } }>
+      }
+    }>(ws, (payload) => {
+      if (!payload || typeof payload !== 'object') return null
+      const message = payload as { type?: unknown; payload?: unknown }
+      if (message.type !== 'shell-session-events' || !message.payload || typeof message.payload !== 'object') return null
+      const body = message.payload as {
+        sessionId?: unknown
+        events?: unknown
+      }
+      if (body.sessionId !== sessionId || !Array.isArray(body.events)) return null
+      const sawOutput = body.events.some((event) => {
+        if (!event || typeof event !== 'object') return false
+        if ((event as { type?: unknown }).type !== 'output') return false
+        const text = ((event as { data?: unknown }).data as { text?: unknown } | undefined)?.text
+        return typeof text === 'string' && text.includes('night-orch-shell-test')
+      })
+      if (!sawOutput) return null
+      return message as {
+        type: string
+        payload: {
+          sessionId: string
+          events: Array<{ type: string; data?: { text?: unknown } }>
+        }
+      }
+    }, 10_000)
+
+    expect(shellEvents.payload.sessionId).toBe(sessionId)
+    expect(shellEvents.payload.events.some((event) => {
+      const text = event.data?.text
+      return event.type === 'output' && typeof text === 'string' && text.includes('night-orch-shell-test')
+    })).toBe(true)
+
+    ws.close()
+
+    const close = await fetch(`${baseUrl}/api/shell/sessions/${encodeURIComponent(sessionId)}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+    })
+    expect(close.status).toBe(200)
+    await expect(close.json()).resolves.toMatchObject({
+      session: {
+        id: sessionId,
+        status: 'closed',
+      },
+    })
+  })
+
+  it('requires auth token for shell read APIs and shell websocket commands', async () => {
+    server = await startWebServer(
+      deps,
+      {
+        host: '127.0.0.1',
+        port: 0,
+        frontendDistPath: frontendDir,
+        snapshotIntervalMs: 50,
+      },
+    )
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Unexpected address type')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+    const mutationToken = await getMutationToken(baseUrl)
+
+    const create = await fetch(`${baseUrl}/api/shell/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [MUTATION_INTENT_HEADER]: 'mutate',
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+      body: JSON.stringify({ cwd: '~' }),
+    })
+    expect(create.status).toBe(200)
+    const createPayload = await create.json() as {
+      session: { id: string }
+    }
+    const sessionId = createPayload.session.id
+
+    const unauthList = await fetch(`${baseUrl}/api/shell/sessions`)
+    expect(unauthList.status).toBe(401)
+    await expect(unauthList.json()).resolves.toMatchObject({
+      error: `Missing required header: ${WEB_AUTH_TOKEN_HEADER}`,
+    })
+
+    const authList = await fetch(`${baseUrl}/api/shell/sessions`, {
+      headers: {
+        [WEB_AUTH_TOKEN_HEADER]: mutationToken,
+      },
+    })
+    expect(authList.status).toBe(200)
+
+    const wsOrigin = `http://127.0.0.1:${address.port}`
+    const unauthWs = new WebSocket(`ws://127.0.0.1:${address.port}/ws`, { origin: wsOrigin })
+    await once(unauthWs, 'open')
+    unauthWs.send(JSON.stringify({ type: 'shell-input', sessionId, data: 'echo should-not-run\n' }))
+
+    const unauthError = await waitForWsMessage<{ type: string; error: string }>(unauthWs, (payload) => {
+      if (!payload || typeof payload !== 'object') return null
+      const message = payload as { type?: unknown; error?: unknown }
+      if (message.type !== 'error' || typeof message.error !== 'string') return null
+      if (!message.error.includes('Unauthorized websocket command: shell-input')) return null
+      return { type: message.type, error: message.error }
+    }, 5_000)
+    expect(unauthError.error).toContain('Unauthorized websocket command: shell-input')
+    unauthWs.close()
+
+    const authWs = new WebSocket(
+      `ws://127.0.0.1:${address.port}/ws?token=${encodeURIComponent(mutationToken)}`,
+      { origin: wsOrigin },
+    )
+    await once(authWs, 'open')
+    authWs.send(JSON.stringify({ type: 'subscribe-shell-session-events', sessionId, since: 0 }))
+    authWs.send(JSON.stringify({ type: 'shell-input', sessionId, data: "printf 'authorized-shell\\n'\\n" }))
+
+    const authShellEvents = await waitForWsMessage<{
+      type: string
+      payload: {
+        sessionId: string
+        events: Array<{ type: string; data?: { text?: unknown } }>
+      }
+    }>(authWs, (payload) => {
+      if (!payload || typeof payload !== 'object') return null
+      const message = payload as { type?: unknown; payload?: unknown }
+      if (message.type !== 'shell-session-events' || !message.payload || typeof message.payload !== 'object') return null
+      const body = message.payload as {
+        sessionId?: unknown
+        events?: unknown
+      }
+      if (body.sessionId !== sessionId || !Array.isArray(body.events)) return null
+      const sawOutput = body.events.some((event) => {
+        if (!event || typeof event !== 'object') return false
+        if ((event as { type?: unknown }).type !== 'output') return false
+        const text = ((event as { data?: unknown }).data as { text?: unknown } | undefined)?.text
+        return typeof text === 'string' && text.includes('authorized-shell')
+      })
+      if (!sawOutput) return null
+      return message as {
+        type: string
+        payload: {
+          sessionId: string
+          events: Array<{ type: string; data?: { text?: unknown } }>
+        }
+      }
+    }, 10_000)
+
+    expect(authShellEvents.payload.sessionId).toBe(sessionId)
+    authWs.close()
   })
 
   it('streams run events over websocket subscriptions', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { type FormEvent, type ReactElement, useCallback, useEffect, useMemo, use
 import { useNavigate } from '@tanstack/react-router'
 
 import { BudgetOverridesPanel } from './components/BudgetOverridesPanel.js'
-import { AgentSessionsPage } from './components/AgentSessionsPage.js'
+import { ShellSessionsPage } from './components/ShellSessionsPage.js'
 import { DashboardHeader } from './components/DashboardHeader.js'
 import { DashboardMetrics } from './components/DashboardMetrics.js'
 import { DashboardNavigation } from './components/DashboardNavigation.js'
@@ -18,9 +18,9 @@ import { extractMessage } from './lib/format.js'
 import { STATUS_BADGE_TONE } from './lib/run-tone.js'
 import { asRunEventsPayload, mergeRunEvents } from './lib/run-events.js'
 import {
-  asInteractiveAgentSessionEventsPayload,
-  mergeInteractiveAgentSessionEvents,
-} from './lib/agent-session-events.js'
+  asShellSessionEventsPayload,
+  mergeShellSessionEvents,
+} from './lib/shell-session-events.js'
 import { confirmSelfUpdate } from './lib/update-confirmation.js'
 import {
   clearUpdateTransitionState,
@@ -33,12 +33,11 @@ import {
 import {
   type DashboardPage,
   type DashboardSnapshot,
-  type InteractiveAgentSessionDetail,
-  type InteractiveAgentSessionEvent,
-  type InteractiveAgentSessionsSnapshot,
-  type InteractiveAgentType,
   type ProjectsSnapshot,
   type RunEvent,
+  type ShellSessionDetail,
+  type ShellSessionEvent,
+  type ShellSessionsSnapshot,
   type SettingsSnapshot,
   type SessionResponse,
   type UpdateStatus,
@@ -86,19 +85,12 @@ export function App({
   const [selectedRepo, setSelectedRepo] = useState('all')
   const [selectedRunId, setSelectedRunId] = useState('')
   const [runEvents, setRunEvents] = useState<RunEvent[]>([])
-  const [agentSessionsSnapshot, setAgentSessionsSnapshot] = useState<InteractiveAgentSessionsSnapshot | null>(null)
-  const [isAgentSessionsLoading, setIsAgentSessionsLoading] = useState(false)
-  const [selectedAgentSessionId, setSelectedAgentSessionId] = useState('')
-  const [selectedAgentSession, setSelectedAgentSession] = useState<InteractiveAgentSessionDetail | null>(null)
-  const [agentSessionEvents, setAgentSessionEvents] = useState<InteractiveAgentSessionEvent[]>([])
-  const [agentPromptDraft, setAgentPromptDraft] = useState('')
-  const [agentCreateDraft, setAgentCreateDraft] = useState<{
-    agent: InteractiveAgentType
-    profileName: string
-  }>({
-    agent: 'codex',
-    profileName: '',
-  })
+  const [shellSessionsSnapshot, setShellSessionsSnapshot] = useState<ShellSessionsSnapshot | null>(null)
+  const [isShellSessionsLoading, setIsShellSessionsLoading] = useState(false)
+  const [selectedShellSessionId, setSelectedShellSessionId] = useState('')
+  const [selectedShellSession, setSelectedShellSession] = useState<ShellSessionDetail | null>(null)
+  const [shellSessionEvents, setShellSessionEvents] = useState<ShellSessionEvent[]>([])
+  const [shellCreateDraft, setShellCreateDraft] = useState<{ cwd: string }>({ cwd: '' })
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
   const [activeOperation, setActiveOperation] = useState<string | null>(null)
@@ -133,9 +125,9 @@ export function App({
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimerRef = useRef<number | null>(null)
   const selectedStreamRunIdRef = useRef('')
-  const selectedAgentSessionIdRef = useRef('')
+  const selectedShellSessionIdRef = useRef('')
   const subscribedRunRef = useRef('')
-  const subscribedAgentSessionRef = useRef('')
+  const subscribedShellSessionRef = useRef('')
   const updateTransitionRef = useRef<UpdateTransitionState>(clearUpdateTransitionState())
 
   const repos = snapshot?.config.repos ?? []
@@ -253,34 +245,48 @@ export function App({
     )
   }, [])
 
-  const loadAgentSessions = useCallback(async () => {
-    const response = await fetch('/api/agent/sessions')
-    if (!response.ok) {
-      throw new Error(`Failed to load agent sessions (${response.status})`)
+  const loadShellSessions = useCallback(async () => {
+    if (!webMutationToken) {
+      throw new Error('Web session is not initialized yet. Refresh the page and try again.')
     }
-    const payload = await response.json() as InteractiveAgentSessionsSnapshot
-    setAgentSessionsSnapshot(payload)
-  }, [])
+    const response = await fetch('/api/shell/sessions', {
+      headers: {
+        [WEB_AUTH_TOKEN_HEADER]: webMutationToken,
+      },
+    })
+    if (!response.ok) {
+      throw new Error(`Failed to load shell sessions (${response.status})`)
+    }
+    const payload = await response.json() as ShellSessionsSnapshot
+    setShellSessionsSnapshot(payload)
+  }, [webMutationToken])
 
-  const loadAgentSessionDetail = useCallback(async (sessionId: string) => {
+  const loadShellSessionDetail = useCallback(async (sessionId: string) => {
+    if (!webMutationToken) {
+      throw new Error('Web session is not initialized yet. Refresh the page and try again.')
+    }
     if (!sessionId) {
-      setSelectedAgentSession(null)
+      setSelectedShellSession(null)
       return
     }
-    const response = await fetch(`/api/agent/sessions/${encodeURIComponent(sessionId)}`)
+    const response = await fetch(`/api/shell/sessions/${encodeURIComponent(sessionId)}`, {
+      headers: {
+        [WEB_AUTH_TOKEN_HEADER]: webMutationToken,
+      },
+    })
     if (response.status === 404) {
-      setSelectedAgentSession(null)
+      setSelectedShellSession(null)
       return
     }
     if (!response.ok) {
-      throw new Error(`Failed to load agent session (${response.status})`)
+      throw new Error(`Failed to load shell session (${response.status})`)
     }
-    const payload = await response.json() as { session?: InteractiveAgentSessionDetail }
+    const payload = await response.json() as { session?: ShellSessionDetail }
     if (!payload.session) {
-      throw new Error('Malformed agent session response')
+      throw new Error('Malformed shell session response')
     }
-    setSelectedAgentSession(payload.session)
-  }, [])
+    setSelectedShellSession(payload.session)
+  }, [webMutationToken])
 
   useEffect(() => {
     void (async () => {
@@ -347,20 +353,20 @@ export function App({
   }, [decodedIssueDetailRunId])
 
   useEffect(() => {
-    if (activePage !== 'agent') return
+    if (activePage !== 'agent' || !webMutationToken) return
     let cancelled = false
-    setIsAgentSessionsLoading(true)
+    setIsShellSessionsLoading(true)
     setErrorMessage(null)
     void (async () => {
       try {
-        await loadAgentSessions()
+        await loadShellSessions()
       } catch (err) {
         if (!cancelled) {
           setErrorMessage((err as Error).message)
         }
       } finally {
         if (!cancelled) {
-          setIsAgentSessionsLoading(false)
+          setIsShellSessionsLoading(false)
         }
       }
     })()
@@ -368,25 +374,25 @@ export function App({
     return () => {
       cancelled = true
     }
-  }, [activePage, loadAgentSessions])
+  }, [activePage, loadShellSessions, webMutationToken])
 
   useEffect(() => {
     if (activePage !== 'agent') return
-    const sessions = agentSessionsSnapshot?.sessions ?? []
-    setSelectedAgentSessionId((previous) => {
+    const sessions = shellSessionsSnapshot?.sessions ?? []
+    setSelectedShellSessionId((previous) => {
       if (previous && sessions.some((session) => session.id === previous)) {
         return previous
       }
       return sessions[0]?.id ?? ''
     })
-  }, [activePage, agentSessionsSnapshot])
+  }, [activePage, shellSessionsSnapshot])
 
   useEffect(() => {
-    if (activePage !== 'agent') return
+    if (activePage !== 'agent' || !webMutationToken) return
     let cancelled = false
     void (async () => {
       try {
-        await loadAgentSessionDetail(selectedAgentSessionId)
+        await loadShellSessionDetail(selectedShellSessionId)
       } catch (err) {
         if (!cancelled) {
           setErrorMessage((err as Error).message)
@@ -396,14 +402,17 @@ export function App({
     return () => {
       cancelled = true
     }
-  }, [activePage, loadAgentSessionDetail, selectedAgentSessionId])
+  }, [activePage, loadShellSessionDetail, selectedShellSessionId, webMutationToken])
 
   useEffect(() => {
     let cancelled = false
 
     const connect = (): void => {
       const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
-      const socket = new WebSocket(`${protocol}://${window.location.host}/ws`)
+      const authQuery = webMutationToken
+        ? `?token=${encodeURIComponent(webMutationToken)}`
+        : ''
+      const socket = new WebSocket(`${protocol}://${window.location.host}/ws${authQuery}`)
       wsRef.current = socket
 
       socket.onopen = () => {
@@ -414,9 +423,9 @@ export function App({
         if (activeRun) {
           socket.send(JSON.stringify({ type: 'subscribe-run-events', runId: activeRun, since: 0 }))
         }
-        const activeSession = selectedAgentSessionIdRef.current
+        const activeSession = selectedShellSessionIdRef.current
         if (activeSession) {
-          socket.send(JSON.stringify({ type: 'subscribe-agent-session-events', sessionId: activeSession, since: 0 }))
+          socket.send(JSON.stringify({ type: 'subscribe-shell-session-events', sessionId: activeSession, since: 0 }))
         }
       }
 
@@ -438,13 +447,13 @@ export function App({
             return
           }
 
-          if (envelope.type === 'agent-session-events' && envelope.payload) {
-            const payload = asInteractiveAgentSessionEventsPayload(envelope.payload)
+          if (envelope.type === 'shell-session-events' && envelope.payload) {
+            const payload = asShellSessionEventsPayload(envelope.payload)
             if (!payload) {
               return
             }
 
-            setAgentSessionsSnapshot((current) => {
+            setShellSessionsSnapshot((current) => {
               if (!current) return current
               return {
                 ...current,
@@ -458,12 +467,12 @@ export function App({
                 )),
               }
             })
-            if (payload.sessionId !== selectedAgentSessionIdRef.current) {
+            if (payload.sessionId !== selectedShellSessionIdRef.current) {
               return
             }
 
-            setAgentSessionEvents((previous) => mergeInteractiveAgentSessionEvents(previous, payload.events))
-            setSelectedAgentSession((current) => (
+            setShellSessionEvents((previous) => mergeShellSessionEvents(previous, payload.events))
+            setSelectedShellSession((current) => (
               current && current.id === payload.sessionId
                 ? { ...current, status: payload.status }
                 : current
@@ -504,7 +513,7 @@ export function App({
       wsRef.current?.close()
       wsRef.current = null
     }
-  }, [])
+  }, [webMutationToken])
 
   useEffect(() => {
     selectedStreamRunIdRef.current = selectedStreamRunId
@@ -529,26 +538,26 @@ export function App({
   }, [selectedStreamRunId, socketConnected])
 
   useEffect(() => {
-    selectedAgentSessionIdRef.current = selectedAgentSessionId
-    setAgentSessionEvents([])
+    selectedShellSessionIdRef.current = selectedShellSessionId
+    setShellSessionEvents([])
 
     const socket = wsRef.current
     if (!socket || socket.readyState !== WebSocket.OPEN) {
-      subscribedAgentSessionRef.current = selectedAgentSessionId
+      subscribedShellSessionRef.current = selectedShellSessionId
       return
     }
 
-    const previousSession = subscribedAgentSessionRef.current
-    if (previousSession && previousSession !== selectedAgentSessionId) {
-      socket.send(JSON.stringify({ type: 'unsubscribe-agent-session-events', sessionId: previousSession }))
+    const previousSession = subscribedShellSessionRef.current
+    if (previousSession && previousSession !== selectedShellSessionId) {
+      socket.send(JSON.stringify({ type: 'unsubscribe-shell-session-events', sessionId: previousSession }))
     }
 
-    if (selectedAgentSessionId) {
-      socket.send(JSON.stringify({ type: 'subscribe-agent-session-events', sessionId: selectedAgentSessionId, since: 0 }))
+    if (selectedShellSessionId) {
+      socket.send(JSON.stringify({ type: 'subscribe-shell-session-events', sessionId: selectedShellSessionId, since: 0 }))
     }
 
-    subscribedAgentSessionRef.current = selectedAgentSessionId
-  }, [selectedAgentSessionId, socketConnected])
+    subscribedShellSessionRef.current = selectedShellSessionId
+  }, [selectedShellSessionId, socketConnected])
 
   const [serverUnreachable, setServerUnreachable] = useState(false)
 
@@ -666,7 +675,7 @@ export function App({
     }
   }, [loadDashboard, loadSettings, operationsEnabled, webMutationToken])
 
-  const runAgentMutation = useCallback(async (
+  const runShellMutation = useCallback(async (
     operationName: string,
     endpoint: string,
     payload: Record<string, unknown>,
@@ -678,6 +687,9 @@ export function App({
 
       if (!webMutationToken) {
         throw new Error('Web session is not initialized yet. Refresh the page and try again.')
+      }
+      if (!operationsEnabled) {
+        throw new Error('Web operations are disabled by server policy.')
       }
 
       const response = await fetch(endpoint, {
@@ -703,7 +715,7 @@ export function App({
     } finally {
       setActiveOperation(null)
     }
-  }, [webMutationToken])
+  }, [operationsEnabled, webMutationToken])
 
   const refreshDashboardData = useCallback(async () => {
     try {
@@ -715,7 +727,7 @@ export function App({
         loadSettings(),
       ]
       if (activePage === 'agent') {
-        refreshTasks.push(loadAgentSessions())
+        refreshTasks.push(loadShellSessions())
       }
       await Promise.all(refreshTasks)
       if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -726,7 +738,7 @@ export function App({
     } finally {
       setIsHeaderRefreshing(false)
     }
-  }, [activePage, loadAgentSessions, loadDashboard, loadProjects, loadSettings])
+  }, [activePage, loadDashboard, loadProjects, loadSettings, loadShellSessions])
 
   const triggerPoll = useCallback(() => {
     void runOperation('poll', '/api/operations/poll', {}, 'Manual poll requested')
@@ -985,66 +997,57 @@ export function App({
     )
   }, [costOverrideDraft, runOperation])
 
-  const submitCreateAgentSession = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+  const submitCreateShellSession = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const response = await runAgentMutation(
-      'agent:create-session',
-      '/api/agent/sessions',
+    const response = await runShellMutation(
+      'shell:create-session',
+      '/api/shell/sessions',
       {
-        agent: agentCreateDraft.agent,
-        profileName: agentCreateDraft.profileName || undefined,
+        cwd: shellCreateDraft.cwd.trim() || undefined,
       },
     )
     if (!response) return
 
-    const session = response['session'] as InteractiveAgentSessionDetail | undefined
-    await loadAgentSessions()
+    const session = response['session'] as ShellSessionDetail | undefined
+    await loadShellSessions()
     if (session?.id) {
-      setSelectedAgentSessionId(session.id)
-      setSelectedAgentSession(session)
-      setAgentSessionEvents([])
-      setFeedbackMessage(`Created ${session.agent} session`)
+      setSelectedShellSessionId(session.id)
+      setSelectedShellSession(session)
+      setShellSessionEvents([])
+      setFeedbackMessage(`Created shell session in ${session.cwd}`)
     }
-  }, [agentCreateDraft.agent, agentCreateDraft.profileName, loadAgentSessions, runAgentMutation])
+  }, [loadShellSessions, runShellMutation, shellCreateDraft.cwd])
 
-  const submitAgentPrompt = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!selectedAgentSessionId) {
-      setErrorMessage('Select a session before sending a prompt')
-      return
-    }
-    const prompt = agentPromptDraft.trim()
-    if (!prompt) {
-      setErrorMessage('Prompt cannot be empty')
-      return
-    }
-
-    const response = await runAgentMutation(
-      'agent:send-prompt',
-      `/api/agent/sessions/${encodeURIComponent(selectedAgentSessionId)}/messages`,
-      { prompt },
-    )
-    if (!response) return
-
-    setAgentPromptDraft('')
-    setFeedbackMessage('Prompt sent')
-    await loadAgentSessionDetail(selectedAgentSessionId)
-  }, [agentPromptDraft, loadAgentSessionDetail, runAgentMutation, selectedAgentSessionId])
-
-  const closeAgentSession = useCallback(async () => {
-    if (!selectedAgentSessionId) return
-    const response = await runAgentMutation(
-      'agent:close-session',
-      `/api/agent/sessions/${encodeURIComponent(selectedAgentSessionId)}`,
+  const closeShellSession = useCallback(async () => {
+    if (!selectedShellSessionId) return
+    const response = await runShellMutation(
+      'shell:close-session',
+      `/api/shell/sessions/${encodeURIComponent(selectedShellSessionId)}`,
       {},
       'DELETE',
     )
     if (!response) return
 
-    await loadAgentSessions()
-    await loadAgentSessionDetail(selectedAgentSessionId)
-    setFeedbackMessage('Session closed')
-  }, [loadAgentSessionDetail, loadAgentSessions, runAgentMutation, selectedAgentSessionId])
+    await loadShellSessions()
+    await loadShellSessionDetail(selectedShellSessionId)
+    setFeedbackMessage('Shell session closed')
+  }, [loadShellSessionDetail, loadShellSessions, runShellMutation, selectedShellSessionId])
+
+  const sendShellInput = useCallback((data: string) => {
+    const sessionId = selectedShellSessionIdRef.current
+    if (!sessionId) return
+    const socket = wsRef.current
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    socket.send(JSON.stringify({ type: 'shell-input', sessionId, data }))
+  }, [])
+
+  const sendShellResize = useCallback((cols: number, rows: number) => {
+    const sessionId = selectedShellSessionIdRef.current
+    if (!sessionId) return
+    const socket = wsRef.current
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    socket.send(JSON.stringify({ type: 'shell-resize', sessionId, cols, rows }))
+  }, [])
 
   const isIssueDetailScreen = activePage === 'issues' && decodedIssueDetailRunId !== null
   const isProjectDetailScreen = activePage === 'projects' && decodedProjectDetailRepo !== null
@@ -1215,31 +1218,29 @@ export function App({
             )}
 
             {activePage === 'agent' && (
-              <AgentSessionsPage
-                snapshot={agentSessionsSnapshot}
-                selectedSessionId={selectedAgentSessionId}
-                selectedSession={selectedAgentSession}
-                events={agentSessionEvents}
-                promptDraft={agentPromptDraft}
-                createDraft={agentCreateDraft}
-                isLoading={isAgentSessionsLoading}
+              <ShellSessionsPage
+                snapshot={shellSessionsSnapshot}
+                selectedSessionId={selectedShellSessionId}
+                selectedSession={selectedShellSession}
+                events={shellSessionEvents}
+                createDraft={shellCreateDraft}
+                isLoading={isShellSessionsLoading}
                 isMutating={activeOperation !== null}
+                socketConnected={socketConnected}
                 onSelectSession={(sessionId) => {
-                  setSelectedAgentSessionId(sessionId)
+                  setSelectedShellSessionId(sessionId)
                 }}
                 onCreateDraftChange={(patch) => {
-                  setAgentCreateDraft((current) => ({ ...current, ...patch }))
+                  setShellCreateDraft((current) => ({ ...current, ...patch }))
                 }}
-                onPromptDraftChange={setAgentPromptDraft}
                 onCreateSession={(event) => {
-                  void submitCreateAgentSession(event)
-                }}
-                onSendPrompt={(event) => {
-                  void submitAgentPrompt(event)
+                  void submitCreateShellSession(event)
                 }}
                 onCloseSession={() => {
-                  void closeAgentSession()
+                  void closeShellSession()
                 }}
+                onTerminalInput={sendShellInput}
+                onTerminalResize={sendShellResize}
               />
             )}
 

--- a/web/src/components/DashboardNavigation.tsx
+++ b/web/src/components/DashboardNavigation.tsx
@@ -22,7 +22,7 @@ const PAGES: PageDefinition[] = [
   { id: 'issues', label: 'issues', shortLabel: 'issues', Icon: IssuesIcon },
   { id: 'stats', label: 'stats', shortLabel: 'stats', Icon: StatsIcon },
   { id: 'projects', label: 'projects', shortLabel: 'projects', Icon: ProjectsIcon },
-  { id: 'agent', label: 'agent', shortLabel: 'agent', Icon: AgentIcon },
+  { id: 'agent', label: 'shell', shortLabel: 'shell', Icon: AgentIcon },
   { id: 'settings', label: 'settings', shortLabel: 'settings', Icon: SettingsIcon },
 ]
 

--- a/web/src/components/ShellSessionsPage.tsx
+++ b/web/src/components/ShellSessionsPage.tsx
@@ -1,0 +1,316 @@
+import { type FormEvent, type ReactElement, useEffect, useRef } from 'react'
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import type { IDisposable } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+
+import {
+  type ShellSessionDetail,
+  type ShellSessionEvent,
+  type ShellSessionsSnapshot,
+} from '../types/dashboard.js'
+
+interface ShellSessionsPageProps {
+  snapshot: ShellSessionsSnapshot | null
+  selectedSessionId: string
+  selectedSession: ShellSessionDetail | null
+  events: ShellSessionEvent[]
+  createDraft: {
+    cwd: string
+  }
+  isLoading: boolean
+  isMutating: boolean
+  socketConnected: boolean
+  onSelectSession: (sessionId: string) => void
+  onCreateDraftChange: (patch: Partial<{ cwd: string }>) => void
+  onCreateSession: (event: FormEvent<HTMLFormElement>) => void
+  onCloseSession: () => void
+  onTerminalInput: (data: string) => void
+  onTerminalResize: (cols: number, rows: number) => void
+}
+
+const STATUS_BADGE_CLASS: Record<ShellSessionDetail['status'], string> = {
+  running: 'badge-success',
+  closed: 'badge-neutral',
+}
+
+export function ShellSessionsPage({
+  snapshot,
+  selectedSessionId,
+  selectedSession,
+  events,
+  createDraft,
+  isLoading,
+  isMutating,
+  socketConnected,
+  onSelectSession,
+  onCreateDraftChange,
+  onCreateSession,
+  onCloseSession,
+  onTerminalInput,
+  onTerminalResize,
+}: ShellSessionsPageProps): ReactElement {
+  const terminalHostRef = useRef<HTMLDivElement | null>(null)
+  const terminalRef = useRef<Terminal | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
+  const outputCursorRef = useRef(0)
+  const selectedSessionIdRef = useRef(selectedSessionId)
+  const onTerminalInputRef = useRef(onTerminalInput)
+  const onTerminalResizeRef = useRef(onTerminalResize)
+
+  useEffect(() => {
+    selectedSessionIdRef.current = selectedSessionId
+  }, [selectedSessionId])
+
+  useEffect(() => {
+    onTerminalInputRef.current = onTerminalInput
+  }, [onTerminalInput])
+
+  useEffect(() => {
+    onTerminalResizeRef.current = onTerminalResize
+  }, [onTerminalResize])
+
+  useEffect(() => {
+    const host = terminalHostRef.current
+    if (!host) return
+
+    const terminal = new Terminal({
+      cursorBlink: true,
+      allowProposedApi: false,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+      fontSize: 13,
+      lineHeight: 1.35,
+      convertEol: false,
+      scrollback: 10_000,
+      theme: {
+        background: '#090f14',
+        foreground: '#d4dce4',
+        cursor: '#81d4fa',
+        black: '#0a1016',
+        red: '#f87171',
+        green: '#4ade80',
+        yellow: '#facc15',
+        blue: '#60a5fa',
+        magenta: '#f472b6',
+        cyan: '#22d3ee',
+        white: '#e2e8f0',
+        brightBlack: '#475569',
+        brightRed: '#fb7185',
+        brightGreen: '#86efac',
+        brightYellow: '#fde047',
+        brightBlue: '#93c5fd',
+        brightMagenta: '#f9a8d4',
+        brightCyan: '#67e8f9',
+        brightWhite: '#f8fafc',
+      },
+    })
+    const fitAddon = new FitAddon()
+    terminal.loadAddon(fitAddon)
+    terminal.open(host)
+    terminalRef.current = terminal
+    fitAddonRef.current = fitAddon
+
+    const reportSize = (): void => {
+      fitAddon.fit()
+      if (selectedSessionIdRef.current) {
+        onTerminalResizeRef.current(terminal.cols, terminal.rows)
+      }
+    }
+
+    const inputDisposable = terminal.onData((data) => {
+      onTerminalInputRef.current(data)
+    })
+
+    let resizeObserver: ResizeObserver | null = null
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        reportSize()
+      })
+      resizeObserver.observe(host)
+    }
+
+    reportSize()
+
+    return () => {
+      resizeObserver?.disconnect()
+      disposeSafely(inputDisposable)
+      terminal.dispose()
+      terminalRef.current = null
+      fitAddonRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const terminal = terminalRef.current
+    if (!terminal) return
+
+    terminal.reset()
+    outputCursorRef.current = 0
+
+    if (!selectedSession) {
+      terminal.writeln('No shell session selected. Create one to start.')
+      return
+    }
+
+    terminal.writeln(`Attached to ${selectedSession.shell}`)
+    terminal.writeln(`cwd: ${selectedSession.cwd}`)
+    terminal.writeln('')
+
+    const fitAddon = fitAddonRef.current
+    fitAddon?.fit()
+    onTerminalResize(terminal.cols, terminal.rows)
+  }, [onTerminalResize, selectedSession])
+
+  useEffect(() => {
+    const terminal = terminalRef.current
+    if (!terminal || !selectedSession) return
+
+    const start = Math.max(0, Math.min(outputCursorRef.current, events.length))
+    for (let index = start; index < events.length; index += 1) {
+      const event = events[index]
+      if (!event) continue
+
+      if (event.type === 'output') {
+        const text = event.data['text']
+        if (typeof text === 'string' && text.length > 0) {
+          terminal.write(text)
+        }
+        continue
+      }
+
+      if (event.type === 'status') {
+        const message = event.data['message']
+        if (typeof message === 'string' && message.length > 0) {
+          terminal.writeln(`\r\n[status] ${message}`)
+        }
+        continue
+      }
+
+      if (event.type === 'exit') {
+        const code = typeof event.data['exitCode'] === 'number' ? event.data['exitCode'] : null
+        const signal = typeof event.data['signal'] === 'number' ? event.data['signal'] : null
+        const byRequest = event.data['byRequest'] === true
+        const codeLabel = code === null ? 'n/a' : String(code)
+        const signalLabel = signal === null ? 'n/a' : String(signal)
+        const reason = byRequest ? 'requested' : 'process exit'
+        terminal.writeln(`\r\n[exit] code=${codeLabel} signal=${signalLabel} (${reason})`)
+      }
+    }
+
+    outputCursorRef.current = events.length
+  }, [events, selectedSession])
+
+  return (
+    <div className="grid gap-5 xl:grid-cols-[320px_minmax(0,1fr)]">
+      <section className="card border border-base-300/70 bg-base-100/70 shadow-panel">
+        <div className="card-body gap-4 p-4">
+          <div>
+            <h2 className="card-title text-lg">Browser Shell</h2>
+            <p className="text-xs text-base-content/65">
+              Sessions run under <code>{snapshot?.homePath ?? '~'}</code>
+            </p>
+          </div>
+
+          <form className="grid gap-3" onSubmit={onCreateSession}>
+            <label className="form-control gap-1.5">
+              <span className="label-text text-xs uppercase tracking-wide text-base-content/65">Start Directory</span>
+              <input
+                className="input input-bordered input-sm w-full"
+                value={createDraft.cwd}
+                placeholder="~"
+                onChange={(event) => {
+                  onCreateDraftChange({ cwd: event.target.value })
+                }}
+                disabled={isMutating}
+              />
+            </label>
+
+            <button className="btn btn-primary btn-sm" type="submit" disabled={isMutating}>
+              Create Shell Session
+            </button>
+          </form>
+
+          <div className="divider my-1" />
+
+          <div className="min-h-0 space-y-2 overflow-y-auto pr-1">
+            {isLoading ? (
+              <p className="text-sm text-base-content/65">Loading shell sessions...</p>
+            ) : (snapshot?.sessions.length ?? 0) === 0 ? (
+              <p className="text-sm text-base-content/65">No shell sessions yet.</p>
+            ) : (
+              snapshot?.sessions.map((session) => (
+                <button
+                  key={session.id}
+                  type="button"
+                  className={`w-full rounded-lg border px-3 py-2 text-left ${
+                    selectedSessionId === session.id
+                      ? 'border-primary/60 bg-primary/10'
+                      : 'border-base-300/70 bg-base-100/45 hover:bg-base-100/70'
+                  }`}
+                  onClick={() => {
+                    onSelectSession(session.id)
+                  }}
+                >
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <span className="font-medium">shell</span>
+                    <span className={`badge badge-xs ${STATUS_BADGE_CLASS[session.status]}`}>{session.status}</span>
+                  </div>
+                  <p className="truncate text-xs text-base-content/65">{session.cwd}</p>
+                  <p className="truncate text-[11px] text-base-content/55">{session.id}</p>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="card border border-base-300/70 bg-base-100/70 shadow-panel">
+        <div className="card-body gap-4 p-4">
+          {selectedSession ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="card-title text-lg">Shell Session</h2>
+                <span className={`badge badge-sm ${STATUS_BADGE_CLASS[selectedSession.status]}`}>
+                  {selectedSession.status}
+                </span>
+                <span className={`badge badge-outline badge-sm ${socketConnected ? '' : 'badge-error'}`}>
+                  {socketConnected ? 'ws connected' : 'ws reconnecting'}
+                </span>
+                <span className="badge badge-outline badge-sm">{selectedSession.shell}</span>
+                <button
+                  type="button"
+                  className="btn btn-outline btn-xs ml-auto"
+                  onClick={onCloseSession}
+                  disabled={selectedSession.status === 'closed' || isMutating}
+                >
+                  Close Session
+                </button>
+              </div>
+
+              <p className="truncate text-xs text-base-content/60">cwd: {selectedSession.cwd}</p>
+
+              <div className="rounded-lg border border-base-300/70 bg-base-100/60 p-2">
+                <div
+                  ref={terminalHostRef}
+                  className="h-[520px] w-full overflow-hidden rounded-md border border-base-content/15 bg-[#090f14] p-1"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="flex h-[520px] items-center justify-center text-sm text-base-content/60">
+              Select or create a shell session to begin.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function disposeSafely(disposable: IDisposable): void {
+  try {
+    disposable.dispose()
+  } catch {
+    // no-op
+  }
+}

--- a/web/src/lib/shell-session-events.ts
+++ b/web/src/lib/shell-session-events.ts
@@ -1,0 +1,48 @@
+import {
+  type ShellSessionEvent,
+  type ShellSessionEventsPayload,
+} from '../types/dashboard.js'
+
+export function asShellSessionEventsPayload(
+  payload: unknown,
+): ShellSessionEventsPayload | null {
+  if (!payload || typeof payload !== 'object') return null
+
+  const sessionId = (payload as { sessionId?: unknown }).sessionId
+  const status = (payload as { status?: unknown }).status
+  const events = (payload as { events?: unknown }).events
+  const lastEventId = (payload as { lastEventId?: unknown }).lastEventId
+
+  if (typeof sessionId !== 'string') return null
+  if (status !== 'running' && status !== 'closed') return null
+  if (!Array.isArray(events)) return null
+  if (typeof lastEventId !== 'number') return null
+
+  return {
+    sessionId,
+    status,
+    events: events.filter((event): event is ShellSessionEvent => {
+      if (!event || typeof event !== 'object') return false
+      const maybeId = (event as { id?: unknown }).id
+      return typeof maybeId === 'number'
+    }),
+    lastEventId,
+  }
+}
+
+export function mergeShellSessionEvents(
+  existing: ShellSessionEvent[],
+  incoming: ShellSessionEvent[],
+): ShellSessionEvent[] {
+  const seen = new Set(existing.map((event) => event.id))
+  const merged = [...existing]
+
+  for (const event of incoming) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    merged.push(event)
+  }
+
+  merged.sort((a, b) => a.id - b.id)
+  return merged
+}

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -251,6 +251,45 @@ export interface InteractiveAgentSessionEventsPayload {
   lastEventId: number
 }
 
+export type ShellSessionStatus = 'running' | 'closed'
+export type ShellSessionEventType = 'status' | 'output' | 'exit'
+
+export interface ShellSessionSummary {
+  id: string
+  status: ShellSessionStatus
+  shell: string
+  cwd: string
+  cols: number
+  rows: number
+  createdAt: string
+  updatedAt: string
+  exitCode: number | null
+  exitSignal: number | null
+}
+
+export type ShellSessionDetail = ShellSessionSummary
+
+export interface ShellSessionEvent {
+  id: number
+  sessionId: string
+  timestamp: string
+  type: ShellSessionEventType
+  data: Record<string, unknown>
+}
+
+export interface ShellSessionsSnapshot {
+  generatedAt: string
+  homePath: string
+  sessions: ShellSessionSummary[]
+}
+
+export interface ShellSessionEventsPayload {
+  sessionId: string
+  status: ShellSessionStatus
+  events: ShellSessionEvent[]
+  lastEventId: number
+}
+
 export interface WsEnvelope {
   type: string
   payload?: unknown


### PR DESCRIPTION
Closes #150

## Plan
**Objective:** Add real shell access via browser by tunneling PTY sessions over WebSocket with xterm.js frontend

1. Install backend dependency: `node-pty` in package.json dependencies and `@types/node-pty` in devDependencies. Install frontend dependencies: `@xterm/xterm` and `@xterm/addon-fit` in web/package.json (or root devDependencies since web is built with Vite).
2. Create `src/web/shell-session.ts` — a ShellSessionManager class following the InteractiveAgentSessionManager pattern. Key differences: spawns a real PTY via `node-pty` (IPty) instead of streamingExec; stores sessions in a Map<string, ShellSessionState>; exposes create(cwd)/write(data)/resize(cols,rows)/close methods; emits output events via a listener pattern (same as agent-session.ts onSessionEvent); enforces max concurrent sessions (e.g. 5); auto-closes idle sessions after a configurable timeout (e.g. 30min).
3. Extend WebSocket types and handling in `src/web/server.ts`: (a) Add new WebSocketCommand variants: `shell-input` (sessionId + data string), `shell-resize` (sessionId + cols + rows), `subscribe-shell-session` (sessionId), `unsubscribe-shell-session` (sessionId). (b) Add `shellSubscriptions: Map<string, boolean>` to WsClientState. (c) Instantiate ShellSessionManager alongside InteractiveAgentSessionManager. (d) Handle shell WS commands in handleWsMessage — for shell-input, validate mutation auth on the WS connection, then call manager.write(). (e) Wire shell session output events to broadcast to subscribed WS clients as binary frames or JSON with base64-encoded data.
4. Add REST API endpoints in server.ts for shell session CRUD: POST `/api/shell/sessions` (create, mutation-guarded), GET `/api/shell/sessions` (list), DELETE `/api/shell/sessions/:id` (close, mutation-guarded). These follow the exact same pattern as the agent session endpoints.
5. Add frontend types in `web/src/types/dashboard.ts`: ShellSessionSummary (id, status, cwd, createdAt), ShellSessionsSnapshot, ShellOutputPayload. Add 'shell' to DASHBOARD_PAGES array (or replace 'agent' depending on user preference).
6. Create `web/src/components/ShellPage.tsx` — the terminal UI component. Uses @xterm/xterm Terminal instance with FitAddon. On mount: creates a shell session via POST, subscribes via WS, attaches xterm onData handler to send `shell-input` WS messages, renders incoming output. Includes: session list sidebar (like agent sessions), create/close buttons, resize handling via ResizeObserver + shell-resize WS command.
7. Update `web/src/components/DashboardNavigation.tsx` to add a 'shell' page entry with a terminal icon (e.g. `>_` prompt icon). Update `web/src/App.tsx` to add shell page state management (selectedShellSessionId, shellSessions list), WS message handling for shell-output, and render the ShellPage component when activePage === 'shell'.
8. Update `docs/USAGE.md` to document the new shell feature: how to access it in the web UI, security considerations (runs as server user), and any configuration options.

## Implementation
Addressed all review findings for shell security and sizing: added per-socket websocket auth state derived from `x-night-orch-web-token` (header) or `?token=` (query), enforced auth for shell websocket commands (`subscribe/unsubscribe-shell-session-events`, `shell-input`, `shell-resize`), required web-token auth on all `/api/shell/*` GET read endpoints, updated the web client to send auth headers for shell GET calls and include the token in websocket URL query, and fixed shell attach resize to send actual xterm dimensions (`terminal.cols`/`terminal.rows`) after fit. Added/updated tests to cover shell GET auth and authenticated vs unauthenticated shell websocket behavior.

**Changed files:**
- `src/web/server.ts`
- `web/src/App.tsx`
- `web/src/components/ShellSessionsPage.tsx`
- `test/web/server.test.ts`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
All previously reported blockers are addressed. WebSocket shell commands now enforce auth state before subscribe/input/resize (`src/web/server.ts:1754-2112`), shell read APIs are guarded by token validation for `GET /api/shell/*` (`src/web/server.ts:494-503`, `src/web/server.ts:1268-1284`), and terminal attach now reports live xterm dimensions instead of stale session metadata (`web/src/components/ShellSessionsPage.tsx:152-153`). Verification run: `pnpm test -- test/web/server.test.ts test/web/router-integration.test.ts` (pass), `pnpm typecheck` (pass), `pnpm lint` (pass).

---

**Triage:** standard | **Iterations:** 2 | **Roles:** plan=claude code=codex review=codex