### PR TITLE
[CHORE] Web - Improve error card readability and add copy button (night-orch / #158)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { mergeConfig, type UserConfig } from 'vite'
 
 const config: StorybookConfig = {
-  stories: ['../src/components/**/*.stories.@(ts|tsx)'],
+  stories: ['../src/components/**/*.stories.@(ts|tsx)', '../web/src/components/**/*.stories.@(ts|tsx)'],
   addons: ['@storybook/addon-a11y'],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,8 +1,13 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../web/tsconfig.json",
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["../src/components/**/*.ts", "../src/components/**/*.tsx"],
+  "include": [
+    "../src/components/**/*.ts",
+    "../src/components/**/*.tsx",
+    "../web/src/components/**/*.ts",
+    "../web/src/components/**/*.tsx"
+  ],
   "exclude": ["../node_modules", "../dist", "../test"]
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -558,6 +558,7 @@ Issue detail pages render line-oriented issue history rather than only the curre
 The web client now keeps the websocket open across auth-token refreshes, uses heartbeat-based liveness detection, and reconnects with exponential backoff instead of a fixed 2-second loop.
 On narrow mobile viewports, the top-line dashboard metric cards render in a compact 2-column layout so the runs list stays the primary focus on the Issues page.
 The Issues page run list now includes history filters (`Active`, `Completed`, `Failed`, `All`) plus a `Load more` control for paginated archive browsing (20 runs per page).
+Inline run errors on both issue cards and issue detail pages are rendered in a reusable error block with line numbers, a one-click copy control (`Copied!` feedback), and expand/collapse controls for long traces.
 
 For mobile or server-hosted setups, use an external terminal client such as Terminus instead of expecting shell access through the browser UI.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "night-orch",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Nightly GitHub/Forgejo issue orchestrator — autonomous AI agent coding tool",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "night-orch",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Nightly GitHub/Forgejo issue orchestrator — autonomous AI agent coding tool",
   "license": "MIT",
   "repository": {

--- a/src/components/badge/badge.web.tsx
+++ b/src/components/badge/badge.web.tsx
@@ -4,6 +4,20 @@ import { buildBadgeViewModel } from './view-model.js'
 
 export function BadgeWeb(props: BadgeProps): ReactElement {
   const badge = buildBadgeViewModel(props)
+  const {
+    children,
+    tone: _tone,
+    variant: _variant,
+    size: _size,
+    capitalize: _capitalize,
+    className: _className,
+    ...nativeProps
+  } = props
+  void _tone
+  void _variant
+  void _size
+  void _capitalize
+  void _className
 
-  return <span className={badge.webClassName}>{props.children}</span>
+  return <span {...nativeProps} className={badge.webClassName}>{children}</span>
 }

--- a/src/components/badge/types.ts
+++ b/src/components/badge/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
 
 export type BadgeTone =
   | 'neutral'
@@ -14,7 +14,7 @@ export type BadgeTone =
 export type BadgeVariant = 'solid' | 'outline'
 export type BadgeSize = 'xs' | 'sm' | 'md'
 
-export interface BadgeProps {
+export interface BadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children' | 'className'> {
   children: ReactNode
   tone?: BadgeTone
   variant?: BadgeVariant

--- a/src/metrics/service.ts
+++ b/src/metrics/service.ts
@@ -83,6 +83,34 @@ class LiveMetricsService implements MetricsService {
   }
 
   async start(): Promise<void> {
+    const maxRetries = 5
+    const baseDelayMs = 1000
+
+    for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+      try {
+        await this.tryListen()
+        return
+      } catch (err) {
+        const isAddrInUse = err instanceof Error
+          && 'code' in err
+          && (err as NodeJS.ErrnoException).code === 'EADDRINUSE'
+        if (!isAddrInUse || attempt === maxRetries) {
+          throw err
+        }
+
+        const delay = baseDelayMs * Math.pow(2, attempt)
+        logger.warn(
+          { port: this.config.port, attempt: attempt + 1, maxRetries, delayMs: delay },
+          'Metrics port in use — retrying',
+        )
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delay)
+        })
+      }
+    }
+  }
+
+  private async tryListen(): Promise<void> {
     const server = startMetricsServer(this.metrics, this.config.host, this.config.port)
     this.server = server
     await new Promise<void>((resolve, reject) => {

--- a/src/poller/attempt-dispatcher.ts
+++ b/src/poller/attempt-dispatcher.ts
@@ -41,6 +41,7 @@ import {
   applyRecoveryPlan,
   classifyInfraError,
 } from './error-recovery.js'
+import { clearResumeDecisionArtifacts } from '../loop/checkpoint.js'
 import { PollerNotifier } from './notify-dispatcher.js'
 import {
   coerceAgentName,
@@ -274,7 +275,7 @@ export async function dispatchAttempt(
       branchSlug: slug,
       worktreePath,
       phaseData: {
-        ...(run.phaseData ?? {}),
+        ...clearResumeDecisionArtifacts(run.phaseData),
         issueRepo,
       },
       endedAt: null,

--- a/src/reactions/handler.ts
+++ b/src/reactions/handler.ts
@@ -9,6 +9,7 @@ import { resolveIssueRepo } from '../utils/issue-repo.js'
 import { logger } from '../utils/logger.js'
 import { createFollowupAttempt, AttemptTerminatedError, AttemptNotFoundError } from '../state/attempts.js'
 import { recordUserAction } from '../state/run-log-events.js'
+import { clearResumeDecisionArtifacts } from '../loop/checkpoint.js'
 
 export interface ReactionHandlerDeps {
   db: Database.Database
@@ -51,7 +52,7 @@ export async function handleReaction(
   }
 
   const issueRepo = resolveIssueRepo(run.phaseData, reaction.repo)
-  const existingPhaseData = run.phaseData ?? {}
+  const existingPhaseData = clearResumeDecisionArtifacts(run.phaseData)
 
   if (reaction.type === 'merge_conflict') {
     try {

--- a/test/metrics/service.test.ts
+++ b/test/metrics/service.test.ts
@@ -177,7 +177,7 @@ describe('MetricsService', () => {
       expect(body).not.toContain('night_orch_estimated_cost_dollars{repo="org/repo",agent="claude"}')
     })
 
-    it('start rejects when port is already in use', async () => {
+    it('start rejects when port is already in use', { timeout: 120_000 }, async () => {
       const occupiedServer = http.createServer((_req, res) => {
         res.writeHead(200)
         res.end('ok')
@@ -188,6 +188,7 @@ describe('MetricsService', () => {
 
       try {
         service = createMetricsService({ enabled: true, host: '127.0.0.1', port })
+        // Retries up to 5 times with exponential backoff before rejecting.
         await expect(service.start()).rejects.toMatchObject({ code: 'EADDRINUSE' })
       } finally {
         await new Promise<void>((resolve, reject) => {

--- a/test/poller/attempt-dispatcher.test.ts
+++ b/test/poller/attempt-dispatcher.test.ts
@@ -133,6 +133,19 @@ function makeForge(issue: ForgeIssue): ForgeAdapter {
   } as unknown as ForgeAdapter
 }
 
+function makePhaseDataWithDecisionArtifacts(): Record<string, unknown> {
+  return {
+    issueRepo: 'org/repo',
+    __decisionOutcomes: {
+      decide: { action: 'error', reason: 'stale terminal state' },
+    },
+    __stepOutputs: {
+      blockMessage: 'obsolete block state',
+      keep: 'retain me',
+    },
+  }
+}
+
 describe('dispatchAttempt review_ready replay guard', () => {
   let tmpDir: string
   let db: Database.Database
@@ -303,6 +316,7 @@ describe('dispatchAttempt review_ready replay guard', () => {
       status: 'blocked',
       endedAt: '2026-04-13T00:00:00Z',
       lastError: 'verify failed',
+      phaseData: makePhaseDataWithDecisionArtifacts(),
     })
 
     const result = await dispatchAttempt({
@@ -334,5 +348,11 @@ describe('dispatchAttempt review_ready replay guard', () => {
 
     expect(result.outcome).toBe('processed')
     expect(mockExecuteLoop).toHaveBeenCalledTimes(1)
+    const replayed = runManager.getById(run.id)
+    expect(replayed?.phaseData?.__decisionOutcomes).toBeUndefined()
+    expect(replayed?.phaseData?.issueRepo).toBe('org/repo')
+    const stepOutputs = replayed?.phaseData?.__stepOutputs as Record<string, unknown> | undefined
+    expect(stepOutputs?.blockMessage).toBeUndefined()
+    expect(stepOutputs?.keep).toBe('retain me')
   })
 })

--- a/test/reactions/handler.test.ts
+++ b/test/reactions/handler.test.ts
@@ -49,6 +49,19 @@ function makeReaction(type: Reaction['type']): Reaction {
   }
 }
 
+function makePhaseDataWithDecisionArtifacts(): Record<string, unknown> {
+  return {
+    issueRepo: 'foo/bar',
+    __decisionOutcomes: {
+      decide: { action: 'block', reason: 'stale terminal state' },
+    },
+    __stepOutputs: {
+      blockMessage: 'obsolete block message',
+      keep: 'retain me',
+    },
+  }
+}
+
 describe('handleReaction', () => {
   let tmpDir: string
   let db: Database.Database
@@ -65,7 +78,7 @@ describe('handleReaction', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  function seedReviewReadyRun(): string {
+  function seedReviewReadyRun(phaseData: Record<string, unknown> = { issueRepo: 'foo/bar' }): string {
     const row = runs.create({
       repo: 'foo/bar',
       issueNumber: 7,
@@ -78,13 +91,13 @@ describe('handleReaction', () => {
       status: 'review_ready',
       branchName: 'feature/x',
       prNumber: 42,
-      phaseData: { issueRepo: 'foo/bar' },
+      phaseData,
     })
     return row.id
   }
 
   it('merge_conflict reaction creates a new attempt with intent=rebase and terminates the previous one', async () => {
-    const prevId = seedReviewReadyRun()
+    const prevId = seedReviewReadyRun(makePhaseDataWithDecisionArtifacts())
     const forge = makeForge()
 
     await handleReaction(makeReaction('merge_conflict'), { db, forge, runManager: runs, repoConfig })
@@ -100,6 +113,11 @@ describe('handleReaction', () => {
     expect(newRun!.status).toBe('queued')
     expect(newRun!.branchName).toBe('feature/x')
     expect(newRun!.prNumber).toBe(42)
+    expect(newRun!.phaseData?.__decisionOutcomes).toBeUndefined()
+    expect(newRun!.phaseData?.issueRepo).toBe('foo/bar')
+    const stepOutputs = newRun!.phaseData?.__stepOutputs as Record<string, unknown> | undefined
+    expect(stepOutputs?.blockMessage).toBeUndefined()
+    expect(stepOutputs?.keep).toBe('retain me')
 
     const controlPayload = db
       .prepare('SELECT control_payload FROM runs WHERE id = ?')
@@ -116,7 +134,7 @@ describe('handleReaction', () => {
   })
 
   it('non-merge_conflict reactions flip the same run in place to queued', async () => {
-    const prevId = seedReviewReadyRun()
+    const prevId = seedReviewReadyRun(makePhaseDataWithDecisionArtifacts())
     const forge = makeForge()
 
     await handleReaction(makeReaction('ci_failure'), { db, forge, runManager: runs, repoConfig })
@@ -125,6 +143,10 @@ describe('handleReaction', () => {
     expect(same!.id).toBe(prevId)
     expect(same!.status).toBe('queued')
     expect(same!.phaseData?.reactionType).toBe('ci_failure')
+    expect(same!.phaseData?.__decisionOutcomes).toBeUndefined()
+    const stepOutputs = same!.phaseData?.__stepOutputs as Record<string, unknown> | undefined
+    expect(stepOutputs?.blockMessage).toBeUndefined()
+    expect(stepOutputs?.keep).toBe('retain me')
 
     const term = db.prepare('SELECT terminated_at FROM runs WHERE id = ?').get(prevId) as {
       terminated_at: string | null

--- a/test/web/error-block.test.ts
+++ b/test/web/error-block.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBlock } from '../../web/src/components/ErrorBlock.js'
+
+type ErrorBlockProps = React.ComponentProps<typeof ErrorBlock>
+
+function renderErrorBlock(overrides: Partial<ErrorBlockProps> = {}): void {
+  const props: ErrorBlockProps = {
+    error: 'line 1\nline 2\nline 3\nline 4',
+    collapsedLineCount: 2,
+    ...overrides,
+  }
+  render(React.createElement(ErrorBlock, props))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('ErrorBlock', () => {
+  it('shows line numbers and collapsed output by default', () => {
+    renderErrorBlock()
+
+    expect(screen.getByText('line 1')).toBeDefined()
+    expect(screen.getByText('line 2')).toBeDefined()
+    expect(screen.queryByText('line 3')).toBeNull()
+    expect(screen.getByText('Showing first 2 lines.')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Expand' })).toBeDefined()
+    expect(screen.getAllByTestId('error-line-number').map((node) => node.textContent)).toEqual(['01', '02'])
+  })
+
+  it('expands and collapses long errors', () => {
+    renderErrorBlock()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }))
+
+    expect(screen.getByText('line 3')).toBeDefined()
+    expect(screen.getByText('line 4')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Collapse' })).toBeDefined()
+    expect(screen.getAllByTestId('error-line-number').map((node) => node.textContent)).toEqual(['01', '02', '03', '04'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }))
+    expect(screen.queryByText('line 4')).toBeNull()
+  })
+
+  it('collapses oversized single-line errors by character count', () => {
+    renderErrorBlock({
+      error: 'x'.repeat(5_000),
+      collapsedLineCount: 8,
+      collapsedCharCount: 256,
+    })
+
+    expect(screen.getByText('Showing first 256 characters.')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Expand' })).toBeDefined()
+    expect(screen.getByText((content) => content.length === 256 && /^x+$/.test(content))).toBeDefined()
+  })
+
+  it('copies full error text and clears copied feedback after timeout', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    renderErrorBlock({
+      error: 'critical failure\nstack line 1\nstack line 2',
+      collapsedLineCount: 2,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy error' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(writeText).toHaveBeenCalledWith('critical failure\nstack line 1\nstack line 2')
+    expect(screen.getByText('Copied!')).toBeDefined()
+
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(screen.queryByText('Copied!')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Copy error' })).toBeDefined()
+  })
+
+  it('falls back to execCommand when clipboard API writeText rejects', async () => {
+    const writeText = vi.fn<(value: string) => Promise<void>>().mockRejectedValue(new Error('clipboard denied'))
+    const execCommand = vi.fn<(command: string) => boolean>().mockReturnValue(true)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    Object.defineProperty(globalThis.document, 'execCommand', {
+      value: execCommand,
+      configurable: true,
+    })
+
+    renderErrorBlock({
+      error: 'fallback copy test',
+      collapsedLineCount: 2,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy error' }))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith('fallback copy test')
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(screen.getByText('Copied!')).toBeDefined()
+  })
+})

--- a/test/web/router-integration.test.ts
+++ b/test/web/router-integration.test.ts
@@ -157,6 +157,25 @@ const ISSUE_DETAIL_RUN: RunSummary = {
   endedAt: null,
 }
 
+const ISSUE_LIST_RUN_WITH_ERROR: RunSummary = {
+  runId: 'run-list-error-1',
+  hasRun: true,
+  repo: 'org/repo',
+  issue: 55,
+  issueTitle: 'Run card copy behavior',
+  status: 'error',
+  prNumber: null,
+  phase: 'verify',
+  iterations: 3,
+  costUsd: 0.85,
+  promptTokens: 3400,
+  completionTokens: 1100,
+  cacheReadTokens: 9000,
+  lastError: 'build failed\nstack line 1\nstack line 2\nstack line 3',
+  startedAt: '2026-04-06T09:20:00.000Z',
+  endedAt: '2026-04-06T09:23:00.000Z',
+}
+
 const COMPLETED_HISTORY_RUN_PAGE_ONE: RunSummary = {
   runId: 'run-completed-1',
   hasRun: true,
@@ -477,6 +496,33 @@ describe('dashboard router integration (real App)', () => {
       expect(screen.getByText('Second completed history run')).toBeDefined()
     })
     expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull()
+  })
+
+  it('copies run-card error text without triggering navigation and opens detail via explicit action', async () => {
+    const fetchMock = buildFetchMock(withRuns([ISSUE_LIST_RUN_WITH_ERROR]))
+    vi.stubGlobal('fetch', fetchMock)
+    const writeText = vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    const { router } = renderDashboard('/issues')
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/issues')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy error' }))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('build failed\nstack line 1\nstack line 2\nstack line 3')
+    })
+    expect(router.state.location.pathname).toBe('/issues')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open run run-list-error-1' }))
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/issues/run-list-error-1')
+    })
   })
 
   it('renders /settings with real settings content and active nav state', async () => {

--- a/web/src/components/ErrorBlock.stories.tsx
+++ b/web/src/components/ErrorBlock.stories.tsx
@@ -1,0 +1,96 @@
+import { type ReactElement, useEffect, useRef } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ErrorBlock } from './ErrorBlock.js'
+
+const SAMPLE_ERROR = [
+  'Error: verify command failed',
+  'at runVerify (src/loop/verifier.ts:143:11)',
+  'at executeLoop (src/loop/engine.ts:302:9)',
+  'at processTicksAndRejections (node:internal/process/task_queues:95:5)',
+  'AssertionError: expected 200 to equal 201',
+  '    at test/workflow.spec.ts:84:17',
+  '    at async Promise.all (index 0)',
+  'Build failed with exit code 1',
+].join('\n')
+
+const meta = {
+  title: 'Web/ErrorBlock',
+  component: ErrorBlock,
+  args: {
+    title: 'Run error',
+    error: SAMPLE_ERROR,
+    collapsedLineCount: 4,
+    collapsedCharCount: 600,
+  },
+} satisfies Meta<typeof ErrorBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Collapsed: Story = {}
+
+export const Expanded: Story = {
+  args: {
+    defaultExpanded: true,
+  },
+}
+
+export const CopiedState: Story = {
+  render: (args) => <CopyFeedbackPreview {...args} mode="copied" />,
+}
+
+export const CopyFailureState: Story = {
+  render: (args) => <CopyFeedbackPreview {...args} mode="failed" />,
+}
+
+type CopyFeedbackPreviewProps = React.ComponentProps<typeof ErrorBlock> & {
+  mode: 'copied' | 'failed'
+}
+
+function CopyFeedbackPreview({ mode, ...args }: CopyFeedbackPreviewProps): ReactElement {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const navigatorDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'clipboard')
+    const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand')
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: () => (mode === 'copied' ? Promise.resolve() : Promise.reject(new Error('copy failed'))),
+      },
+      configurable: true,
+    })
+    if (mode === 'failed') {
+      Object.defineProperty(document, 'execCommand', {
+        value: () => false,
+        configurable: true,
+      })
+    }
+
+    const copyButton = containerRef.current?.querySelector<HTMLButtonElement>('button[aria-label="Copy error"]')
+    copyButton?.click()
+
+    return () => {
+      restoreProperty(window.navigator, 'clipboard', navigatorDescriptor)
+      restoreProperty(document, 'execCommand', execCommandDescriptor)
+    }
+  }, [mode])
+
+  return (
+    <div ref={containerRef}>
+      <ErrorBlock {...args} />
+    </div>
+  )
+}
+
+function restoreProperty(
+  target: object,
+  key: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor)
+    return
+  }
+  Reflect.deleteProperty(target, key)
+}

--- a/web/src/components/ErrorBlock.tsx
+++ b/web/src/components/ErrorBlock.tsx
@@ -1,0 +1,272 @@
+import { type MouseEvent, type ReactElement, useEffect, useMemo, useState } from 'react'
+import { ButtonWeb } from '../../../src/components/button/button.web.js'
+
+const COPY_FEEDBACK_MS = 2000
+const DEFAULT_COLLAPSED_LINE_COUNT = 8
+const DEFAULT_COLLAPSED_CHAR_COUNT = 4000
+
+type CopyStatus = 'idle' | 'copied' | 'failed'
+type TruncationReason = 'line' | 'char' | null
+
+interface ErrorBlockProps {
+  error: string
+  className?: string
+  title?: string
+  collapsedLineCount?: number
+  collapsedCharCount?: number
+  defaultExpanded?: boolean
+}
+
+export function ErrorBlock({
+  error,
+  className,
+  title = 'Error output',
+  collapsedLineCount = DEFAULT_COLLAPSED_LINE_COUNT,
+  collapsedCharCount = DEFAULT_COLLAPSED_CHAR_COUNT,
+  defaultExpanded = false,
+}: ErrorBlockProps): ReactElement {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle')
+
+  const safeCollapsedLineCount = Math.max(1, Math.floor(collapsedLineCount))
+  const safeCollapsedCharCount = Math.max(256, Math.floor(collapsedCharCount))
+  const collapsedPreview = useMemo(
+    () => buildCollapsedPreview(error, safeCollapsedLineCount, safeCollapsedCharCount),
+    [error, safeCollapsedCharCount, safeCollapsedLineCount],
+  )
+  const canExpand = collapsedPreview.truncated
+  const expandedLines = useMemo(
+    () => (expanded && canExpand ? splitErrorLines(error) : null),
+    [canExpand, error, expanded],
+  )
+  const visibleLines = expanded && expandedLines !== null
+    ? expandedLines
+    : collapsedPreview.lines
+  const lineNumberWidth = Math.max(2, String(Math.max(visibleLines.length, 1)).length)
+
+  useEffect(() => {
+    setExpanded(defaultExpanded)
+  }, [defaultExpanded, error])
+
+  useEffect(() => {
+    if (copyStatus === 'idle') return undefined
+    const timer = globalThis.setTimeout(() => {
+      setCopyStatus('idle')
+    }, COPY_FEEDBACK_MS)
+    return () => {
+      globalThis.clearTimeout(timer)
+    }
+  }, [copyStatus])
+
+  const onCopyClick = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    void copyErrorText(error)
+      .then(() => setCopyStatus('copied'))
+      .catch(() => setCopyStatus('failed'))
+  }
+
+  const onExpandClick = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    setExpanded((current) => !current)
+  }
+
+  const copyStatusLabel = copyStatus === 'copied'
+    ? 'Copied!'
+    : copyStatus === 'failed'
+      ? 'Copy failed'
+      : null
+  const copyButtonLabel = copyStatus === 'copied'
+    ? 'Copied!'
+    : copyStatus === 'failed'
+      ? 'Copy failed'
+      : 'Copy error'
+  const previewMessage = canExpand && !expanded
+    ? collapsedPreview.reason === 'line'
+      ? `Showing first ${visibleLines.length} lines.`
+      : `Showing first ${safeCollapsedCharCount.toLocaleString()} characters.`
+    : null
+  const composedClassName = className
+    ? `min-w-0 rounded-md border border-error/35 bg-error/10 p-2 text-error ${className}`
+    : 'min-w-0 rounded-md border border-error/35 bg-error/10 p-2 text-error'
+
+  return (
+    <div
+      className={composedClassName}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <div className="mb-2 flex min-w-0 items-start justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-error/75">
+          {title}
+        </p>
+        <div className="flex shrink-0 items-center gap-1">
+          {copyStatusLabel && (
+            <span role="status" className="text-[10px] font-medium text-error/80">
+              {copyStatusLabel}
+            </span>
+          )}
+          {canExpand && (
+            <ButtonWeb
+              type="button"
+              tone="ghost"
+              size="xs"
+              className="border border-error/35 bg-base-100/55 text-[11px] text-error/85 hover:border-error/50 hover:bg-base-100/75"
+              onClick={onExpandClick}
+            >
+              {expanded ? 'Collapse' : 'Expand'}
+            </ButtonWeb>
+          )}
+          <ButtonWeb
+            type="button"
+            tone="ghost"
+            size="xs"
+            shape="circle"
+            className="border border-error/35 bg-base-100/55 text-error/85 hover:border-error/50 hover:bg-base-100/75"
+            title={copyButtonLabel}
+            ariaLabel={copyButtonLabel}
+            onClick={onCopyClick}
+          >
+            <ClipboardIcon />
+          </ButtonWeb>
+        </div>
+      </div>
+
+      <div className="min-w-0 overflow-x-auto rounded border border-error/25 bg-base-100/45 px-2 py-1.5 font-mono text-[11px] leading-5 text-error/90">
+        {visibleLines.map((line, index) => (
+          <div key={index} className="grid min-w-0 grid-cols-[auto_1fr] gap-x-3">
+            <span
+              data-testid="error-line-number"
+              className="select-none pr-0.5 text-right tabular-nums text-error/60"
+              style={{ minWidth: `${lineNumberWidth}ch` }}
+            >
+              {String(index + 1).padStart(lineNumberWidth, '0')}
+            </span>
+            <span className="whitespace-pre-wrap break-words">
+              {line.length > 0 ? line : ' '}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {previewMessage && (
+        <p className="mt-1 text-[10px] text-error/75">
+          {previewMessage}
+        </p>
+      )}
+    </div>
+  )
+}
+
+async function copyErrorText(value: string): Promise<void> {
+  if (globalThis.navigator?.clipboard?.writeText) {
+    try {
+      await globalThis.navigator.clipboard.writeText(value)
+      return
+    } catch {
+      // Fall through to the legacy path if Clipboard API is blocked/rejected.
+    }
+  }
+
+  if (!globalThis.document?.body || typeof globalThis.document.execCommand !== 'function') {
+    throw new Error('Clipboard API unavailable')
+  }
+
+  const textArea = globalThis.document.createElement('textarea')
+  textArea.value = value
+  textArea.setAttribute('readonly', 'true')
+  textArea.style.position = 'fixed'
+  textArea.style.opacity = '0'
+  textArea.style.pointerEvents = 'none'
+  globalThis.document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+
+  const copied = globalThis.document.execCommand('copy')
+  globalThis.document.body.removeChild(textArea)
+  if (!copied) {
+    throw new Error('Copy failed')
+  }
+}
+
+function splitErrorLines(value: string): string[] {
+  const normalized = value.replace(/\r\n?/g, '\n')
+  return normalized.split('\n')
+}
+
+function buildCollapsedPreview(
+  value: string,
+  maxLines: number,
+  maxChars: number,
+): { lines: string[]; truncated: boolean; reason: TruncationReason } {
+  const lines: string[] = []
+  let current = ''
+  let chars = 0
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char === '\r') {
+      if (value[index + 1] === '\n') {
+        index += 1
+      }
+      lines.push(current)
+      current = ''
+      if (lines.length >= maxLines) {
+        return { lines, truncated: true, reason: 'line' }
+      }
+      continue
+    }
+
+    if (char === '\n') {
+      lines.push(current)
+      current = ''
+      if (lines.length >= maxLines) {
+        return { lines, truncated: true, reason: 'line' }
+      }
+      continue
+    }
+
+    if (chars >= maxChars) {
+      return finalizeCharPreview(lines, current)
+    }
+
+    current += char
+    chars += 1
+  }
+
+  lines.push(current)
+  return { lines, truncated: false, reason: null }
+}
+
+function finalizeCharPreview(lines: string[], current: string): {
+  lines: string[]
+  truncated: true
+  reason: 'char'
+} {
+  return {
+    lines: [...lines, current],
+    truncated: true,
+    reason: 'char',
+  }
+}
+
+function ClipboardIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3.5"
+      aria-hidden="true"
+    >
+      <path d="M9 5.5h6" />
+      <path d="M9.5 3.5h5a1.5 1.5 0 0 1 1.5 1.5v1.5h-8V5a1.5 1.5 0 0 1 1.5-1.5Z" />
+      <path d="M7.5 6.5h9a2 2 0 0 1 2 2V18a2.5 2.5 0 0 1-2.5 2.5h-7A2.5 2.5 0 0 1 6.5 18V8.5a2 2 0 0 1 1-1.8" />
+    </svg>
+  )
+}

--- a/web/src/components/ErrorBlock.tsx
+++ b/web/src/components/ErrorBlock.tsx
@@ -175,17 +175,31 @@ async function copyErrorText(value: string): Promise<void> {
   }
 
   const textArea = globalThis.document.createElement('textarea')
+  const previouslyFocusedElement = globalThis.document.activeElement instanceof HTMLElement
+    ? globalThis.document.activeElement
+    : null
   textArea.value = value
   textArea.setAttribute('readonly', 'true')
   textArea.style.position = 'fixed'
   textArea.style.opacity = '0'
   textArea.style.pointerEvents = 'none'
   globalThis.document.body.appendChild(textArea)
-  textArea.focus()
-  textArea.select()
+  let copied = false
+  try {
+    textArea.focus()
+    textArea.select()
+    copied = globalThis.document.execCommand('copy')
+  } finally {
+    globalThis.document.body.removeChild(textArea)
+    if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+      try {
+        previouslyFocusedElement.focus()
+      } catch {
+        // Ignore focus restore failures for detached/disabled elements.
+      }
+    }
+  }
 
-  const copied = globalThis.document.execCommand('copy')
-  globalThis.document.body.removeChild(textArea)
   if (!copied) {
     throw new Error('Copy failed')
   }

--- a/web/src/components/IssueDetailPage.tsx
+++ b/web/src/components/IssueDetailPage.tsx
@@ -162,7 +162,7 @@ export function IssueDetailPage({
                     </span>
                   </div>
                   <select
-                    className="select select-bordered select-sm w-full bg-base-100/80"
+                    className="select select-sm w-full bg-base-100/80"
                     value={actionStrategy}
                     onChange={(event) => setActionStrategy(event.target.value as 'default' | UpdateStrategy)}
                   >

--- a/web/src/components/IssueDetailPage.tsx
+++ b/web/src/components/IssueDetailPage.tsx
@@ -6,6 +6,7 @@ import { describeRunEvent, formatTimestamp, formatTokenCount, truncate } from '.
 import { STATUS_BADGE_TONE } from '../lib/run-tone.js'
 import { type RunEvent, type RunSummary } from '../types/dashboard.js'
 import { ActionButton } from './ActionButton.js'
+import { ErrorBlock } from './ErrorBlock.js'
 
 type UpdateStrategy = 'merge' | 'rebase'
 
@@ -125,9 +126,13 @@ export function IssueDetailPage({
                 </BadgeWeb>
               </div>
               {run.lastError && (
-                <p className="mt-2 whitespace-pre-wrap break-words rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
-                  {truncate(run.lastError, 2000)}
-                </p>
+                <ErrorBlock
+                  className="mt-2"
+                  error={run.lastError}
+                  title="Run error"
+                  collapsedLineCount={14}
+                  collapsedCharCount={6000}
+                />
               )}
               <p className="mt-2 text-[11px] text-base-content/65">
                 started {run.startedAt ? formatTimestamp(run.startedAt) : '-'}

--- a/web/src/components/RunsPanel.tsx
+++ b/web/src/components/RunsPanel.tsx
@@ -58,7 +58,7 @@ export function RunsPanel({
               </span>
             </div>
             <select
-              className="select select-bordered select-sm w-full bg-base-100/80"
+              className="select select-sm w-full bg-base-100/80"
               value={selectedRepo}
               onChange={(event) => onSelectedRepoChange(event.target.value)}
             >

--- a/web/src/components/RunsPanel.tsx
+++ b/web/src/components/RunsPanel.tsx
@@ -10,6 +10,7 @@ import {
   badgeToneForPrNumber,
 } from '../lib/run-tone.js'
 import { type RunListView, type RunStatus, type RunSummary } from '../types/dashboard.js'
+import { ErrorBlock } from './ErrorBlock.js'
 
 interface RunsPanelProps {
   isLoading: boolean
@@ -97,10 +98,8 @@ export function RunsPanel({
               {filteredRuns.map((run) => {
                 const isRunning = run.status === 'running'
                 return (
-                  <button
+                  <div
                     key={run.runId}
-                    type="button"
-                    onClick={() => onOpenRun(run.runId)}
                     className={`card w-full min-w-0 overflow-hidden border text-left transition-all ${
                       selectedRunId === run.runId
                         ? 'border-primary/65 bg-primary/10 shadow-md'
@@ -120,13 +119,24 @@ export function RunsPanel({
                             {run.hasRun ? run.runId : 'Tracked issue (no run yet)'}
                           </p>
                         </div>
-                        <BadgeWeb
-                          size="sm"
-                          capitalize
-                          className={`${statusTone[run.status]} ${isRunning ? 'orch-working-pulse' : ''}`}
-                        >
-                          {run.status.replaceAll('_', ' ')}
-                        </BadgeWeb>
+                        <div className="flex items-center gap-2">
+                          <ButtonWeb
+                            type="button"
+                            size="xs"
+                            tone={selectedRunId === run.runId ? 'primary' : 'ghost'}
+                            ariaLabel={`Open run ${run.runId}`}
+                            onClick={() => onOpenRun(run.runId)}
+                          >
+                            Open
+                          </ButtonWeb>
+                          <BadgeWeb
+                            size="sm"
+                            capitalize
+                            className={`${statusTone[run.status]} ${isRunning ? 'orch-working-pulse' : ''}`}
+                          >
+                            {run.status.replaceAll('_', ' ')}
+                          </BadgeWeb>
+                        </div>
                       </div>
                       <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
                         <BadgeWeb size="xs" className={badgeToneForPhase(run.phase)}>
@@ -146,12 +156,15 @@ export function RunsPanel({
                         </span>
                       </div>
                       {run.lastError && (
-                        <p className="whitespace-pre-wrap break-words rounded-md border border-error/30 bg-error/10 px-2 py-1 text-xs text-error">
-                          {truncate(run.lastError, 500)}
-                        </p>
+                        <ErrorBlock
+                          error={run.lastError}
+                          title="Recent error"
+                          collapsedLineCount={6}
+                          collapsedCharCount={1200}
+                        />
                       )}
                     </div>
-                  </button>
+                  </div>
                 )
               })}
             </div>


### PR DESCRIPTION
Closes #158

## Plan
**Objective:** Resolve merge conflicts with origin/master and ensure ErrorBlock feature integrates cleanly with the design-system migration

1. Start merge of origin/master into the branch
2. Resolve package.json conflict: take master's version (0.19.0), keep master's new dev:web-only script, keep any branch-specific additions (storybook config addition of web stories glob)
3. Resolve src/components/badge/badge.web.tsx conflict: take master's version which destructures props and spreads native HTML attributes — the branch's changes to this file were part of a prior iteration and master's refactor supersedes them
4. Resolve src/components/badge/types.ts conflict: take master's version which imports shared Tone type and extends HTMLAttributes
5. Resolve src/metrics/service.ts conflict: take master's version which adds rebase metrics and retry logic — the branch's changes here were unrelated to ErrorBlock
6. Resolve test/metrics/service.test.ts conflict: take master's version with rebase counter tests and adjusted timeouts
7. Resolve test/poller/attempt-dispatcher.test.ts conflict: take master's version with WorktreeInfo and conflict-handling test
8. Resolve test/reactions/handler.test.ts conflict: take master's version with intent=refresh rename and operationIntent assertion
9. Reconcile web/src/components/RunsPanel.tsx: start from master's version (which uses SelectWeb, TabsWeb, AlertWeb primitives), then apply branch's changes: (a) change <button> cards to <div> with explicit Open button, (b) replace inline error <p> with <ErrorBlock>, (c) add ErrorBlock import. This file auto-merged but needs verification that both sides' intent is preserved correctly.
10. Verify .storybook/main.ts still includes the web stories glob after merge (branch added '../web/src/components/**/*.stories.@(ts|tsx)' — this shouldn't conflict but verify)
11. Run pnpm typecheck to verify the merge compiles cleanly
12. Run pnpm test to verify all tests pass post-merge
13. Commit the merge resolution

## Implementation
Integrated the ErrorBlock-related pages with the current DaisyUI v5 styling conventions by removing legacy `select-bordered` classes in the two relevant selectors (`RunsPanel` repo filter and `IssueDetailPage` update strategy), while preserving the existing ErrorBlock copy/line-number/expand behavior. Verification passed with eslint, typecheck, and targeted vitest runs for `error-block` and `router-integration`.

**Changed files:**
- `web/src/components/RunsPanel.tsx`
- `web/src/components/IssueDetailPage.tsx`

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | :white_check_mark: |
| `pnpm lint` | :white_check_mark: |
| `pnpm test` | :white_check_mark: |

## Review
**Verdict:** APPROVED
Reviewed all changed files in full (including staged updates to web/src/components/IssueDetailPage.tsx and web/src/components/RunsPanel.tsx), checked adjacent runtime/UI patterns, and verified behavior with test coverage. The ErrorBlock feature is implemented consistently (line numbering, copy action with feedback, truncation/expand controls), integrated into run cards and issue detail, Storybook coverage was added, and regression tests were added/updated. Verification also passed locally: pnpm test, pnpm typecheck, pnpm lint.

---

**Triage:** standard | **Iterations:** 1 | **Roles:** plan=claude code=codex review=codex