### PR TITLE
[CHORE] Web - issue actions - move to issue show page (night-orch / #141)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -373,6 +373,7 @@ Start the embedded web control surface. Serves the React/Tailwind frontend, a RE
 
 By default, `web` runs in attach mode: no poll loop, no metrics server, and no embedded MCP server are started in the web process. Manual web operations (`poll`, `sync`, `cleanup`, `retry`, `continue`, `rebase`, `delete entry`, runtime settings set/clear) remain available and execute in the web process.
 Use `--standalone` to run poller + metrics + embedded MCP in the same process as the web server.
+Issue-specific actions (`retry`, `continue`, `rebase`, `delete entry`) are launched from each issue's detail page and require a confirmation dialog before execution. `Delete entry` also supports a force toggle for active/shared-state cleanup scenarios.
 
 The web UI includes a **Shell** page for real browser terminal access backed by PTY sessions. Shells start in the current user's home directory (or a home subdirectory you choose), stream output live over websocket, and expose REST routes under `/api/shell/sessions` (create/list/detail/events/close).
 On narrow mobile viewports, the top-line dashboard metric cards render in a compact 2-column layout so the runs list stays the primary focus on the Issues page.

--- a/test/web/router-integration.test.ts
+++ b/test/web/router-integration.test.ts
@@ -9,6 +9,7 @@ import { createDashboardRouter } from '../../web/src/router.js'
 import {
   type DashboardSnapshot,
   type ProjectsSnapshot,
+  type RunSummary,
   type SettingsSnapshot,
   type SessionResponse,
   type ShellSessionsSnapshot,
@@ -132,6 +133,22 @@ const DASHBOARD_SNAPSHOT: DashboardSnapshot = {
   },
 }
 
+const ISSUE_DETAIL_RUN: RunSummary = {
+  runId: 'run-issue-1',
+  hasRun: true,
+  repo: 'org/repo',
+  issue: 42,
+  issueTitle: 'Issue detail action coverage',
+  status: 'blocked',
+  prNumber: 123,
+  phase: 'verify',
+  iterations: 2,
+  costUsd: 1.25,
+  lastError: null,
+  startedAt: '2026-04-06T09:55:00.000Z',
+  endedAt: null,
+}
+
 const PROJECTS_SNAPSHOT: ProjectsSnapshot = {
   generatedAt: '2026-04-06T10:00:00.000Z',
   githubDefaults: {
@@ -184,24 +201,66 @@ function createJsonResponse(payload: unknown, status = 200): Response {
   })
 }
 
-function buildFetchMock() {
-  return vi.fn(async (input: string | URL | Request) => {
+function withRuns(runs: RunSummary[]): DashboardSnapshot {
+  return {
+    ...DASHBOARD_SNAPSHOT,
+    runs: {
+      count: runs.length,
+      runs,
+    },
+  }
+}
+
+function buildFetchMock(snapshot: DashboardSnapshot = DASHBOARD_SNAPSHOT) {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const rawUrl = typeof input === 'string'
       ? input
       : input instanceof URL
         ? input.toString()
         : input.url
     const pathname = new URL(rawUrl, window.location.origin).pathname
+    const method = init?.method ?? (input instanceof Request ? input.method : 'GET')
 
-    if (pathname === '/api/dashboard') return createJsonResponse(DASHBOARD_SNAPSHOT)
+    if (pathname === '/api/dashboard') return createJsonResponse(snapshot)
     if (pathname === '/api/session') return createJsonResponse(SESSION_RESPONSE)
     if (pathname === '/api/projects') return createJsonResponse(PROJECTS_SNAPSHOT)
     if (pathname === '/api/settings') return createJsonResponse(SETTINGS_SNAPSHOT)
     if (pathname === '/api/shell/sessions') return createJsonResponse(SHELL_SESSIONS_SNAPSHOT)
     if (pathname === '/api/update-status') return createJsonResponse({}, 404)
+    if (method === 'POST' && pathname.startsWith('/api/operations/')) {
+      return createJsonResponse({ message: `${pathname} accepted` })
+    }
 
     return createJsonResponse({ error: `Unhandled endpoint: ${pathname}` }, 404)
   })
+}
+
+interface OperationCall {
+  pathname: string
+  body: Record<string, unknown>
+}
+
+function listOperationCalls(fetchMock: ReturnType<typeof buildFetchMock>): OperationCall[] {
+  return fetchMock.mock.calls
+    .map(([input, init]) => {
+      const rawUrl = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+      const pathname = new URL(rawUrl, window.location.origin).pathname
+      const method = init?.method ?? (input instanceof Request ? input.method : 'GET')
+      if (method !== 'POST' || !pathname.startsWith('/api/operations/')) {
+        return null
+      }
+
+      const rawBody = init?.body
+      if (typeof rawBody !== 'string') {
+        return { pathname, body: {} }
+      }
+      return { pathname, body: JSON.parse(rawBody) as Record<string, unknown> }
+    })
+    .filter((call): call is OperationCall => call !== null)
 }
 
 function renderDashboard(pathname: string) {
@@ -322,6 +381,72 @@ describe('dashboard router integration (real App)', () => {
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/issues')
     })
+  })
+
+  it('runs issue detail actions after confirmation and forwards force delete payload', async () => {
+    const fetchMock = buildFetchMock(withRuns([ISSUE_DETAIL_RUN]))
+    vi.stubGlobal('fetch', fetchMock)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const { router } = renderDashboard('/issues/run-issue-1')
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/issues/run-issue-1')
+    })
+
+    expect(screen.getByText('Issue Detail')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Queue Retry' })).toBeDefined()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Retry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Rebase' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Continue Pass' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Local Entry' }))
+
+    await waitFor(() => {
+      expect(listOperationCalls(fetchMock)).toHaveLength(4)
+    })
+
+    fireEvent.click(screen.getByLabelText('Force delete (for active/shared issue state)'))
+    fireEvent.click(screen.getByRole('button', { name: 'Force Delete Local Entry' }))
+
+    await waitFor(() => {
+      expect(listOperationCalls(fetchMock)).toHaveLength(5)
+    })
+
+    const operationCalls = listOperationCalls(fetchMock)
+    expect(operationCalls.map((call) => call.pathname)).toEqual([
+      '/api/operations/retry',
+      '/api/operations/rebase',
+      '/api/operations/continue',
+      '/api/operations/delete-entry',
+      '/api/operations/delete-entry',
+    ])
+
+    expect(operationCalls[0]?.body).toMatchObject({ repo: 'org/repo', issueNumber: 42, resetPlan: false, fresh: false })
+    expect(operationCalls[1]?.body).toMatchObject({ repo: 'org/repo', issueNumber: 42 })
+    expect(operationCalls[2]?.body).toMatchObject({ repo: 'org/repo', issueNumber: 42 })
+    expect(operationCalls[3]?.body).toMatchObject({ repo: 'org/repo', issueNumber: 42, force: false })
+    expect(operationCalls[4]?.body).toMatchObject({ repo: 'org/repo', issueNumber: 42, force: true })
+
+    expect(confirmSpy).toHaveBeenCalledTimes(5)
+  })
+
+  it('skips issue detail operations when confirmation is declined', async () => {
+    const fetchMock = buildFetchMock(withRuns([ISSUE_DETAIL_RUN]))
+    vi.stubGlobal('fetch', fetchMock)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    const { router } = renderDashboard('/issues/run-issue-1')
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/issues/run-issue-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Retry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Rebase' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Queue Continue Pass' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Local Entry' }))
+
+    expect(confirmSpy).toHaveBeenCalledTimes(4)
+    expect(listOperationCalls(fetchMock)).toHaveLength(0)
   })
 
   it('renders project detail route and navigates back to projects list', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import {
   type ProjectsSnapshot,
   type RuntimeSettingValue,
   type RunEvent,
+  type RunSummary,
   type ShellSessionDetail,
   type ShellSessionEvent,
   type ShellSessionsSnapshot,
@@ -114,21 +115,7 @@ export function App({
     issueNumber: '',
     amount: '',
   })
-
-  const [retryRepo, setRetryRepo] = useState('')
-  const [retryIssueNumber, setRetryIssueNumber] = useState('')
-  const [retryResetPlan, setRetryResetPlan] = useState(false)
-  const [retryFresh, setRetryFresh] = useState(false)
-
-  const [rebaseRepo, setRebaseRepo] = useState('')
-  const [rebaseIssueNumber, setRebaseIssueNumber] = useState('')
-  const [continueRepo, setContinueRepo] = useState('')
-  const [continueIssueNumber, setContinueIssueNumber] = useState('')
   const [labelsInitRepo, setLabelsInitRepo] = useState('')
-
-  const [deleteRepo, setDeleteRepo] = useState('')
-  const [deleteIssueNumber, setDeleteIssueNumber] = useState('')
-  const [deleteForce, setDeleteForce] = useState(false)
 
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null)
 
@@ -341,19 +328,11 @@ export function App({
 
   useEffect(() => {
     if (repos.length === 0) {
-      setRetryRepo('')
-      setRebaseRepo('')
-      setContinueRepo('')
       setLabelsInitRepo('')
-      setDeleteRepo('')
       return
     }
 
-    setRetryRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
-    setRebaseRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
-    setContinueRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setLabelsInitRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
-    setDeleteRepo((prev) => (prev && repos.includes(prev) ? prev : repos[0] ?? ''))
     setSelectedRepo((prev) => (prev === 'all' || repos.includes(prev) ? prev : 'all'))
   }, [repos])
 
@@ -826,65 +805,78 @@ export function App({
     }
   }, [readUpdateStatus, runOperation])
 
-  const submitRetry = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const issueNumber = Number.parseInt(retryIssueNumber, 10)
-    if (!retryRepo || !Number.isFinite(issueNumber) || issueNumber <= 0) {
-      setErrorMessage('Retry requires a repo and a positive issue number')
+  const runIssueOperation = useCallback(async (
+    run: RunSummary,
+    options: {
+      operationName: string
+      endpoint: string
+      confirmMessage: string
+      fallbackMessage: string
+      payload?: Record<string, unknown>
+    },
+  ) => {
+    if (!window.confirm(options.confirmMessage)) {
       return
     }
 
     await runOperation(
-      'retry',
-      '/api/operations/retry',
+      options.operationName,
+      options.endpoint,
       {
-        repo: retryRepo,
-        issueNumber,
-        resetPlan: retryResetPlan,
-        fresh: retryFresh,
+        repo: run.repo,
+        issueNumber: run.issue,
+        ...options.payload,
       },
-      `Retry queued for ${retryRepo}#${issueNumber}`,
+      options.fallbackMessage,
     )
-  }, [retryFresh, retryIssueNumber, retryRepo, retryResetPlan, runOperation])
+  }, [runOperation])
 
-  const submitRebase = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const issueNumber = Number.parseInt(rebaseIssueNumber, 10)
-    if (!rebaseRepo || !Number.isFinite(issueNumber) || issueNumber <= 0) {
-      setErrorMessage('Rebase requires a repo and a positive issue number')
-      return
-    }
-
-    await runOperation(
-      'rebase',
-      '/api/operations/rebase',
-      {
-        repo: rebaseRepo,
-        issueNumber,
+  const triggerIssueRetry = useCallback((run: RunSummary) => {
+    void runIssueOperation(run, {
+      operationName: 'retry',
+      endpoint: '/api/operations/retry',
+      confirmMessage: `Queue retry for ${run.repo}#${run.issue}?`,
+      fallbackMessage: `Retry queued for ${run.repo}#${run.issue}`,
+      payload: {
+        resetPlan: false,
+        fresh: false,
       },
-      `Rebase queued for ${rebaseRepo}#${issueNumber}`,
-    )
-  }, [rebaseIssueNumber, rebaseRepo, runOperation])
+    })
+  }, [runIssueOperation])
 
-  const submitDeleteEntry = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const issueNumber = Number.parseInt(deleteIssueNumber, 10)
-    if (!deleteRepo || !Number.isFinite(issueNumber) || issueNumber <= 0) {
-      setErrorMessage('Delete entry requires a repo and a positive issue number')
-      return
-    }
+  const triggerIssueRebase = useCallback((run: RunSummary) => {
+    void runIssueOperation(run, {
+      operationName: 'rebase',
+      endpoint: '/api/operations/rebase',
+      confirmMessage: `Queue rebase for ${run.repo}#${run.issue}?`,
+      fallbackMessage: `Rebase queued for ${run.repo}#${run.issue}`,
+    })
+  }, [runIssueOperation])
 
-    await runOperation(
-      'delete-entry',
-      '/api/operations/delete-entry',
-      {
-        repo: deleteRepo,
-        issueNumber,
-        force: deleteForce,
+  const triggerIssueContinue = useCallback((run: RunSummary) => {
+    void runIssueOperation(run, {
+      operationName: 'continue',
+      endpoint: '/api/operations/continue',
+      confirmMessage: `Queue continue pass for ${run.repo}#${run.issue}?`,
+      fallbackMessage: `Continue pass queued for ${run.repo}#${run.issue}`,
+    })
+  }, [runIssueOperation])
+
+  const triggerIssueDeleteEntry = useCallback((run: RunSummary, force: boolean) => {
+    void runIssueOperation(run, {
+      operationName: 'delete-entry',
+      endpoint: '/api/operations/delete-entry',
+      confirmMessage: force
+        ? `Force delete local entry for ${run.repo}#${run.issue}? This can remove run-local state while shared issue state is still active elsewhere.`
+        : `Delete local entry for ${run.repo}#${run.issue}?`,
+      fallbackMessage: force
+        ? `Force-deleted local entry for ${run.repo}#${run.issue}`
+        : `Deleted local entry for ${run.repo}#${run.issue}`,
+      payload: {
+        force,
       },
-      `Deleted local entry for ${deleteRepo}#${issueNumber}`,
-    )
-  }, [deleteForce, deleteIssueNumber, deleteRepo, runOperation])
+    })
+  }, [runIssueOperation])
 
   const submitLabelsInit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -902,25 +894,6 @@ export function App({
       `Labels initialized for ${labelsInitRepo}`,
     )
   }, [labelsInitRepo, runOperation])
-
-  const submitContinue = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const issueNumber = Number.parseInt(continueIssueNumber, 10)
-    if (!continueRepo || !Number.isFinite(issueNumber) || issueNumber <= 0) {
-      setErrorMessage('Continue requires a repo and a positive issue number')
-      return
-    }
-
-    await runOperation(
-      'continue',
-      '/api/operations/continue',
-      {
-        repo: continueRepo,
-        issueNumber,
-      },
-      `Continue pass queued for ${continueRepo}#${issueNumber}`,
-    )
-  }, [continueIssueNumber, continueRepo, runOperation])
 
   const applySetting = useCallback(async (key: string) => {
     const value = settingsDrafts[key]
@@ -1114,6 +1087,12 @@ export function App({
                   run={selectedIssueDetailRun}
                   runId={decodedIssueDetailRunId ?? ''}
                   runEvents={runEvents}
+                  operationsEnabled={operationsEnabled}
+                  activeOperation={activeOperation}
+                  onRetry={triggerIssueRetry}
+                  onRebase={triggerIssueRebase}
+                  onContinue={triggerIssueContinue}
+                  onDeleteEntry={triggerIssueDeleteEntry}
                   onBack={closeIssueDetail}
                 />
               ) : (
@@ -1137,46 +1116,8 @@ export function App({
                       activeOperation={activeOperation}
                       updateStatus={updateStatus}
                       repos={repos}
-                      retryForm={{
-                        repo: retryRepo,
-                        issueNumber: retryIssueNumber,
-                        resetPlan: retryResetPlan,
-                        fresh: retryFresh,
-                      }}
-                      rebaseForm={{
-                        repo: rebaseRepo,
-                        issueNumber: rebaseIssueNumber,
-                      }}
-                      continueForm={{
-                        repo: continueRepo,
-                        issueNumber: continueIssueNumber,
-                      }}
-                      deleteEntryForm={{
-                        repo: deleteRepo,
-                        issueNumber: deleteIssueNumber,
-                        force: deleteForce,
-                      }}
                       labelsInitForm={{
                         repo: labelsInitRepo,
-                      }}
-                      onRetryFormChange={(patch) => {
-                        if (patch.repo !== undefined) setRetryRepo(patch.repo)
-                        if (patch.issueNumber !== undefined) setRetryIssueNumber(patch.issueNumber)
-                        if (patch.resetPlan !== undefined) setRetryResetPlan(patch.resetPlan)
-                        if (patch.fresh !== undefined) setRetryFresh(patch.fresh)
-                      }}
-                      onRebaseFormChange={(patch) => {
-                        if (patch.repo !== undefined) setRebaseRepo(patch.repo)
-                        if (patch.issueNumber !== undefined) setRebaseIssueNumber(patch.issueNumber)
-                      }}
-                      onContinueFormChange={(patch) => {
-                        if (patch.repo !== undefined) setContinueRepo(patch.repo)
-                        if (patch.issueNumber !== undefined) setContinueIssueNumber(patch.issueNumber)
-                      }}
-                      onDeleteEntryFormChange={(patch) => {
-                        if (patch.repo !== undefined) setDeleteRepo(patch.repo)
-                        if (patch.issueNumber !== undefined) setDeleteIssueNumber(patch.issueNumber)
-                        if (patch.force !== undefined) setDeleteForce(patch.force)
                       }}
                       onLabelsInitFormChange={(patch) => {
                         if (patch.repo !== undefined) setLabelsInitRepo(patch.repo)
@@ -1186,18 +1127,6 @@ export function App({
                       onCleanup={triggerCleanup}
                       onLabelsInitSubmit={(event) => {
                         void submitLabelsInit(event)
-                      }}
-                      onRetrySubmit={(event) => {
-                        void submitRetry(event)
-                      }}
-                      onRebaseSubmit={(event) => {
-                        void submitRebase(event)
-                      }}
-                      onContinueSubmit={(event) => {
-                        void submitContinue(event)
-                      }}
-                      onDeleteEntrySubmit={(event) => {
-                        void submitDeleteEntry(event)
                       }}
                       onUpdate={() => {
                         void submitUpdate()

--- a/web/src/components/IssueDetailPage.tsx
+++ b/web/src/components/IssueDetailPage.tsx
@@ -2,11 +2,18 @@ import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react'
 
 import { describeEventData, formatTimestamp, truncate } from '../lib/format.js'
 import { type RunEvent, type RunSummary } from '../types/dashboard.js'
+import { ActionButton } from './ActionButton.js'
 
 interface IssueDetailPageProps {
   run: RunSummary | null
   runId: string
   runEvents: RunEvent[]
+  operationsEnabled: boolean
+  activeOperation: string | null
+  onRetry: (run: RunSummary) => void
+  onRebase: (run: RunSummary) => void
+  onContinue: (run: RunSummary) => void
+  onDeleteEntry: (run: RunSummary, force: boolean) => void
   onBack: () => void
 }
 
@@ -17,9 +24,16 @@ export function IssueDetailPage({
   run,
   runId,
   runEvents,
+  operationsEnabled,
+  activeOperation,
+  onRetry,
+  onRebase,
+  onContinue,
+  onDeleteEntry,
   onBack,
 }: IssueDetailPageProps): ReactElement {
   const [autoScroll, setAutoScroll] = useState(true)
+  const [forceDelete, setForceDelete] = useState(false)
   const eventsContainerRef = useRef<HTMLDivElement | null>(null)
 
   const visibleEvents = useMemo(
@@ -35,6 +49,7 @@ export function IssueDetailPage({
 
   useEffect(() => {
     setAutoScroll(true)
+    setForceDelete(false)
   }, [runId])
 
   return (
@@ -90,6 +105,52 @@ export function IssueDetailPage({
                 {'  ·  '}
                 ended {run.endedAt ? formatTimestamp(run.endedAt) : '-'}
               </p>
+            </section>
+
+            <section className="min-w-0 rounded-box border border-base-300/70 bg-base-100/70 px-3 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-sm font-semibold text-base-content">Issue Actions</h3>
+                <p className="text-xs text-base-content/65">Each action requires confirmation.</p>
+              </div>
+              {!operationsEnabled && (
+                <div className="alert alert-warning mt-3 text-xs">
+                  <span>Operations are disabled by server policy for this web instance.</span>
+                </div>
+              )}
+              <fieldset
+                disabled={!operationsEnabled}
+                className={`mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 ${!operationsEnabled ? 'opacity-60' : ''}`}
+              >
+                <ActionButton
+                  busy={activeOperation === 'retry'}
+                  onClick={() => onRetry(run)}
+                  label="Queue Retry"
+                />
+                <ActionButton
+                  busy={activeOperation === 'rebase'}
+                  onClick={() => onRebase(run)}
+                  label="Queue Rebase"
+                />
+                <ActionButton
+                  busy={activeOperation === 'continue'}
+                  onClick={() => onContinue(run)}
+                  label="Queue Continue Pass"
+                />
+                <label className="label cursor-pointer justify-start gap-2 py-0 sm:col-span-2">
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-warning checkbox-sm"
+                    checked={forceDelete}
+                    onChange={(event) => setForceDelete(event.target.checked)}
+                  />
+                  <span className="label-text text-xs">Force delete (for active/shared issue state)</span>
+                </label>
+                <ActionButton
+                  busy={activeOperation === 'delete-entry'}
+                  onClick={() => onDeleteEntry(run, forceDelete)}
+                  label={forceDelete ? 'Force Delete Local Entry' : 'Delete Local Entry'}
+                />
+              </fieldset>
             </section>
 
             {!run.hasRun ? (

--- a/web/src/components/OperationsPanel.tsx
+++ b/web/src/components/OperationsPanel.tsx
@@ -3,29 +3,6 @@ import { type FormEvent, type ReactElement } from 'react'
 import { type UpdateStatus } from '../types/dashboard.js'
 import { ActionButton } from './ActionButton.js'
 
-interface RetryFormState {
-  repo: string
-  issueNumber: string
-  resetPlan: boolean
-  fresh: boolean
-}
-
-interface RebaseFormState {
-  repo: string
-  issueNumber: string
-}
-
-interface ContinueFormState {
-  repo: string
-  issueNumber: string
-}
-
-interface DeleteEntryFormState {
-  repo: string
-  issueNumber: string
-  force: boolean
-}
-
 interface LabelsInitFormState {
   repo: string
 }
@@ -35,24 +12,12 @@ interface OperationsPanelProps {
   activeOperation: string | null
   updateStatus: UpdateStatus | null
   repos: string[]
-  retryForm: RetryFormState
-  rebaseForm: RebaseFormState
-  continueForm: ContinueFormState
-  deleteEntryForm: DeleteEntryFormState
   labelsInitForm: LabelsInitFormState
-  onRetryFormChange: (patch: Partial<RetryFormState>) => void
-  onRebaseFormChange: (patch: Partial<RebaseFormState>) => void
-  onContinueFormChange: (patch: Partial<ContinueFormState>) => void
-  onDeleteEntryFormChange: (patch: Partial<DeleteEntryFormState>) => void
   onLabelsInitFormChange: (patch: Partial<LabelsInitFormState>) => void
   onPoll: () => void
   onSync: () => void
   onCleanup: () => void
   onLabelsInitSubmit: (event: FormEvent<HTMLFormElement>) => void
-  onRetrySubmit: (event: FormEvent<HTMLFormElement>) => void
-  onRebaseSubmit: (event: FormEvent<HTMLFormElement>) => void
-  onContinueSubmit: (event: FormEvent<HTMLFormElement>) => void
-  onDeleteEntrySubmit: (event: FormEvent<HTMLFormElement>) => void
   onUpdate: () => void
 }
 
@@ -61,24 +26,12 @@ export function OperationsPanel({
   activeOperation,
   updateStatus,
   repos,
-  retryForm,
-  rebaseForm,
-  continueForm,
-  deleteEntryForm,
   labelsInitForm,
-  onRetryFormChange,
-  onRebaseFormChange,
-  onContinueFormChange,
-  onDeleteEntryFormChange,
   onLabelsInitFormChange,
   onPoll,
   onSync,
   onCleanup,
   onLabelsInitSubmit,
-  onRetrySubmit,
-  onRebaseSubmit,
-  onContinueSubmit,
-  onDeleteEntrySubmit,
   onUpdate,
 }: OperationsPanelProps): ReactElement {
   const updateRunning =
@@ -122,165 +75,6 @@ export function OperationsPanel({
                 </select>
               </label>
               <ActionButton busy={activeOperation === 'labels-init'} label="Bootstrap Labels" submit />
-            </div>
-          </form>
-
-          <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onRetrySubmit}>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Retry</h3>
-            <div className="mt-2 space-y-2">
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Repo</span>
-                </div>
-                <select
-                  className="select select-bordered select-sm w-full bg-base-100/90"
-                  value={retryForm.repo}
-                  onChange={(event) => onRetryFormChange({ repo: event.target.value })}
-                >
-                  {repos.map((repo) => (
-                    <option key={repo} value={repo}>{repo}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Issue Number</span>
-                </div>
-                <input
-                  className="input input-bordered input-sm w-full bg-base-100/90"
-                  value={retryForm.issueNumber}
-                  onChange={(event) => onRetryFormChange({ issueNumber: event.target.value })}
-                  inputMode="numeric"
-                  placeholder="123"
-                />
-              </label>
-              <label className="label cursor-pointer justify-start gap-2 py-0">
-                <input
-                  type="checkbox"
-                  className="checkbox checkbox-info checkbox-sm"
-                  checked={retryForm.resetPlan}
-                  onChange={(event) => onRetryFormChange({ resetPlan: event.target.checked })}
-                />
-                <span className="label-text text-xs">Reset saved plan</span>
-              </label>
-              <label className="label cursor-pointer justify-start gap-2 py-0">
-                <input
-                  type="checkbox"
-                  className="checkbox checkbox-info checkbox-sm"
-                  checked={retryForm.fresh}
-                  onChange={(event) => onRetryFormChange({ fresh: event.target.checked })}
-                />
-                <span className="label-text text-xs">Fresh branch reset</span>
-              </label>
-              <ActionButton busy={activeOperation === 'retry'} label="Queue Retry" submit />
-            </div>
-          </form>
-
-          <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onRebaseSubmit}>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Rebase</h3>
-            <div className="mt-2 space-y-2">
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Repo</span>
-                </div>
-                <select
-                  className="select select-bordered select-sm w-full bg-base-100/90"
-                  value={rebaseForm.repo}
-                  onChange={(event) => onRebaseFormChange({ repo: event.target.value })}
-                >
-                  {repos.map((repo) => (
-                    <option key={repo} value={repo}>{repo}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Issue Number</span>
-                </div>
-                <input
-                  className="input input-bordered input-sm w-full bg-base-100/90"
-                  value={rebaseForm.issueNumber}
-                  onChange={(event) => onRebaseFormChange({ issueNumber: event.target.value })}
-                  inputMode="numeric"
-                  placeholder="123"
-                />
-              </label>
-              <ActionButton busy={activeOperation === 'rebase'} label="Queue Rebase" submit />
-            </div>
-          </form>
-
-          <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onContinueSubmit}>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Continue</h3>
-            <div className="mt-2 space-y-2">
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Repo</span>
-                </div>
-                <select
-                  className="select select-bordered select-sm w-full bg-base-100/90"
-                  value={continueForm.repo}
-                  onChange={(event) => onContinueFormChange({ repo: event.target.value })}
-                >
-                  {repos.map((repo) => (
-                    <option key={repo} value={repo}>{repo}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Issue Number</span>
-                </div>
-                <input
-                  className="input input-bordered input-sm w-full bg-base-100/90"
-                  value={continueForm.issueNumber}
-                  onChange={(event) => onContinueFormChange({ issueNumber: event.target.value })}
-                  inputMode="numeric"
-                  placeholder="123"
-                />
-              </label>
-              <ActionButton busy={activeOperation === 'continue'} label="Queue Continue Pass" submit />
-            </div>
-          </form>
-
-          <form className="rounded-box border border-base-300/70 bg-base-100/60 p-3" onSubmit={onDeleteEntrySubmit}>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-info">Delete Entry</h3>
-            <div className="mt-2 space-y-2">
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Repo</span>
-                </div>
-                <select
-                  className="select select-bordered select-sm w-full bg-base-100/90"
-                  value={deleteEntryForm.repo}
-                  onChange={(event) => onDeleteEntryFormChange({ repo: event.target.value })}
-                >
-                  {repos.map((repo) => (
-                    <option key={repo} value={repo}>{repo}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="form-control">
-                <div className="label py-0 pb-1">
-                  <span className="label-text text-xs">Issue Number</span>
-                </div>
-                <input
-                  className="input input-bordered input-sm w-full bg-base-100/90"
-                  value={deleteEntryForm.issueNumber}
-                  onChange={(event) => onDeleteEntryFormChange({ issueNumber: event.target.value })}
-                  inputMode="numeric"
-                  placeholder="123"
-                />
-              </label>
-              <label className="label cursor-pointer justify-start gap-2 py-0">
-                <input
-                  type="checkbox"
-                  className="checkbox checkbox-warning checkbox-sm"
-                  checked={deleteEntryForm.force}
-                  onChange={(event) => onDeleteEntryFormChange({ force: event.target.checked })}
-                />
-                <span className="label-text text-xs">Force delete if running</span>
-              </label>
-              <ActionButton busy={activeOperation === 'delete-entry'} label="Delete Local Entry" submit />
             </div>
           </form>
         </fieldset>


### PR DESCRIPTION
Closes #141

## Plan
**Objective:** Move issue-specific actions (Retry, Rebase, Continue, Delete Entry) from OperationsPanel to IssueDetailPage with confirmation dialogs

1. Slim down OperationsPanel: remove the 4 issue-specific forms (Retry, Rebase, Continue, Delete Entry) and their associated props. Keep Poll, Sync, Cleanup, Labels Init, and Deploy sections.
2. Update App.tsx: (a) Remove the issue-specific form state variables (retryRepo/retryIssueNumber/etc, rebaseRepo/etc, continueRepo/etc, deleteRepo/etc) — these are no longer needed since repo+issue come from the RunSummary. (b) Remove the form change callbacks and form prop wiring from OperationsPanel. (c) Create new simplified submit callbacks for Retry/Rebase/Continue/DeleteEntry that accept repo+issueNumber+options directly (no form state). (d) Pass these callbacks and operationsEnabled/activeOperation down to IssueDetailPage.
3. Update IssueDetailPage: (a) Accept new props for operation callbacks (onRetry, onRebase, onContinue, onDeleteEntry) plus operationsEnabled and activeOperation. (b) Add an action bar below the issue summary with 4 action buttons (Retry, Rebase, Continue, Delete Entry). (c) Each button opens a ModalWeb confirmation dialog — Retry dialog includes resetPlan/fresh checkboxes, Delete dialog includes force checkbox, Rebase and Continue are simple confirms. (d) On confirm, call the appropriate callback with the run's repo and issue number. (e) Disable buttons when operationsEnabled is false or an operation is in progress.
4. Remove the useEffect that syncs retryRepo/rebaseRepo/continueRepo/deleteRepo with the repos array, since those state variables are gone. Clean up unused imports.
5. Verify: run pnpm typecheck && pnpm lint to ensure no compilation or lint errors.

## Implementation
Implemented the issue-action move to Issue Detail and addressed review findings: added a force-delete control in Issue Detail (`Force delete (for active/shared issue state)`), reset that toggle on run change, and wired delete to pass `force` through to `/api/operations/delete-entry` with a stronger confirmation message when force is enabled. Kept Retry/Rebase/Continue/Delete as confirmed actions on Issue Detail and removed issue selector forms from OperationsPanel. Added router integration tests that use a real run snapshot and verify: (1) confirm-accepted paths call `/api/operations/retry|rebase|continue|delete-entry`, including both `force: false` and `force: true` delete payloads, and (2) confirm-declined paths perform no operation calls. Updated docs to reflect Issue Detail action location and force-delete availability. Validation passed: `pnpm -s typecheck`, `pnpm -s lint`, `pnpm -s test`.

**Changed files:**
- `web/src/App.tsx`
- `web/src/components/IssueDetailPage.tsx`
- `web/src/components/OperationsPanel.tsx`
- `test/web/router-integration.test.ts`
- `docs/USAGE.md`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all modified files in full (`web/src/App.tsx`, `web/src/components/IssueDetailPage.tsx`, `web/src/components/OperationsPanel.tsx`, `test/web/router-integration.test.ts`, `docs/USAGE.md`) plus adjacent backend behavior (`src/ops/delete-entry.ts`, `src/web/routes/api-operations.ts`). The prior major gaps are addressed: force-delete is available from Issue Detail and forwarded to `/api/operations/delete-entry`, all issue actions are confirm-gated, and integration tests now verify both confirmation accepted/declined flows and force payload behavior. Verification passed: `pnpm typecheck`, `pnpm lint`, and `pnpm test`.

---

**Triage:** standard | **Iterations:** 4 | **Roles:** plan=claude code=codex review=codex